### PR TITLE
Encode varbinary literals as a function call to from_base64(...)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
@@ -17,6 +17,7 @@ import com.facebook.presto.metadata.FunctionInfo;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.scalar.VarbinaryFunctions;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.SemanticException;
@@ -46,6 +47,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.TYPE_MISMATCH;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
@@ -132,6 +134,13 @@ public final class LiteralInterpreter
 
         if (type.equals(BOOLEAN)) {
             return new BooleanLiteral(object.toString());
+        }
+
+        if (type.equals(VARBINARY) && object instanceof Slice) {
+            // HACK: we need to serialize VARBINARY in a format that can be embedded in an expression to be
+            // able to encode it in the plan that gets sent to workers.
+            // We do this by transforming the in-memory varbinary into a call to from_base64(<base64-encoded value>)
+            return new FunctionCall(new QualifiedName("from_base64"), ImmutableList.of(new StringLiteral(VarbinaryFunctions.toBase64((Slice) object).toStringUtf8())));
         }
 
         Signature signature = FunctionRegistry.getMagicLiteralFunctionSignature(type);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -92,6 +92,14 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testVarbinary()
+            throws Exception
+    {
+        assertQuery("SELECT LENGTH(x) FROM (SELECT from_base64('gw==') as x)", "SELECT 1");
+        assertQuery("SELECT LENGTH(from_base64('gw=='))", "SELECT 1");
+    }
+
+    @Test
     public void testRowFieldAccessor()
             throws Exception
     {


### PR DESCRIPTION
They were being encoded using the "magic literal" hack, but the value
was being encoded as a UTF-8 string. The magic literal evaluator doesn't
know it has to reverse the process, so this ends up corrupting varbinary
literals during constant folding or distributed evaluation.

This minor hack turns varbinary literals into function calls to:

```
from_base64(<base64-encoded varchar>)
```

Fixes https://github.com/facebook/presto/issues/2197