### PR TITLE
Map constructor throws NPE with null keys

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.TypeParameter;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -83,6 +84,11 @@ public final class MapConstructor
         Type keyType = types.get("K");
         Type valueType = types.get("V");
 
+        //TODO Why is this null instead of unknown?
+        if (keyType == null) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "map key cannot be null");
+        }
+
         Type mapType = typeManager.getParameterizedType(MAP, ImmutableList.of(keyType.getTypeSignature(), valueType.getTypeSignature()), ImmutableList.of());
         ImmutableList<TypeSignature> argumentTypes = ImmutableList.of(parameterizedTypeName(StandardTypes.ARRAY, keyType.getTypeSignature()), parameterizedTypeName(StandardTypes.ARRAY, valueType.getTypeSignature()));
         Signature signature = new Signature("map", ImmutableList.<TypeParameter>of(), mapType.getTypeSignature(), argumentTypes, false, false);
@@ -101,6 +107,10 @@ public final class MapConstructor
 
             checkCondition(keysArray.length == valuesArray.length, INVALID_FUNCTION_ARGUMENT, "Key and value arrays must be the same length");
             for (int i = 0; i < keysArray.length; i++) {
+                if (keysArray[i] == null) {
+                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "map key cannot be null");
+                }
+
                 map.put(keysArray[i], valuesArray[i]);
             }
         }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -146,6 +146,9 @@ public class TestMapOperators
     public void testSubscript()
             throws Exception
     {
+        assertInvalidFunction("MAP(ARRAY [null], ARRAY [1])", "map key cannot be null");
+        assertInvalidFunction("MAP(ARRAY [null], ARRAY [null])", "map key cannot be null");
+        assertInvalidFunction("MAP(ARRAY [1,null], ARRAY [null,2])", "map key cannot be null");
         assertFunction("MAP(ARRAY [1, 3], ARRAY [2, 4])[3]", 4L);
         assertFunction("MAP(ARRAY [1, 3], ARRAY[2, NULL])[3]", null);
         assertFunction("MAP(ARRAY [1, 3], ARRAY [2.0, 4.0])[1]", 2.0);


### PR DESCRIPTION
Instead it should give a more meaningful error message.

```
presto:nyigitbasi> select map(array[null], array[null]);
Query 20150109_064055_00000_c84kn failed: null
java.lang.NullPointerException
        at com.facebook.presto.operator.scalar.MapConstructor.specialize(MapConstructor.java:86)
        at com.facebook.presto.metadata.FunctionRegistry.resolveFunction(FunctionRegistry.java:360)
        
presto:nyigitbasi> select map(array[null], array[1]);
Query 20150109_064057_00001_c84kn failed: null
java.lang.NullPointerException
        at com.facebook.presto.operator.scalar.MapConstructor.specialize(MapConstructor.java:86)
        at com.facebook.presto.metadata.FunctionRegistry.resolveFunction(FunctionRegistry.java:360)
```