### PR TITLE
Handle null values in map subscript operator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
@@ -72,6 +72,22 @@ public class MapSubscriptOperator
         }
     }
 
+    public static void longvoidSubscript(Type keyType, Type valueType, Slice map, long key)
+    {
+    }
+
+    public static void SlicevoidSubscript(Type keyType, Type valueType, Slice map, Slice key)
+    {
+    }
+
+    public static void booleanvoidSubscript(Type keyType, Type valueType, Slice map, boolean key)
+    {
+    }
+
+    public static void doublevoidSubscript(Type keyType, Type valueType, Slice map, double key)
+    {
+    }
+
     public static Long SlicelongSubscript(Type keyType, Type valueType, Slice map, Slice key)
     {
         return subscript(keyType, valueType, map, key);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -167,6 +167,10 @@ public class TestMapOperators
     public void testSubscript()
             throws Exception
     {
+        assertFunction("MAP(ARRAY [1], ARRAY [null])[1]", null);
+        assertFunction("MAP(ARRAY [1.0], ARRAY [null])[1.0]", null);
+        assertFunction("MAP(ARRAY [TRUE], ARRAY [null])[TRUE]", null);
+        assertFunction("MAP(ARRAY['puppies'], ARRAY [null])['puppies']", null);
         assertInvalidFunction("MAP(ARRAY [CAST(null as bigint)], ARRAY [1])", "map key cannot be null");
         assertInvalidFunction("MAP(ARRAY [CAST(null as bigint)], ARRAY [CAST(null as bigint)])", "map key cannot be null");
         assertInvalidFunction("MAP(ARRAY [1,null], ARRAY [null,2])", "map key cannot be null");


### PR DESCRIPTION
I can create a map ``{1=null}``, but I cannot access its elements. 

**This PR is not complete yet. I created it to make it easy to reproduce the problem.** The reason it's not complete is, even though I add a ``longvoidSubscript`` method to ``MapSubscriptOperator``, I get a weird NPE (somehow the map constructor gets called with null keys, any ideas why?) 

```
presto:nyigitbasi> select MAP(ARRAY [1], ARRAY [null]);
  _col0   
----------
 {1=null} 
(1 row)

presto:nyigitbasi> select MAP(ARRAY [1], ARRAY [null])[1];
Query 20150109_064827_00004_c84kn failed: java.lang.NoSuchMethodException: com.facebook.presto.operator.scalar.MapSubscriptOperator.longvoidSubscript(io.airlift.slice.Slice, long)
java.lang.RuntimeException: java.lang.NoSuchMethodException: com.facebook.presto.operator.scalar.MapSubscriptOperator.longvoidSubscript(io.airlift.slice.Slice, long)
```
Here is the NPE:
```
java.lang.NullPointerException
	at com.facebook.presto.type.MapType.toStackRepresentation(MapType.java:65)
	at com.facebook.presto.operator.scalar.MapConstructor.createMap(MapConstructor.java:111)
```