### PR TITLE
Add MinDataSize constraints to s3 multipart upload config parameters

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -21,6 +21,7 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.airlift.units.MinDataSize;
 import io.airlift.units.MinDuration;
 
 import javax.validation.constraints.Min;
@@ -569,8 +570,8 @@ public class HiveClientConfig
         return this;
     }
 
-    // TODO: add @MinDataSize(5MB) when supported in Airlift
     @NotNull
+    @MinDataSize("16MB")
     public DataSize getS3MultipartMinFileSize()
     {
         return s3MultipartMinFileSize;
@@ -584,8 +585,8 @@ public class HiveClientConfig
         return this;
     }
 
-    // TODO: add @MinDataSize(5MB) when supported in Airlift
     @NotNull
+    @MinDataSize("5MB")
     public DataSize getS3MultipartMinPartSize()
     {
         return s3MultipartMinPartSize;


### PR DESCRIPTION
This PR sets min data size constraints for the s3 multipart upload config parameters using the default values in the AWS SDK (see [s3MultipartMinPartSize](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManagerConfiguration.java#L31) and [s3MultipartMinFileSize](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManagerConfiguration.java#L34)).