### PR TITLE
Escape DatabaseMetaData pattern String

### DIFF
--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcClient.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcClient.java
@@ -72,4 +72,16 @@ public class TestJdbcClient
                 new JdbcColumnHandle(CONNECTOR_ID, "TEXT", VARCHAR, 0),
                 new JdbcColumnHandle(CONNECTOR_ID, "VALUE", BIGINT, 1)));
     }
+
+    @Test
+    public void testMetadataWithSchemaPattern()
+            throws Exception
+    {
+        SchemaTableName schemaTableName = new SchemaTableName("exa_ple", "num_ers");
+        JdbcTableHandle table = jdbcClient.getTableHandle(schemaTableName);
+        assertNotNull(table, "table is null");
+        assertEquals(jdbcClient.getColumns(table), ImmutableList.of(
+                new JdbcColumnHandle(CONNECTOR_ID, "TE_T", VARCHAR, 0),
+                new JdbcColumnHandle(CONNECTOR_ID, "VA_UE", BIGINT, 1)));
+    }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
@@ -109,6 +109,14 @@ public class TestJdbcMetadata
                 new ColumnMetadata("text", VARCHAR, 0, false),
                 new ColumnMetadata("value", BIGINT, 1, false)));
 
+        // escaping name patterns
+        JdbcTableHandle specialTableHandle = metadata.getTableHandle(SESSION, new SchemaTableName("exa_ple", "num_ers"));
+        ConnectorTableMetadata specialTableMetadata = metadata.getTableMetadata(specialTableHandle);
+        assertEquals(specialTableMetadata.getTable(), new SchemaTableName("exa_ple", "num_ers"));
+        assertEquals(specialTableMetadata.getColumns(), ImmutableList.of(
+                new ColumnMetadata("te_t", VARCHAR, 0, false),
+                new ColumnMetadata("va_ue", BIGINT, 1, false)));
+
         // unknown tables should produce null
         unknownTableMetadata(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("u", "numbers"), null, "unknown", "unknown"));
         unknownTableMetadata(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("example", "numbers"), null, "example", "unknown"));
@@ -132,7 +140,8 @@ public class TestJdbcMetadata
         assertEquals(ImmutableSet.copyOf(metadata.listTables(SESSION, null)), ImmutableSet.of(
                 new SchemaTableName("example", "numbers"),
                 new SchemaTableName("tpch", "orders"),
-                new SchemaTableName("tpch", "lineitem")));
+                new SchemaTableName("tpch", "lineitem"),
+                new SchemaTableName("exa_ple", "num_ers")));
 
         // specific schema
         assertEquals(ImmutableSet.copyOf(metadata.listTables(SESSION, "example")), ImmutableSet.of(
@@ -140,6 +149,8 @@ public class TestJdbcMetadata
         assertEquals(ImmutableSet.copyOf(metadata.listTables(SESSION, "tpch")), ImmutableSet.of(
                 new SchemaTableName("tpch", "orders"),
                 new SchemaTableName("tpch", "lineitem")));
+        assertEquals(ImmutableSet.copyOf(metadata.listTables(SESSION, "exa_ple")), ImmutableSet.of(
+                new SchemaTableName("exa_ple", "num_ers")));
 
         // unknown schema
         assertEquals(ImmutableSet.copyOf(metadata.listTables(SESSION, "unknown")), ImmutableSet.of());

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
@@ -64,6 +64,9 @@ final class TestingDatabase
         connection.createStatement().execute("CREATE TABLE tpch.orders(orderkey bigint primary key, custkey bigint)");
         connection.createStatement().execute("CREATE TABLE tpch.lineitem(orderkey bigint primary key, partkey bigint)");
 
+        connection.createStatement().execute("CREATE SCHEMA exa_ple");
+        connection.createStatement().execute("CREATE TABLE exa_ple.num_ers(te_t varchar primary key, va_ue bigint)");
+
         connection.commit();
     }
 


### PR DESCRIPTION
Some DatabaseMetaData methods take arguments that are String patterns.
Escape special chars '_' and '%' for the methods.