### PR TITLE
Fix v0.88 release notes

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.88.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.88.rst
@@ -16,4 +16,3 @@ General Changes
 * Fix an issue that could cause queries using :func:`row_number()` and ``LIMIT`` to never terminate.
 * Fix an issue that could cause queries with :func:`row_number()` and specific filters to produce incorrect results.
 * Fixed an issue that caused the Cassandra plugin to fail to load with a SecurityException.
-* Fix a NullPointerException when accessing S3 data.


### PR DESCRIPTION
After talking to @nileema we found out that in 0.88 release notes the change ``Fix a NullPointerException when accessing S3 data`` is not something released in 0.88. In fact, it is a quite old change, see https://github.com/facebook/presto/commit/cf0b2d6. This PR removes that item from the release notes to avoid confusion.