### PR TITLE
Clear LazyBlockLoader reference after block load

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyFixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyFixedWidthBlock.java
@@ -24,7 +24,7 @@ public class LazyFixedWidthBlock
         extends AbstractFixedWidthBlock
 {
     private final int positionCount;
-    private final LazyBlockLoader<LazyFixedWidthBlock> loader;
+    private LazyBlockLoader<LazyFixedWidthBlock> loader;
     private Slice slice;
     private boolean[] valueIsNull;
 
@@ -102,6 +102,9 @@ public class LazyFixedWidthBlock
         if (slice == null) {
             throw new IllegalArgumentException("Lazy block loader did not load this block");
         }
+
+        // clear reference to loader to free resources, since load was successful
+        loader = null;
     }
 
     public void setRawSlice(Slice slice)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazySliceArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazySliceArrayBlock.java
@@ -25,7 +25,7 @@ public class LazySliceArrayBlock
         extends AbstractVariableWidthBlock
 {
     private final int positionCount;
-    private final LazyBlockLoader<LazySliceArrayBlock> loader;
+    private LazyBlockLoader<LazySliceArrayBlock> loader;
     private Slice[] values;
     private final AtomicInteger sizeInBytes = new AtomicInteger(-1);
 
@@ -124,6 +124,9 @@ public class LazySliceArrayBlock
         if (values == null) {
             throw new IllegalArgumentException("Lazy block loader did not load this block");
         }
+
+        // clear reference to loader to free resources, since load was successful
+        loader = null;
     }
 
     @Override


### PR DESCRIPTION
LazyBlockLoaders for ORC retains large memory allocations, which
are not needed once the block is fully loaded.