### PR TITLE
Allow Raptor files to be sorted on column(s)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/PagesIndexPageSorter.java
+++ b/presto-main/src/main/java/com/facebook/presto/PagesIndexPageSorter.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto;
+
+import com.facebook.presto.operator.PagesIndex;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageSorter;
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.List;
+
+import static com.facebook.presto.operator.SyntheticAddress.decodePosition;
+import static com.facebook.presto.operator.SyntheticAddress.decodeSliceIndex;
+
+public class PagesIndexPageSorter
+        implements PageSorter
+{
+    @Override
+    public long[] sort(List<Type> types, List<Page> pages, List<Type> sortTypes, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions)
+    {
+        PagesIndex pagesIndex = new PagesIndex(types, expectedPositions);
+        pages.forEach(pagesIndex::addPage);
+        pagesIndex.sort(sortTypes, sortChannels, sortOrders);
+
+        return pagesIndex.getValueAddresses().toLongArray(null);
+    }
+
+    @Override
+    public int decodePageIndex(long address)
+    {
+        return decodeSliceIndex(address);
+    }
+
+    @Override
+    public int decodePositionIndex(long address)
+    {
+        return decodePosition(address);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -113,7 +113,7 @@ public class HashBuilderOperator
         this.hashChannels = ImmutableList.copyOf(checkNotNull(hashChannels, "hashChannels is null"));
         this.hashChannel = checkNotNull(hashChannel, "hashChannel is null");
 
-        this.pagesIndex = new PagesIndex(lookupSourceSupplier.getTypes(), expectedPositions, operatorContext);
+        this.pagesIndex = new PagesIndex(lookupSourceSupplier.getTypes(), expectedPositions);
     }
 
     @Override
@@ -135,7 +135,7 @@ public class HashBuilderOperator
             return;
         }
 
-        LookupSource lookupSource = pagesIndex.createLookupSource(hashChannels, hashChannel);
+        LookupSource lookupSource = pagesIndex.createLookupSource(hashChannels, operatorContext, hashChannel);
         lookupSourceSupplier.setLookupSource(lookupSource);
         finished = true;
     }
@@ -159,6 +159,7 @@ public class HashBuilderOperator
         checkState(!isFinished(), "Operator is already finished");
 
         pagesIndex.addPage(page);
+        operatorContext.setMemoryReservation(pagesIndex.getEstimatedSize().toBytes());
         operatorContext.recordGeneratedOutput(page.getSizeInBytes(), page.getPositionCount());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/OrderByOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OrderByOperator.java
@@ -130,7 +130,7 @@ public class OrderByOperator
         this.sortChannels = ImmutableList.copyOf(checkNotNull(sortChannels, "sortChannels is null"));
         this.sortOrder = ImmutableList.copyOf(checkNotNull(sortOrder, "sortOrder is null"));
 
-        this.pageIndex = new PagesIndex(sourceTypes, expectedPositions, operatorContext);
+        this.pageIndex = new PagesIndex(sourceTypes, expectedPositions);
 
         this.pageBuilder = new PageBuilder(this.types);
     }
@@ -177,6 +177,7 @@ public class OrderByOperator
         checkNotNull(page, "page is null");
 
         pageIndex.addPage(page);
+        operatorContext.setMemoryReservation(pageIndex.getEstimatedSize().toBytes());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -63,7 +63,6 @@ public class PagesIndex
     private static final JoinCompiler joinCompiler = new JoinCompiler();
 
     private final List<Type> types;
-    private final OperatorContext operatorContext;
     private final LongArrayList valueAddresses;
     private final ObjectArrayList<Block>[] channels;
 
@@ -71,10 +70,9 @@ public class PagesIndex
     private long pagesMemorySize;
     private long estimatedSize;
 
-    public PagesIndex(List<Type> types, int expectedPositions, OperatorContext operatorContext)
+    public PagesIndex(List<Type> types, int expectedPositions)
     {
         this.types = ImmutableList.copyOf(checkNotNull(types, "types is null"));
-        this.operatorContext = checkNotNull(operatorContext, "operatorContext is null");
         this.valueAddresses = new LongArrayList(expectedPositions);
 
         //noinspection rawtypes
@@ -120,7 +118,7 @@ public class PagesIndex
             valueAddresses.add(sliceAddress);
         }
 
-        estimatedSize = operatorContext.setMemoryReservation(calculateEstimatedSize());
+        estimatedSize = calculateEstimatedSize();
     }
 
     public DataSize getEstimatedSize()
