### PR TITLE
show partitions fails

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
@@ -108,7 +108,7 @@ public final class QueryUtil
 
     public static Expression caseWhen(Expression operand, Expression result)
     {
-        return new SearchedCaseExpression(ImmutableList.of(new WhenClause(operand, result)), null);
+        return new SearchedCaseExpression(ImmutableList.of(new WhenClause(operand, result)), Optional.empty());
     }
 
     public static Expression functionCall(String name, Expression... arguments)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SearchedCaseExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SearchedCaseExpression.java
@@ -13,11 +13,12 @@
  */
 package com.facebook.presto.sql.tree;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class SearchedCaseExpression
         extends Expression
@@ -27,7 +28,8 @@ public class SearchedCaseExpression
 
     public SearchedCaseExpression(List<WhenClause> whenClauses, Optional<Expression> defaultValue)
     {
-        Preconditions.checkNotNull(whenClauses, "whenClauses is null");
+        checkNotNull(whenClauses, "whenClauses is null");
+        checkNotNull(defaultValue, "defaultValue is null");
         this.whenClauses = ImmutableList.copyOf(whenClauses);
         this.defaultValue = defaultValue;
     }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.tree.Approximate;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.ArrayConstructor;
 import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.CurrentTime;
@@ -42,12 +43,14 @@ import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.RenameTable;
 import com.facebook.presto.sql.tree.ResetSession;
 import com.facebook.presto.sql.tree.SetSession;
 import com.facebook.presto.sql.tree.ShowCatalogs;
+import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
 import com.facebook.presto.sql.tree.ShowSession;
 import com.facebook.presto.sql.tree.ShowTables;
@@ -605,6 +608,28 @@ public class TestSqlParser
         assertStatement("SHOW TABLES", new ShowTables(Optional.empty(), Optional.empty()));
         assertStatement("SHOW TABLES FROM a", new ShowTables(Optional.of(QualifiedName.of("a")), Optional.empty()));
         assertStatement("SHOW TABLES IN a LIKE '%'", new ShowTables(Optional.of(QualifiedName.of("a")), Optional.of("%")));
+    }
+
+    @Test
+    public void testShowPartitions()
+    {
+        assertStatement("SHOW PARTITIONS FROM T", new ShowPartitions(QualifiedName.of("T"), Optional.empty(), ImmutableList.of(), Optional.empty()));
+
+        assertStatement("SHOW PARTITIONS FROM T where x=1",
+                new ShowPartitions(QualifiedName.of("T"), Optional.of(new ComparisonExpression(ComparisonExpression.Type.EQUAL, new QualifiedNameReference(QualifiedName.of("x")), new LongLiteral("1"))),
+                                   ImmutableList.of(),
+                                   Optional.empty()));
+
+        assertStatement("SHOW PARTITIONS FROM T where x=1 order by y",
+                new ShowPartitions(QualifiedName.of("T"), Optional.of(new ComparisonExpression(ComparisonExpression.Type.EQUAL, new QualifiedNameReference(QualifiedName.of("x")), new LongLiteral("1"))),
+                                   ImmutableList.of(new SortItem(new QualifiedNameReference(QualifiedName.of("y")), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
+                                   Optional.empty()));
+
+        assertStatement("SHOW PARTITIONS FROM T where x=1 order by y limit 10",
+                new ShowPartitions(QualifiedName.of("T"),
+                                   Optional.of(new ComparisonExpression(ComparisonExpression.Type.EQUAL, new QualifiedNameReference(QualifiedName.of("x")), new LongLiteral("1"))),
+                                   ImmutableList.of(new SortItem(new QualifiedNameReference(QualifiedName.of("y")), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
+                                   Optional.of("10")));
     }
 
     @Test


### PR DESCRIPTION
The ``defaultValue`` is set to ``null`` instead of ``Optional.empty()`` when constructing the ``SearchedCaseExpression``, causing a NPE later on. This PR fixes that.

```
presto:default> show partitions from my_table;
Query 20150108_223912_00053_nig3u failed: null
java.lang.NullPointerException
        at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.getCaseResultExpressions(ExpressionAnalyzer.java:424)
        at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.visitSearchedCaseExpression(ExpressionAnalyzer.java:385)
        at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.visitSearchedCaseExpression(ExpressionAnalyzer.java:180)
        at com.facebook.presto.sql.tree.SearchedCaseExpression.accept(SearchedCaseExpression.java:48)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
        at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.process(ExpressionAnalyzer.java:198)
        at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.visitCast(ExpressionAnalyzer.java:687)
        at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.visitCast(ExpressionAnalyzer.java:180)
        at com.facebook.presto.sql.tree.Cast.accept(Cast.java:61)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
        at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.process(ExpressionAnalyzer.java:198)
        at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.visitFunctionCall(ExpressionAnalyzer.java:621)
        at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.visitFunctionCall(ExpressionAnalyzer.java:180)
        at com.facebook.presto.sql.tree.FunctionCall.accept(FunctionCall.java:70)
        at com.facebook.presto.sql.analyzer.ExpressionAnalyzer.analyze(ExpressionAnalyzer.java:177)
        at com.facebook.presto.sql.analyzer.ExpressionAnalyzer.analyzeExpression(ExpressionAnalyzer.java:970)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.analyzeExpression(TupleAnalyzer.java:1066)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.analyzeSelect(TupleAnalyzer.java:869)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.visitQuerySpecification(TupleAnalyzer.java:348)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.visitQuerySpecification(TupleAnalyzer.java:133)
        at com.facebook.presto.sql.tree.QuerySpecification.accept(QuerySpecification.java:99)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
        at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitQuery(StatementAnalyzer.java:493)
        at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitQuery(StatementAnalyzer.java:114)
        at com.facebook.presto.sql.tree.Query.accept(Query.java:81)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.visitTableSubquery(TupleAnalyzer.java:329)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.visitTableSubquery(TupleAnalyzer.java:133)
        at com.facebook.presto.sql.tree.TableSubquery.accept(TableSubquery.java:36)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.analyzeFrom(TupleAnalyzer.java:918)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.visitQuerySpecification(TupleAnalyzer.java:344)
        at com.facebook.presto.sql.analyzer.TupleAnalyzer.visitQuerySpecification(TupleAnalyzer.java:133)
        at com.facebook.presto.sql.tree.QuerySpecification.accept(QuerySpecification.java:99)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
        at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitQuery(StatementAnalyzer.java:493)
        at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitQuery(StatementAnalyzer.java:114)
        at com.facebook.presto.sql.tree.Query.accept(Query.java:81)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
        at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitShowPartitions(StatementAnalyzer.java:294)
        at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitShowPartitions(StatementAnalyzer.java:114)
        at com.facebook.presto.sql.tree.ShowPartitions.accept(ShowPartitions.java:64)
        at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
        at com.facebook.presto.sql.analyzer.Analyzer.analyze(Analyzer.java:52)
        at com.facebook.presto.execution.SqlQueryExecution.doAnalyzeQuery(SqlQueryExecution.java:208)
        at com.facebook.presto.execution.SqlQueryExecution.analyzeQuery(SqlQueryExecution.java:193)
        at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:154)
        at com.facebook.presto.execution.SqlQueryManager$QueryStarter$QuerySubmitter$2.run(SqlQueryManager.java:470)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)

```