### PR TITLE
Improve presto documentation navigation

### DIFF
--- a/presto-docs/src/main/sphinx/themes/presto/layout.html
+++ b/presto-docs/src/main/sphinx/themes/presto/layout.html
@@ -6,15 +6,23 @@
 {% macro nav() %}
 <p class="nav">
     <span class="left">
+        <a href="{{ pathto(master_doc) }}">{{ _('Contents') }}</a>
+        {%- for parent in parents %}
+        <span class="padding">&raquo;</span>
+        <a href="{{ parent.link|e }}">{{ parent.title }}</a>
+        {%- endfor %}
+    </span>
+    <span class="right">
         {%- if prev %}
-        &laquo; <a href="{{ prev.link|e }}">{{ prev.title }}</a>
+        &laquo; <a href="{{ prev.link|e }}">previous</a>
+        {%- if next %}
+        <span class="padding">&#124;</span>
+        {%- endif %}
         {%- else %}
         &nbsp;
         {%- endif %}
-    </span>
-    <span class="right">
         {%- if next %}
-        <a href="{{ next.link|e }}">{{ next.title }}</a> &raquo;
+        <a href="{{ next.link|e }}">next</a> &raquo;
         {%- endif %}
     </span>
 </p>

--- a/presto-docs/src/main/sphinx/themes/presto/static/presto.css_t
+++ b/presto-docs/src/main/sphinx/themes/presto/static/presto.css_t
@@ -42,6 +42,11 @@ div.header h1 a {
     text-align: right;
 }
 
+.nav .padding {
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
 div.topnav {
     background: #eeeeee;
 }


### PR DESCRIPTION
Replace navbar with basic breadcrumb navigation on the left and simple
"previous / next" links on the right side.

This allows navigating back to the ToC at any time and navigating up
in the document tree.