### PR TITLE
Add REFRESH statement to refresh table metadata

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -193,4 +193,10 @@ public class JdbcMetadata
     {
         return ImmutableMap.of();
     }
+
+    @Override
+    public void refreshTableMetadata(ConnectorTableHandle table)
+    {
+        throw new UnsupportedOperationException("Refresh is not supported");
+    }
 }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
@@ -335,4 +335,10 @@ public class CassandraMetadata
     {
         return emptyMap();
     }
+
+    @Override
+    public void refreshTableMetadata(ConnectorTableHandle table)
+    {
+        throw new UnsupportedOperationException("Refresh is not supported");
+    }
 }

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleMetadata.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleMetadata.java
@@ -145,6 +145,12 @@ public class ExampleMetadata
         return columns.build();
     }
 
+    @Override
+    public void refreshTableMetadata(ConnectorTableHandle table)
+    {
+        throw new UnsupportedOperationException("Refresh is not supported");
+    }
+
     private ConnectorTableMetadata getTableMetadata(SchemaTableName tableName)
     {
         if (!listSchemaNames().contains(tableName.getSchemaName())) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClient.java
@@ -934,6 +934,18 @@ public class HiveClient
     }
 
     @Override
+    public void refreshTableMetadata(ConnectorTableHandle tableHandle)
+    {
+        SchemaTableName tableName = getTableName(tableHandle);
+        try {
+            metastore.refreshTableMetadata(tableName.getSchemaName(), tableName.getTableName());
+        }
+        catch (NoSuchObjectException e) {
+            throw new TableNotFoundException(tableName);
+        }
+    }
+
+    @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         checkArgument(allowCorruptWritesForTesting || timeZone.equals(DateTimeZone.getDefault()),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -392,6 +392,21 @@ public class CachingHiveMetastore
     }
 
     @Override
+    public void refreshTableMetadata(String databaseName, String tableName) throws NoSuchObjectException
+    {
+        HiveTableName hiveTableName = HiveTableName.table(databaseName, tableName);
+        tableCache.invalidate(hiveTableName);
+        partitionNamesCache.invalidate(hiveTableName);
+        try {
+            tableCache.get(hiveTableName); //trigger a synchronous load
+            partitionNamesCache.get(hiveTableName);
+        }
+        catch (ExecutionException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    @Override
     public List<String> getAllViews(String databaseName)
             throws NoSuchObjectException
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveMetastore.java
@@ -55,4 +55,7 @@ public interface HiveMetastore
 
     Table getTable(String databaseName, String tableName)
             throws NoSuchObjectException;
+
+    public void refreshTableMetadata(String databaseName, String tableName)
+            throws NoSuchObjectException;
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/InMemoryHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/InMemoryHiveMetastore.java
@@ -173,6 +173,12 @@ public class InMemoryHiveMetastore
     }
 
     @Override
+    public void refreshTableMetadata(String databaseName, String tableName) throws NoSuchObjectException
+    {
+        throw new UnsupportedOperationException("Refresh is not supported");
+    }
+
+    @Override
     public void flushCache()
     {
     }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
@@ -192,6 +192,12 @@ public class KafkaMetadata
     }
 
     @Override
+    public void refreshTableMetadata(ConnectorTableHandle table)
+    {
+        throw new UnsupportedOperationException("Refresh is not supported");
+    }
+
+    @Override
     public ColumnMetadata getColumnMetadata(ConnectorTableHandle tableHandle, ConnectorColumnHandle columnHandle)
     {
         handleResolver.convertTableHandle(tableHandle);

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
@@ -201,6 +201,12 @@ public class InformationSchemaMetadata
         return builder.build();
     }
 
+    @Override
+    public void refreshTableMetadata(ConnectorTableHandle table)
+    {
+        throw new UnsupportedOperationException("Refresh is not supported");
+    }
+
     static List<ColumnMetadata> informationSchemaTableColumns(SchemaTableName tableName)
     {
         checkArgument(TABLES.containsKey(tableName), "table does not exist: %s", tableName);

--- a/presto-main/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
@@ -172,6 +172,12 @@ public class JmxMetadata
         return columns.build();
     }
 
+    @Override
+    public void refreshTableMetadata(ConnectorTableHandle table)
+    {
+        throw new UnsupportedOperationException("Refresh is not supported");
+    }
+
     private Type getColumnType(MBeanAttributeInfo attribute)
     {
         Type columnType;

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemTablesMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemTablesMetadata.java
@@ -132,4 +132,10 @@ public class SystemTablesMetadata
         }
         return builder.build();
     }
