### PR TITLE
Fix The issue:PrestoDB get the wrong result with round(x, d) function #2223 

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -17,7 +17,8 @@ import com.facebook.presto.operator.Description;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.type.SqlType;
 import com.google.common.primitives.Doubles;
-
+import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.concurrent.ThreadLocalRandom;
 
 public final class MathFunctions
@@ -252,8 +253,15 @@ public final class MathFunctions
             return -round(-num, decimals);
         }
 
-        double factor = Math.pow(10, decimals);
-        return Math.floor(num * factor + 0.5) / factor;
+        double log10 = Math.log10(num);
+        int alldecimals = 0;
+        if (log10 < 0.0) {
+            alldecimals = (int) decimals;
+        }
+        else {
+            alldecimals = (int) Math.ceil(log10) + (int) decimals;
+        }
+        return new BigDecimal(num).round(new MathContext(alldecimals)).doubleValue();
     }
 
     @Description("sine")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -321,6 +321,8 @@ public class TestMathFunctions
         assertFunction("round(-3.5, 1)", -3.5);
         assertFunction("round(-3.5001, 1)", -3.5);
         assertFunction("round(-3.99, 1)", -4.0);
+        assertFunction("round(24.700000000000003, 14)", 24.7);
+        assertFunction("round(24.700000000000005, 14)", 24.70000000000001);
     }
 
     @Test


### PR DESCRIPTION
When I use the math function: round(x, d)  i found that :this funtion has a bug like the follows:
presto:default> select round(24.700000000000003,14);

_col0

24.70000000000001 
(1 row)

But the right result should be:24.7
So,I modified the Round Function using BigDecimal.