### PR TITLE
Improve Error Message, including Comparable, Orderable Info

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -366,7 +366,10 @@ public class FunctionRegistry
 
         List<String> expectedParameters = new ArrayList<>();
         for (ParametricFunction function : candidates) {
-            expectedParameters.add(format("%s(%s)", name, Joiner.on(", ").join(function.getSignature().getArgumentTypes())));
+            expectedParameters.add(format("%s(%s) %s",
+                                    name,
+                                    Joiner.on(", ").join(function.getSignature().getArgumentTypes()),
+                                    Joiner.on(", ").join(function.getSignature().getTypeParameters())));
         }
         String parameters = Joiner.on(", ").join(parameterTypes);
         String message = format("Function %s not registered", name);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3460,6 +3460,12 @@ public abstract class AbstractTestQueries
         computeActual("SELECT length(1)");
     }
 
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "\\QUnexpected parameters (color) for function greatest. Expected: greatest(E) E:orderable\\E.*")
+    public void testFunctionArgumentTypeConstraint()
+    {
+        computeActual("SELECT greatest(rgb(255, 0, 0))");
+    }
+
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "\\QOperator NOT_EQUAL(bigint, varchar) not registered\\E")
     public void testTypeMismatch()
     {


### PR DESCRIPTION
Add typeParameter info(Comparable, Orderable) into error message
Fix https://github.com/facebook/presto/issues/2181
