### PR TITLE
New json function similar to Hive's json_tuple

### DIFF
--- a/presto-docs/src/main/sphinx/functions/json.rst
+++ b/presto-docs/src/main/sphinx/functions/json.rst
@@ -65,3 +65,9 @@ JSON Functions
         SELECT json_size('{ "x": {"a": 1, "b": 2} }', '$.x'); => 2
         SELECT json_size('{ "x": [1, 2, 3] }', '$.x'); => 2
         SELECT json_size('{ "x": {"a": 1, "b": 2} }', '$.x.a'); => 0
+
+.. function:: json_extract_multiple(json, array<varchar>) -> varchar
+
+    Extracts the given keys from the input json. For example: ::
+
+        SELECT json_extract_multiple('{ "x": 1, "y": 2, "z": { "x": 3 } }', ARRAY ['x', 'y']); => '{"x":1,"y":2}'


### PR DESCRIPTION
Hive's ```json_tuple``` allows extracting multiple keys from an input json string at once. This PR implements a similar functionality (until Presto supports table generating functions) with a new ```json_extract_multiple``` function. I didn't want to use the name "json_tuple" as in the future Presto may support table generating functions and then we can have a proper ```json_tuple``` function.