### PR TITLE
Remove duplicate License header in HiveRecordSink

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveRecordSink.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveRecordSink.java
@@ -11,20 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.facebook.presto.hive;
 
 import com.facebook.presto.spi.ConnectorSession;


### PR DESCRIPTION
Remove duplicate License header in HiveRecordSink.