### PR TITLE
Add config for metastore filtering

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.90.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.90.rst
@@ -27,6 +27,13 @@ General Changes
 * Improve :doc:`/installation/jdbc` conformance. In particular, all unimplemented
   methods now throw ``SQLException`` rather than ``UnsupportedOperationException``.
 
+Hive Changes
+------------
+* Disable optimized metastore partition fetching for non-string partition keys.
+  This fixes an issue were Presto might silently ignore data with non-canonical
+  partition values. To enable this option, add ``hive.assume-canonical-partition-keys=true``
+  to the coordinator and worker config properties.
+
 SPI Changes
 -----------
 * Add ``getColumnTypes`` to ``RecordSink``.

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -86,6 +86,8 @@ public class HiveClientConfig
 
     private boolean optimizedReaderEnabled = true;
 
+    private boolean assumeCanonicalPartitionKeys;
+
     private DataSize orcMaxMergeDistance = new DataSize(1, MEGABYTE);
 
     public int getMaxInitialSplits()
@@ -623,6 +625,18 @@ public class HiveClientConfig
     public HiveClientConfig setOrcMaxMergeDistance(DataSize orcMaxMergeDistance)
     {
         this.orcMaxMergeDistance = orcMaxMergeDistance;
+        return this;
+    }
+
+    public boolean isAssumeCanonicalPartitionKeys()
+    {
+        return assumeCanonicalPartitionKeys;
+    }
+
+    @Config("hive.assume-canonical-partition-keys")
+    public HiveClientConfig setAssumeCanonicalPartitionKeys(boolean assumeCanonicalPartitionKeys)
+    {
+        this.assumeCanonicalPartitionKeys = assumeCanonicalPartitionKeys;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
@@ -185,6 +185,9 @@ public class OrcPageSourceFactory
             }
             catch (IOException ignored) {
             }
+            if (e instanceof PrestoException) {
+                throw (PrestoException) e;
+            }
             String message = splitError(e, path, start, length);
             if (e.getClass().getSimpleName().equals("BlockMissingException")) {
                 throw new PrestoException(HIVE_MISSING_DATA, message, e);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -77,6 +77,7 @@ public class TestHiveClientConfig
                 .setS3MaxConnections(500)
                 .setS3StagingDirectory(new File(StandardSystemProperty.JAVA_IO_TMPDIR.value()))
                 .setOptimizedReaderEnabled(true)
+                .setAssumeCanonicalPartitionKeys(false)
                 .setOrcMaxMergeDistance(new DataSize(1, Unit.MEGABYTE)));
     }
 
@@ -108,6 +109,7 @@ public class TestHiveClientConfig
                 .put("hive.max-initial-split-size", "16MB")
                 .put("hive.storage-format", "SEQUENCEFILE")
                 .put("hive.force-local-scheduling", "true")
+                .put("hive.assume-canonical-partition-keys", "true")
                 .put("dfs.domain-socket-path", "/foo")
                 .put("hive.s3.aws-access-key", "abc123")
                 .put("hive.s3.aws-secret-key", "secret")
@@ -166,6 +168,7 @@ public class TestHiveClientConfig
                 .setS3MaxConnections(77)
                 .setS3StagingDirectory(new File("/s3-staging"))
                 .setOptimizedReaderEnabled(false)
+                .setAssumeCanonicalPartitionKeys(true)
                 .setOrcMaxMergeDistance(new DataSize(22, Unit.KILOBYTE));
 
         ConfigAssertions.assertFullMapping(properties, expected);

--- a/presto-hive/src/test/sql/create-test.sql
+++ b/presto-hive/src/test/sql/create-test.sql
@@ -106,6 +106,14 @@ STORED AS TEXTFILE
 TBLPROPERTIES ('RETENTION'='-1')
 ;
 
+CREATE TABLE presto_test_partition_schema_change_non_canonical (
+  t_data STRING
+)
+COMMENT 'Presto test non-canonical boolean partition table'
+PARTITIONED BY (t_boolean BOOLEAN)
+TBLPROPERTIES ('RETENTION'='-1')
+;
+
 CREATE VIEW presto_test_view
 COMMENT 'Presto test view'
 TBLPROPERTIES ('RETENTION'='-1')
@@ -221,3 +229,6 @@ ALTER TABLE presto_test_partition_schema_change ADD PARTITION (ds='2012-12-29');
 INSERT OVERWRITE TABLE presto_test_partition_schema_change PARTITION (ds='2012-12-29')
 SELECT '123', '456' FROM presto_test_sequence;
 ALTER TABLE presto_test_partition_schema_change REPLACE COLUMNS (t_data BIGINT);
+
+INSERT OVERWRITE TABLE presto_test_partition_schema_change_non_canonical PARTITION (t_boolean='0')
+SELECT 'test' FROM presto_test_sequence LIMIT 100;

--- a/presto-hive/src/test/sql/drop-test.sql
+++ b/presto-hive/src/test/sql/drop-test.sql
@@ -20,6 +20,7 @@ DROP TABLE IF EXISTS presto_test_bucketed_by_bigint_boolean;
 DROP TABLE IF EXISTS presto_test_bucketed_by_double_float;
 
 DROP TABLE IF EXISTS presto_test_partition_schema_change;
+DROP TABLE IF EXISTS presto_test_partition_schema_change_non_canonical;
 
 DROP VIEW IF EXISTS presto_test_view;
 


### PR DESCRIPTION
The metastore does not enforce canonical representation of values. For
example, a boolean column may represent the false value as "0", "false",
"False" or possibly other representations as well. This adds a config
flag "hive.assume-canonical-partition-keys" which can be set to true, if
all partition values are known to use the canonical (Java)
representation. Doing so may provide a performance increase for tables
with a large number of partitions that have non-string partition keys.