+
+    @Override
+    public void refreshTableMetadata(ConnectorTableHandle table)
+    {
+        throw new UnsupportedOperationException("Refresh is not supported");
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/RefreshTableMetadataTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RefreshTableMetadataTask.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.QualifiedTableName;
+import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.sql.analyzer.SemanticException;
+import com.facebook.presto.sql.tree.RefreshTableMetadata;
+import com.google.common.base.Optional;
+
+import static com.facebook.presto.metadata.MetadataUtil.createQualifiedTableName;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
+
+public class RefreshTableMetadataTask
+        implements DataDefinitionTask<RefreshTableMetadata>
+{
+    @Override
+    public void execute(RefreshTableMetadata statement, Session session, Metadata metadata)
+    {
+        QualifiedTableName tableName = createQualifiedTableName(session, statement.getTableName());
+
+        Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
+        if (!tableHandle.isPresent()) {
+            throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);
+        }
+
+        metadata.refreshTableMetadata(tableHandle.get());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -179,6 +179,13 @@ public interface Metadata
      */
     void dropView(Session session, QualifiedTableName viewName);
 
+    /**
+     * Refreshes the metadata of the specified table.
+     *
+     */
+    @NotNull
+    void refreshTableMetadata(TableHandle tableHandle);
+
     FunctionRegistry getFunctionRegistry();
 
     TypeManager getTypeManager();

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -449,6 +449,12 @@ public class MetadataManager
     }
 
     @Override
+    public void refreshTableMetadata(TableHandle tableHandle)
+    {
+        lookupConnectorFor(tableHandle).refreshTableMetadata(tableHandle.getConnectorHandle());
+    }
+
+    @Override
     public FunctionRegistry getFunctionRegistry()
     {
         return functions;

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.server;
 
+import com.facebook.presto.execution.RefreshTableMetadataTask;
 import com.facebook.presto.execution.RenameTableTask;
 import com.facebook.presto.execution.CreateViewTask;
 import com.facebook.presto.execution.DataDefinitionTask;
@@ -34,6 +35,7 @@ import com.facebook.presto.metadata.ViewDefinition;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.tree.RefreshTableMetadata;
 import com.facebook.presto.sql.tree.RenameTable;
 import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateView;
@@ -132,6 +134,7 @@ public class CoordinatorModule
         binder.bind(DataDefinitionExecutionFactory.class).in(Scopes.SINGLETON);
         bindDataDefinitionTask(binder, executionBinder, RenameTable.class, RenameTableTask.class);
         bindDataDefinitionTask(binder, executionBinder, DropTable.class, DropTableTask.class);
+        bindDataDefinitionTask(binder, executionBinder, RefreshTableMetadata.class, RefreshTableMetadataTask.class);
         bindDataDefinitionTask(binder, executionBinder, CreateView.class, CreateViewTask.class);
         bindDataDefinitionTask(binder, executionBinder, DropView.class, DropViewTask.class);
 

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestingMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestingMetadata.java
@@ -232,6 +232,12 @@ public class TestingMetadata
         return map.build();
     }
 
+    @Override
+    public void refreshTableMetadata(ConnectorTableHandle table)
+    {
+        throw new UnsupportedOperationException("Refresh is not supported");
+    }
+
     private static SchemaTableName getTableName(ConnectorTableHandle tableHandle)
     {
         checkNotNull(tableHandle, "tableHandle is null");

--- a/presto-parser/src/main/antlr3/com/facebook/presto/sql/parser/Statement.g
+++ b/presto-parser/src/main/antlr3/com/facebook/presto/sql/parser/Statement.g
@@ -77,6 +77,7 @@ tokens {
     USE_SCHEMA;
     CREATE_TABLE;
     DROP_TABLE;
+    REFRESH_TABLE;
     RENAME_TABLE;
     CREATE_VIEW;
     DROP_VIEW;
@@ -171,6 +172,7 @@ statement
     | createTableStmt
     | insertStmt
     | dropTableStmt
+    | refreshStmt
     | alterTableStmt
     | createViewStmt
     | dropViewStmt
@@ -649,6 +651,10 @@ dropTableStmt
     : DROP TABLE qname -> ^(DROP_TABLE qname)
     ;
 
+refreshStmt
+    : REFRESH qname -> ^(REFRESH_TABLE qname)
+    ;
+
 insertStmt
     : INSERT INTO qname query -> ^(INSERT qname query)
     ;
@@ -885,6 +891,7 @@ USE: 'USE';
 PARTITIONS: 'PARTITIONS';
 FUNCTIONS: 'FUNCTIONS';
 DROP: 'DROP';
+REFRESH: 'REFRESH';
 UNION: 'UNION';
 EXCEPT: 'EXCEPT';
 INTERSECT: 'INTERSECT';

--- a/presto-parser/src/main/antlr3/com/facebook/presto/sql/parser/StatementBuilder.g
+++ b/presto-parser/src/main/antlr3/com/facebook/presto/sql/parser/StatementBuilder.g
@@ -67,6 +67,7 @@ statement returns [Statement value]
     | useCollection             { $value = $useCollection.value; }
     | createTable               { $value = $createTable.value; }
     | dropTable                 { $value = $dropTable.value; }
+    | refreshTableMetadata      { $value = $refreshTableMetadata.value; }
     | renameTable               { $value = $renameTable.value; }
     | createView                { $value = $createView.value; }
     | dropView                  { $value = $dropView.value; }
@@ -553,6 +554,10 @@ createTable returns [Statement value]
 
 dropTable returns [Statement value]
     : ^(DROP_TABLE qname) { $value = new DropTable($qname.value); }
+    ;
+
+refreshTableMetadata returns [Statement value]
+    : ^(REFRESH_TABLE qname) { $value = new RefreshTableMetadata($qname.value); }
     ;
 
 renameTable returns [Statement value]

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -445,4 +445,9 @@ public abstract class AstVisitor<R, C>
     {
         return visitNode(node, context);
     }
+
+    protected R visitRefreshTableMetadata(RefreshTableMetadata node, C context)
+    {
+        return visitStatement(node, context);
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RefreshTableMetadata.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RefreshTableMetadata.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.base.Objects;
+
+public class RefreshTableMetadata
+        extends Statement
+{
+    private final QualifiedName tableName;
+
+    public RefreshTableMetadata(QualifiedName tableName)
+    {
+        this.tableName = tableName;
+    }
+
+    public QualifiedName getTableName()
+    {
+        return tableName;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitRefreshTableMetadata(this, context);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(tableName);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        RefreshTableMetadata o = (RefreshTableMetadata) obj;
+        return Objects.equal(tableName, o.tableName);
+    }
+
+    @Override
+    public String toString()
+    {
+        return Objects.toStringHelper(this)
+                .add("tableName", tableName)
+                .toString();
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
@@ -431,6 +431,12 @@ public class RaptorMetadata
         return map.build();
     }
 
+    @Override
+    public void refreshTableMetadata(ConnectorTableHandle table)
+    {
+        throw new UnsupportedOperationException("Refresh is not supported");
+    }
+
     private boolean viewExists(ConnectorSession session, SchemaTableName viewName)
     {
         return !getViews(session, viewName.toSchemaTablePrefix()).isEmpty();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorMetadata.java
@@ -128,4 +128,10 @@ public interface ConnectorMetadata
      * Gets the view data for views that match the specified table prefix.
      */
     Map<SchemaTableName, String> getViews(ConnectorSession session, SchemaTablePrefix prefix);
+
+    /**
+     * Refreshes the metadata for the specified table handle.
+     *
+     */
+    void refreshTableMetadata(ConnectorTableHandle tableHandle);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -203,6 +203,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public void refreshTableMetadata(ConnectorTableHandle tableHandle)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.refreshTableMetadata(tableHandle);
+        }
+    }
+
+    @Override
     public String toString()
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
@@ -142,6 +142,12 @@ public class TpchMetadata
     }
 
     @Override
+    public void refreshTableMetadata(ConnectorTableHandle table)
+    {
+        throw new UnsupportedOperationException("Refresh is not supported");
+    }
+
+    @Override
     public ColumnMetadata getColumnMetadata(ConnectorTableHandle tableHandle, ConnectorColumnHandle columnHandle)
     {
         ConnectorTableMetadata tableMetadata = getTableMetadata(tableHandle);

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/testing/SampledTpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/testing/SampledTpchMetadata.java
@@ -36,4 +36,10 @@ public class SampledTpchMetadata
     {
         return new TpchColumnHandle(SAMPLE_WEIGHT_COLUMN_NAME, SAMPLE_WEIGHT_COLUMN_INDEX, BIGINT);
     }
+
+    @Override
+    public void refreshTableMetadata(ConnectorTableHandle table)
+    {
+        throw new UnsupportedOperationException("Refresh is not supported");
+    }
 }


### PR DESCRIPTION
This PR adds support for ```REFRESH table_name``` statement to synchronously refresh the metadata for the specified table and it's list of partitions. Currently only the hive catalog supports this operation.

