### PR TITLE
Fix type parameter binding for unknown type

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFunctions.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.type.SqlType;
 import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 
 import javax.annotation.Nullable;
 
@@ -23,6 +24,13 @@ public final class ArrayFunctions
 {
     private ArrayFunctions()
     {
+    }
+
+    @ScalarFunction(hidden = true)
+    @SqlType("array<unknown>")
+    public static Slice arrayConstructor()
+    {
+        return Slices.utf8Slice("[]");
     }
 
     @Nullable

--- a/presto-main/src/main/java/com/facebook/presto/type/UnknownType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/UnknownType.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.AbstractFixedWidthType;
 
 import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
+import static com.google.common.base.Preconditions.checkArgument;
 
 public final class UnknownType
         extends AbstractFixedWidthType
@@ -32,10 +33,48 @@ public final class UnknownType
     }
 
     @Override
+    public boolean isComparable()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isOrderable()
+    {
+        return true;
+    }
+
+    @Override
+    public int hash(Block block, int position)
+    {
+        // Check that the position is valid
+        checkArgument(block.isNull(position), "Expected NULL value for UnknownType");
+        return 0;
+    }
+
+    @Override
+    public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        // Check that the position is valid
+        checkArgument(leftBlock.isNull(leftPosition), "Expected NULL value for UnknownType");
+        checkArgument(rightBlock.isNull(rightPosition), "Expected NULL value for UnknownType");
+        return true;
+    }
+
+    @Override
+    public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        // Check that the position is valid
+        checkArgument(leftBlock.isNull(leftPosition), "Expected NULL value for UnknownType");
+        checkArgument(rightBlock.isNull(rightPosition), "Expected NULL value for UnknownType");
+        return 0;
+    }
+
+    @Override
     public Object getObjectValue(ConnectorSession session, Block block, int position)
     {
         // call is null in case position is out of bounds
-        block.isNull(position);
+        checkArgument(block.isNull(position), "Expected NULL value for UnknownType");
         return null;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -102,7 +102,7 @@ public class TestAnalyzer
     public void testNonComparableWindowPartition()
             throws Exception
     {
-        assertFails(TYPE_MISMATCH, "SELECT row_number() OVER (PARTITION BY t.x) FROM (VALUES(null)) AS t(x)");
+        assertFails(TYPE_MISMATCH, "SELECT row_number() OVER (PARTITION BY t.x) FROM (VALUES(CAST (NULL AS HyperLogLog))) AS t(x)");
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/AbstractTestType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/AbstractTestType.java
@@ -173,7 +173,7 @@ public abstract class AbstractTestType
         verifyInvalidPositionHandling(block);
 
         if (block.isNull(position)) {
-            if (type.isOrderable()) {
+            if (type.isOrderable() && type.getJavaType() != void.class) {
                 Block nonNullValue = toBlock(getNonNullValue());
                 assertTrue(ASC_NULLS_FIRST.compareBlockValue(type, block, position, nonNullValue, 0) < 0);
                 assertTrue(ASC_NULLS_LAST.compareBlockValue(type, block, position, nonNullValue, 0) > 0);
@@ -288,7 +288,7 @@ public abstract class AbstractTestType
         catch (RuntimeException expected) {
         }
 
-        if (type.isComparable()) {
+        if (type.isComparable() && type.getJavaType() != void.class) {
             Block other = toBlock(getNonNullValue());
             try {
                 type.equalTo(block, -1, other, 0);
@@ -304,7 +304,7 @@ public abstract class AbstractTestType
             }
         }
 
-        if (type.isOrderable()) {
+        if (type.isOrderable() && type.getJavaType() != void.class) {
             Block other = toBlock(getNonNullValue());
             try {
                 ASC_NULLS_FIRST.compareBlockValue(type, block, -1, other, 0);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -273,7 +273,7 @@ public class TestArrayOperators
         assertFunction("ARRAY_SORT(ARRAY [ARRAY [1], ARRAY [2]])", ImmutableList.of(ImmutableList.of(1L), ImmutableList.of(2L)));
 
         try {
-            assertFunction("ARRAY_SORT(ARRAY[NULL, NULL, NULL])", null);
+            assertFunction("ARRAY_SORT(ARRAY[color('red'), color('blue')])", null);
             fail("ARRAY_SORT is not supported for arrays with incomparable elements");
         }
         catch (RuntimeException e) {


### PR DESCRIPTION
Fix case were type parameters could remain unbound during function
resolution, if the argument type was the unknown type