@@ -246,12 +244,12 @@ public class PagesIndex
         };
     }
 
-    public LookupSource createLookupSource(List<Integer> joinChannels)
+    public LookupSource createLookupSource(List<Integer> joinChannels, OperatorContext operatorContext)
     {
-        return createLookupSource(joinChannels, Optional.empty());
+        return createLookupSource(joinChannels, operatorContext, Optional.empty());
     }
 
-    public LookupSource createLookupSource(List<Integer> joinChannels, Optional<Integer> hashChannel)
+    public LookupSource createLookupSource(List<Integer> joinChannels, OperatorContext operatorContext, Optional<Integer> hashChannel)
     {
         try {
             LookupSourceFactory lookupSourceFactory = joinCompiler.compileLookupSourceFactory(types, joinChannels);

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
@@ -218,7 +218,7 @@ public class WindowOperator
 
         this.types = toTypes(sourceTypes, outputChannels, windowFunctions);
 
-        this.pagesIndex = new PagesIndex(sourceTypes, expectedPositions, operatorContext);
+        this.pagesIndex = new PagesIndex(sourceTypes, expectedPositions);
         this.pageBuilder = new PageBuilder(this.types);
     }
 
@@ -278,6 +278,7 @@ public class WindowOperator
         checkNotNull(page, "page is null");
 
         pagesIndex.addPage(page);
+        operatorContext.setMemoryReservation(pagesIndex.getEstimatedSize().toBytes());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.server;
 
+import com.facebook.presto.PagesIndexPageSorter;
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.connector.ConnectorManager;
@@ -50,6 +51,7 @@ import com.facebook.presto.spi.ConnectorFactory;
 import com.facebook.presto.spi.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.PageSorter;
 import com.facebook.presto.spi.block.BlockEncodingFactory;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.block.FixedWidthBlockEncoding;
@@ -269,6 +271,9 @@ public class ServerMainModule
 
         // thread execution visualizer
         jaxrsBinder(binder).bind(QueryExecutionResource.class);
+
+        // PageSorter
+        binder.bind(PageSorter.class).to(PagesIndexPageSorter.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/presto-main/src/test/java/com/facebook/presto/BenchmarkPagesIndexPageSorter.java
+++ b/presto-main/src/test/java/com/facebook/presto/BenchmarkPagesIndexPageSorter.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto;
+
+import com.facebook.presto.block.BlockAssertions;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageSorter;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.Type;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.spi.block.SortOrder.ASC_NULLS_FIRST;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static java.util.Collections.nCopies;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(3)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class BenchmarkPagesIndexPageSorter
+{
+    @Benchmark
+    public int runBenchmark(BenchmarkData data)
+    {
+        PageSorter pageSorter = new PagesIndexPageSorter();
+        long[] addresses = pageSorter.sort(data.types, data.pages, data.sortTypes, data.sortChannels, nCopies(data.sortChannels.size(), ASC_NULLS_FIRST), 10_000);
+        return addresses.length;
+    }
+
+    private static List<Page> createPages(int pageCount, int channelCount, Type type)
+    {
+        int positionCount = BlockBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES / (channelCount * 8);
+
+        List<Page> pages = new ArrayList<>(pageCount);
+        for (int numPage = 0; numPage < pageCount; numPage++) {
+            Block[] blocks = new Block[channelCount];
+            for (int numChannel = 0; numChannel < channelCount; numChannel++) {
+                if (type.equals(BIGINT)) {
+                    blocks[numChannel] = BlockAssertions.createLongSequenceBlock(0, positionCount);
+                }
+                else if (type.equals(VARCHAR)) {
+                    blocks[numChannel] = BlockAssertions.createStringSequenceBlock(0, positionCount);
+                }
+                else if (type.equals(DOUBLE)) {
+                    blocks[numChannel] = BlockAssertions.createDoubleSequenceBlock(0, positionCount);
+                }
+                else if (type.equals(BOOLEAN)) {
+                    blocks[numChannel] = BlockAssertions.createBooleanSequenceBlock(0, positionCount);
+                }
+                else {
+                    throw new IllegalArgumentException("Unsupported type: " + type);
+                }
+            }
+            pages.add(new Page(blocks));
+        }
+        return pages;
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({ "2", "3", "4", "5" })
+        private int numSortChannels;
+
+        @Param({ "BIGINT", "VARCHAR", "DOUBLE", "BOOLEAN" })
+        private String sortChannelType;
+
+        private List<Page> pages;
+        private final int maxPages = 500;
+
+        public List<Type> types;
+        public List<Type> sortTypes;
+        public List<Integer> sortChannels;
+
+        @Setup
+        public void setup()
+        {
+            int totalChannels = 20;
+            Type type = getType();
+
+            pages = createPages(maxPages, totalChannels, type);
+            types = nCopies(totalChannels, type);
+
+            sortChannels = new ArrayList<>();
+            for (int i = 0; i < numSortChannels; i++) {
+                sortChannels.add(i);
+            }
+            sortTypes = nCopies(numSortChannels, type);
+        }
+
+        private Type getType()
+        {
+            switch (sortChannelType) {
+                case "BIGINT":
+                    return BIGINT;
+                case "VARCHAR":
+                    return VARCHAR;
+                case "DOUBLE":
+                    return DOUBLE;
+                case "BOOLEAN":
+                    return BOOLEAN;
+            }
+            throw new IllegalArgumentException("Unsupported type: " + sortChannelType);
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkPagesIndexPageSorter.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/TestPagesIndexPageSorter.java
+++ b/presto-main/src/test/java/com/facebook/presto/TestPagesIndexPageSorter.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.testing.MaterializedResult;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.operator.OperatorAssertion.toMaterializedResult;
+import static com.facebook.presto.spi.block.SortOrder.ASC_NULLS_FIRST;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static org.testng.Assert.assertEquals;
+
+public class TestPagesIndexPageSorter
+{
+    private static final PagesIndexPageSorter sorter = new PagesIndexPageSorter();
+
+    @Test
+    public void testPageSorter()
+            throws Exception
+    {
+        List<Type> types = ImmutableList.of(BIGINT, DOUBLE, VARCHAR);
+        List<Type> sortTypes = ImmutableList.of(BIGINT);
+        List<Integer> sortChannels = Ints.asList(0);
+        List<SortOrder> sortOrders = ImmutableList.of(ASC_NULLS_FIRST);
+
+        List<Page> inputPages = RowPagesBuilder.rowPagesBuilder(types)
+                .row(2, 1.1, "d")
+                .row(1, 2.2, "c")
+                .pageBreak()
+                .row(-2, 2.2, "b")
+                .row(-12, 2.2, "a")
+                .build();
+
+        List<Page> expectedPages = RowPagesBuilder.rowPagesBuilder(types)
+                .row(-12, 2.2, "a")
+                .row(-2, 2.2, "b")
+                .pageBreak()
+                .row(1, 2.2, "c")
+                .row(2, 1.1, "d")
+                .build();
+
+        assertSorted(inputPages, expectedPages, types, sortTypes, sortChannels, sortOrders, 100);
+    }
+
+    @Test
+    public void testPageSorterMultipleChannels()
+            throws Exception
+    {
+        List<Type> types = ImmutableList.of(BIGINT, DOUBLE, VARCHAR);
+        List<Type> sortTypes = ImmutableList.copyOf(types);
+        List<Integer> sortChannels = Ints.asList(0, 1, 2);
+        List<SortOrder> sortOrders = Collections.nCopies(sortChannels.size(), ASC_NULLS_FIRST);
+
+        List<Page> inputPages = RowPagesBuilder.rowPagesBuilder(types)
+                .row(2, 1.1, "d")
+                .row(1, 2.2, "c")
+                .pageBreak()
+                .row(1, 2.2, "b")
+                .row(1, 2.2, "a")
+                .pageBreak()
+                .row(1, 2.2, null)
+                .row(1, null, "z")
+                .row(1, null, null)
+                .build();
+
+        List<Page> expectedPages = RowPagesBuilder.rowPagesBuilder(types)
+                .row(1, null, null)
+                .row(1, null, "z")
+                .row(1, 2.2, null)
+                .row(1, 2.2, "a")
+                .row(1, 2.2, "b")
+                .row(1, 2.2, "c")
+                .row(2, 1.1, "d")
+                .build();
+        assertSorted(inputPages, expectedPages, types, sortTypes, sortChannels, sortOrders, 100);
+    }
+
+    @Test
+    public void testPageSorterSorted()
+            throws Exception
+    {
+        List<Type> types = ImmutableList.of(BIGINT, DOUBLE, VARCHAR);
+        List<Type> sortTypes = ImmutableList.of(BIGINT);
+        List<Integer> sortChannels = Ints.asList(0);
+        List<SortOrder> sortOrders = ImmutableList.of(ASC_NULLS_FIRST);
+
+        List<Page> inputPages = RowPagesBuilder.rowPagesBuilder(types)
+                .row(-12, 2.2, "a")
+                .row(-2, 2.2, "b")
+                .pageBreak()
+                .row(1, 2.2, "d")
+                .row(2, 1.1, "c")
+                .build();
+
+        List<Page> expectedPages = RowPagesBuilder.rowPagesBuilder(types)
+                .row(-12, 2.2, "a")
+                .row(-2, 2.2, "b")
+                .row(1, 2.2, "d")
+                .row(2, 1.1, "c")
+                .build();
+
+        assertSorted(inputPages, expectedPages, types, sortTypes, sortChannels, sortOrders, 100);
+    }
+
+    @Test
+    public void testPageSorterForceExpansion()
+            throws Exception
+    {
+        List<Type> types = ImmutableList.of(BIGINT, DOUBLE, VARCHAR);
+        List<Type> sortTypes = ImmutableList.of(BIGINT);
+        List<Integer> sortChannels = Ints.asList(0);
+        List<SortOrder> sortOrders = ImmutableList.of(ASC_NULLS_FIRST);
+
+        List<Page> inputPages = RowPagesBuilder.rowPagesBuilder(types)
+                .row(2, 1.1, "c")
+                .row(1, 2.2, "d")
+                .pageBreak()
+                .row(-2, 2.2, "b")
+                .row(-12, 2.2, "a")
+                .build();
+
+        List<Page> expectedPages = RowPagesBuilder.rowPagesBuilder(types)
+                .row(-12, 2.2, "a")
+                .row(-2, 2.2, "b")
+                .pageBreak()
+                .row(1, 2.2, "d")
+                .row(2, 1.1, "c")
+                .build();
+
+        assertSorted(inputPages, expectedPages, types, sortTypes, sortChannels, sortOrders, 2);
+    }
+
+    private static void assertSorted(List<Page> inputPages, List<Page> expectedPages, List<Type> types, List<Type> sortTypes, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions)
+    {
+        long[] sortedAddresses = sorter.sort(types, inputPages, sortTypes, sortChannels, sortOrders, expectedPositions);
+        List<Page> outputPages = createOutputPages(types, inputPages, sortedAddresses);
+
+        MaterializedResult expected = toMaterializedResult(TEST_SESSION, types, expectedPages);
+        MaterializedResult actual = toMaterializedResult(TEST_SESSION, types, outputPages);
+        assertEquals(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    private static List<Page> createOutputPages(List<Type> types, List<Page> inputPages, long[] sortedAddresses)
+    {
+        PageBuilder pageBuilder = new PageBuilder(types);
+        pageBuilder.reset();
+        for (long address : sortedAddresses) {
+            int index = sorter.decodePageIndex(address);
+            int position = sorter.decodePositionIndex(address);
+
+            Page page = inputPages.get(index);
+            for (int i = 0; i < types.size(); i++) {
+                Type type = types.get(i);
+                type.appendTo(page.getBlock(i), position, pageBuilder.getBlockBuilder(i));
+            }
+            pageBuilder.declarePosition();
+        }
+        return ImmutableList.of(pageBuilder.build());
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/PageBuffer.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/PageBuffer.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor;
+
+import com.facebook.presto.spi.Page;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+class PageBuffer
+{
+    private final long maxMemoryBytes;
+    private final List<Page> pages = new ArrayList<>();
+
+    private long usedMemoryBytes;
+    private long rowCount;
+
+    public PageBuffer(long maxMemoryBytes)
+    {
+        checkArgument(maxMemoryBytes > 0, "maxMemoryBytes must be positive");
+        this.maxMemoryBytes = maxMemoryBytes;
+    }
+
+    public void add(Page page)
+    {
+        checkNotNull(page, "page is null");
+        pages.add(page);
+        usedMemoryBytes += page.getSizeInBytes();
+        rowCount += page.getPositionCount();
+    }
+
+    public void reset()
+    {
+        pages.clear();
+        rowCount = 0;
+        usedMemoryBytes = 0;
+    }
+
+    public boolean isFull()
+    {
+        return usedMemoryBytes >= maxMemoryBytes;
+    }
+
+    public List<Page> getPages()
+    {
+        return ImmutableList.copyOf(pages);
+    }
+
+    public long getRowCount()
+    {
+        return rowCount;
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnectorFactory.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnectorFactory.java
@@ -19,6 +19,7 @@ import com.facebook.presto.raptor.util.RebindSafeMBeanServer;
 import com.facebook.presto.spi.Connector;
 import com.facebook.presto.spi.ConnectorFactory;
 import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.PageSorter;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.base.Throwables;
@@ -45,12 +46,14 @@ public class RaptorConnectorFactory
     private final NodeManager nodeManager;
     private final BlockEncodingSerde blockEncodingSerde;
     private final TypeManager typeManager;
+    private final PageSorter pageSorter;
 
     public RaptorConnectorFactory(
             String name,
             Module module,
             Map<String, String> optionalConfig,
             NodeManager nodeManager,
+            PageSorter pageSorter,
             BlockEncodingSerde blockEncodingSerde,
             TypeManager typeManager)
     {
@@ -59,6 +62,7 @@ public class RaptorConnectorFactory
         this.module = checkNotNull(module, "module is null");
         this.optionalConfig = checkNotNull(optionalConfig, "optionalConfig is null");
         this.nodeManager = checkNotNull(nodeManager, "nodeManager is null");
+        this.pageSorter = checkNotNull(pageSorter, "pageSorter is null");
         this.blockEncodingSerde = checkNotNull(blockEncodingSerde, "blockEncodingSerde is null");
         this.typeManager = checkNotNull(typeManager, "typeManager is null");
     }
@@ -82,6 +86,7 @@ public class RaptorConnectorFactory
                         binder.bind(MBeanServer.class).toInstance(mbeanServer);
                         binder.bind(CurrentNodeId.class).toInstance(currentNodeId);
                         binder.bind(NodeManager.class).toInstance(nodeManager);
+                        binder.bind(PageSorter.class).toInstance(pageSorter);
                         binder.bind(BlockEncodingSerde.class).toInstance(blockEncodingSerde);
                         binder.bind(TypeManager.class).toInstance(typeManager);
                     },

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorInsertTableHandle.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorInsertTableHandle.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.raptor;
 
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -35,6 +36,8 @@ public class RaptorInsertTableHandle
     private final List<Type> columnTypes;
     @Nullable
     private final String externalBatchId;
+    private final List<RaptorColumnHandle> sortColumnHandles;
+    private final List<SortOrder> sortOrders;
 
     @JsonCreator
     public RaptorInsertTableHandle(
@@ -42,7 +45,9 @@ public class RaptorInsertTableHandle
             @JsonProperty("tableId") long tableId,
             @JsonProperty("columnHandles") List<RaptorColumnHandle> columnHandles,
             @JsonProperty("columnTypes") List<Type> columnTypes,
-            @JsonProperty("externalBatchId") @Nullable String externalBatchId)
+            @JsonProperty("externalBatchId") @Nullable String externalBatchId,
+            @JsonProperty("sortColumnHandles") List<RaptorColumnHandle> sortColumnHandles,
+            @JsonProperty("sortOrders") List<SortOrder> sortOrders)
     {
         checkArgument(tableId > 0, "tableId must be greater than zero");
 
@@ -51,6 +56,9 @@ public class RaptorInsertTableHandle
         this.columnHandles = ImmutableList.copyOf(checkNotNull(columnHandles, "columnHandles is null"));
         this.columnTypes = ImmutableList.copyOf(checkNotNull(columnTypes, "columnTypes is null"));
         this.externalBatchId = externalBatchId;
+
+        this.sortOrders = ImmutableList.copyOf(checkNotNull(sortOrders, "sortOrders is null"));
+        this.sortColumnHandles = ImmutableList.copyOf(checkNotNull(sortColumnHandles, "sortColumnHandles is null"));
     }
 
     @JsonProperty
@@ -82,6 +90,18 @@ public class RaptorInsertTableHandle
     public String getExternalBatchId()
     {
         return externalBatchId;
+    }
+
+    @JsonProperty
+    public List<RaptorColumnHandle> getSortColumnHandles()
+    {
+        return sortColumnHandles;
+    }
+
+    @JsonProperty
+    public List<SortOrder> getSortOrders()
+    {
+        return sortOrders;
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorOutputTableHandle.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorOutputTableHandle.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.raptor;
 
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -36,6 +37,8 @@ public class RaptorOutputTableHandle
     private final List<Type> columnTypes;
     @Nullable
     private final RaptorColumnHandle sampleWeightColumnHandle;
+    private final List<RaptorColumnHandle> sortColumnHandles;
+    private final List<SortOrder> sortOrders;
 
     @JsonCreator
     public RaptorOutputTableHandle(
@@ -43,13 +46,17 @@ public class RaptorOutputTableHandle
             @JsonProperty("tableName") String tableName,
             @JsonProperty("columnHandles") List<RaptorColumnHandle> columnHandles,
             @JsonProperty("columnTypes") List<Type> columnTypes,
-            @JsonProperty("sampleWeightColumnHandle") @Nullable RaptorColumnHandle sampleWeightColumnHandle)
+            @JsonProperty("sampleWeightColumnHandle") @Nullable RaptorColumnHandle sampleWeightColumnHandle,
+            @JsonProperty("sortColumnHandles") List<RaptorColumnHandle> sortColumnHandles,
+            @JsonProperty("sortOrders") List<SortOrder> sortOrders)
     {
         this.schemaName = checkSchemaName(schemaName);
         this.tableName = checkTableName(tableName);
         this.columnHandles = ImmutableList.copyOf(checkNotNull(columnHandles, "columnHandles is null"));
         this.columnTypes = ImmutableList.copyOf(checkNotNull(columnTypes, "columnTypes is null"));
         this.sampleWeightColumnHandle = sampleWeightColumnHandle;
+        this.sortOrders = checkNotNull(sortOrders, "sortOrders is null");
+        this.sortColumnHandles = checkNotNull(sortColumnHandles, "sortColumnHandles is null");
     }
 
     @JsonProperty
@@ -81,6 +88,18 @@ public class RaptorOutputTableHandle
     public RaptorColumnHandle getSampleWeightColumnHandle()
     {
         return sampleWeightColumnHandle;
+    }
+
+    @JsonProperty
+    public List<RaptorColumnHandle> getSortColumnHandles()
+    {
+        return sortColumnHandles;
+    }
+
+    @JsonProperty
+    public List<SortOrder> getSortOrders()
+    {
+        return sortOrders;
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorPlugin.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorPlugin.java
@@ -15,6 +15,7 @@ package com.facebook.presto.raptor;
 
 import com.facebook.presto.spi.ConnectorFactory;
 import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.PageSorter;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.type.TypeManager;
@@ -42,6 +43,7 @@ public class RaptorPlugin
 
     private Map<String, String> optionalConfig = ImmutableMap.of();
     private NodeManager nodeManager;
+    private PageSorter pageSorter;
     private BlockEncodingSerde blockEncodingSerde;
     private TypeManager typeManager;
 
@@ -75,6 +77,12 @@ public class RaptorPlugin
     }
 
     @Inject
+    public void setPageSorter(PageSorter pageSorter)
+    {
+        this.pageSorter = pageSorter;
+    }
+
+    @Inject
     public void setBlockEncodingSerde(BlockEncodingSerde blockEncodingSerde)
     {
         this.blockEncodingSerde = checkNotNull(blockEncodingSerde, "blockEncodingSerde is null");
@@ -99,6 +107,7 @@ public class RaptorPlugin
                     module,
                     optionalConfig,
                     nodeManager,
+                    pageSorter,
                     blockEncodingSerde,
                     typeManager)));
         }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
@@ -40,6 +40,7 @@ public interface MetadataDao
             "  column_name VARCHAR(255) NOT NULL,\n" +
             "  ordinal_position INT NOT NULL,\n" +
             "  data_type VARCHAR(255) NOT NULL,\n" +
+            "  sort_ordinal_position INT DEFAULT NULL,\n" +
             "  PRIMARY KEY (table_id, column_id),\n" +
             "  UNIQUE (table_id, column_name),\n" +
             "  UNIQUE (table_id, ordinal_position),\n" +
@@ -118,6 +119,15 @@ public interface MetadataDao
             "WHERE t.table_id = :tableId\n" +
             "ORDER BY c.ordinal_position")
     List<TableColumn> listTableColumns(@Bind("tableId") long tableId);
+
+    @SqlQuery("SELECT t.schema_name, t.table_name,\n" +
+            "  c.column_id, c.column_name, c.ordinal_position, c.data_type\n" +
+            "FROM tables t\n" +
+            "JOIN columns c ON (t.table_id = c.table_id)\n" +
+            "WHERE t.table_id = :tableId\n" +
+            "  AND c.sort_ordinal_position IS NOT NULL\n" +
+            "ORDER BY c.sort_ordinal_position")
+    List<TableColumn> listSortColumns(@Bind("tableId") long tableId);
 
     @SqlQuery("SELECT catalog_name, schema_name, table_name, data\n" +
             "FROM views\n" +

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -62,21 +62,24 @@ public class OrcStorageManager
     private final ShardRecoveryManager recoveryManager;
     private final Duration recoveryTimeout;
     private final long rowsPerShard;
+    private final DataSize maxBufferSize;
 
     @Inject
     public OrcStorageManager(StorageService storageService, StorageManagerConfig config, ShardRecoveryManager recoveryManager)
     {
-        this(storageService, config.getOrcMaxMergeDistance(), recoveryManager, config.getShardRecoveryTimeout(), config.getRowsPerShard());
+        this(storageService, config.getOrcMaxMergeDistance(), recoveryManager, config.getShardRecoveryTimeout(), config.getRowsPerShard(), config.getMaxBufferSize());
     }
 
-    public OrcStorageManager(StorageService storageService, DataSize orcMaxMergeDistance, ShardRecoveryManager recoveryManager, Duration shardRecoveryTimeout, long rowsPerShard)
+    public OrcStorageManager(StorageService storageService, DataSize orcMaxMergeDistance, ShardRecoveryManager recoveryManager, Duration shardRecoveryTimeout, long rowsPerShard, DataSize maxBufferSize)
     {
         this.storageService = checkNotNull(storageService, "storageService is null");
         this.orcMaxMergeDistance = checkNotNull(orcMaxMergeDistance, "orcMaxMergeDistance is null");
         this.recoveryManager = checkNotNull(recoveryManager, "recoveryManager is null");
         this.recoveryTimeout = checkNotNull(shardRecoveryTimeout, "shardRecoveryTimeout is null");
+
         checkArgument(rowsPerShard > 0, "rowsPerShard must be > 0");
         this.rowsPerShard = rowsPerShard;
+        this.maxBufferSize = checkNotNull(maxBufferSize, "maxBufferSize is null");
     }
 
     @Override
@@ -174,6 +177,12 @@ public class OrcStorageManager
     public long getMaxRowCount()
     {
         return rowsPerShard;
+    }
+
+    @Override
+    public DataSize getMaxBufferSize()
+    {
+        return maxBufferSize;
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManager.java
@@ -17,6 +17,7 @@ import com.facebook.presto.raptor.RaptorColumnHandle;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.TupleDomain;
 import com.facebook.presto.spi.type.Type;
+import io.airlift.units.DataSize;
 
 import java.util.List;
 import java.util.UUID;
@@ -34,4 +35,6 @@ public interface StorageManager
     List<UUID> commit(StorageOutputHandle storageOutputHandle);
 
     long getMaxRowCount();
+
+    DataSize getMaxBufferSize();
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
@@ -17,6 +17,7 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.airlift.units.MinDataSize;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.Max;
@@ -37,6 +38,7 @@ public class StorageManagerConfig
     private DataSize orcMaxMergeDistance = new DataSize(1, MEGABYTE);
     private int recoveryThreads = 10;
     private long rowsPerShard = 1_000_000;
+    private DataSize maxBufferSize = new DataSize(256, MEGABYTE);
 
     @NotNull
     public File getDataDirectory()
@@ -131,6 +133,20 @@ public class StorageManagerConfig
     public StorageManagerConfig setRowsPerShard(long rowsPerShard)
     {
         this.rowsPerShard = rowsPerShard;
+        return this;
+    }
+
+    @MinDataSize("1MB")
+    public DataSize getMaxBufferSize()
+    {
+        return maxBufferSize;
+    }
+
+    @Config("storage.max-buffer-size")
+    @ConfigDescription("Maximum data to buffer before flushing to disk")
+    public StorageManagerConfig setMaxBufferSize(DataSize maxBufferSize)
+    {
+        this.maxBufferSize = maxBufferSize;
         return this;
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StoragePageSink.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StoragePageSink.java
@@ -16,11 +16,14 @@ package com.facebook.presto.raptor.storage;
 import com.facebook.presto.spi.Page;
 
 import java.io.Closeable;
+import java.util.List;
 
 public interface StoragePageSink
         extends Closeable
 {
-    void appendPage(Page page);
+    void appendPages(List<Page> pages);
+
+    void appendPages(List<Page> pages, int[] pageIndexes, int[] positionIndexes);
 
     @Override
     void close();

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorPlugin.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorPlugin.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.raptor;
 
+import com.facebook.presto.PagesIndexPageSorter;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.spi.ConnectorFactory;
 import com.facebook.presto.spi.Plugin;
@@ -42,6 +43,7 @@ public class TestRaptorPlugin
         plugin.setNodeManager(new InMemoryNodeManager());
         plugin.setBlockEncodingSerde(createTestingBlockEncodingManager());
         plugin.setTypeManager(new TypeRegistry());
+        plugin.setPageSorter(new PagesIndexPageSorter());
 
         List<ConnectorFactory> factories = plugin.getServices(ConnectorFactory.class);
         ConnectorFactory factory = getOnlyElement(factories);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorSplitManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorSplitManager.java
@@ -92,7 +92,7 @@ public class TestRaptorSplitManager
         InMemoryNodeManager nodeManager = new InMemoryNodeManager();
         StorageService storageService = new FileStorageService(dataDir, Optional.empty());
         ShardRecoveryManager recoveryManager = new ShardRecoveryManager(storageService, new InMemoryNodeManager(), shardManager, new Duration(5, TimeUnit.MINUTES), 10);
-        StorageManager storageManager = new OrcStorageManager(storageService, new DataSize(1, MEGABYTE), recoveryManager, new Duration(30, TimeUnit.SECONDS), 100);
+        StorageManager storageManager = new OrcStorageManager(storageService, new DataSize(1, MEGABYTE), recoveryManager, new Duration(30, TimeUnit.SECONDS), 100, new DataSize(256, MEGABYTE));
 
         String nodeName = UUID.randomUUID().toString();
         nodeManager.addNode("raptor", new PrestoNode(nodeName, new URI("http://127.0.0.1/"), NodeVersion.UNKNOWN));

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStoragePageSink.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStoragePageSink.java
@@ -82,7 +82,7 @@ public class TestOrcStoragePageSink
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(new EmptyClassLoader());
              StoragePageSink sink = new OrcStoragePageSink(columnIds, columnTypes, file)) {
-            rowPagesBuilder.build().forEach(sink::appendPage);
+            sink.appendPages(rowPagesBuilder.build());
         }
 
         try (FileOrcDataSource dataSource = new FileOrcDataSource(file, new DataSize(1, Unit.MEGABYTE))) {

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStoragePageSink.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStoragePageSink.java
@@ -47,7 +47,7 @@ import static io.airlift.testing.FileUtils.deleteRecursively;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
-public class TestOrcPageSink
+public class TestOrcStoragePageSink
 {
     private File directory;
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestStorageManagerConfig.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestStorageManagerConfig.java
@@ -44,7 +44,8 @@ public class TestStorageManagerConfig
                 .setShardRecoveryTimeout(new Duration(30, SECONDS))
                 .setMissingShardDiscoveryInterval(new Duration(5, MINUTES))
                 .setRecoveryThreads(10)
-                .setRowsPerShard(1_000_000));
+                .setRowsPerShard(1_000_000)
+                .setMaxBufferSize(new DataSize(256, MEGABYTE)));
 
     }
 
@@ -59,6 +60,7 @@ public class TestStorageManagerConfig
                 .put("storage.missing-shard-discovery-interval", "4m")
                 .put("storage.max-recovery-threads", "12")
                 .put("storage.rows-per-shard", "10000")
+                .put("storage.max-buffer-size", "512MB")
                 .build();
 
         StorageManagerConfig expected = new StorageManagerConfig()
@@ -68,7 +70,8 @@ public class TestStorageManagerConfig
                 .setShardRecoveryTimeout(new Duration(1, MINUTES))
                 .setMissingShardDiscoveryInterval(new Duration(4, MINUTES))
                 .setRecoveryThreads(12)
-                .setRowsPerShard(10_000);
+                .setRowsPerShard(10_000)
+                .setMaxBufferSize(new DataSize(512, MEGABYTE));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/PageSorter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/PageSorter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.List;
+
+/**
+ * This interface is not stable and will not be supported in future releases.
+ */
+
+@Deprecated
+public interface PageSorter
+{
+    /**
+     * @return Sorted synthetic addresses for pages. A synthetic address is encoded as a long with
+     * the high 32 bits containing the page index and the low 32 bits containing position index
+     */
+    @Deprecated
+    long[] sort(List<Type> types, List<Page> pages, List<Type> sortTypes, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions);
+
+    int decodePageIndex(long address);
+
+    int decodePositionIndex(long address);
+}


### PR DESCRIPTION
* Add  an interface in presto-main to sort a list of pages (this is marked as deprecated, we should identify a better way to expose this functionality)
* Plug it in the Raptor page sink, cache pages in Raptor, and sort them before writing to disk 
