### PR TITLE
Reassign shards that do not belong to any active node

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
@@ -198,4 +198,7 @@ public interface MetadataDao
             @Bind("catalogName") String catalogName,
             @Bind("schemaName") String schemaName,
             @Bind("tableName") String tableName);
+
+    @SqlQuery("SELECT table_id FROM tables\n")
+    List<Long> getAllTableIds();
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ReassignerNode.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ReassignerNode.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.metadata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.units.Duration;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ReassignerNode
+{
+    private final String nodeIdentifier;
+    private final long millisSinceLastUpdate;
+
+    public ReassignerNode(String nodeIdentifier, long millisSinceLastUpdate)
+    {
+        this.nodeIdentifier = checkNotNull(nodeIdentifier, "nodeIdentifier is null");
+        checkArgument(millisSinceLastUpdate >= 0, "millisSinceLastUpdate must be >= 0");
+        this.millisSinceLastUpdate = millisSinceLastUpdate;
+    }
+
+    @JsonProperty
+    public String getNodeIdentifier()
+    {
+        return nodeIdentifier;
+    }
+
+    @JsonProperty
+    public long getMillisSinceLastUpdate()
+    {
+        return millisSinceLastUpdate;
+    }
+
+    public Duration getDurationSinceLastUpdate()
+    {
+        return new Duration(millisSinceLastUpdate, TimeUnit.MILLISECONDS);
+    }
+
+    public static class Mapper
+            implements ResultSetMapper<ReassignerNode>
+    {
+        @Override
+        public ReassignerNode map(int index, ResultSet r, StatementContext ctx)
+                throws SQLException
+        {
+            return new ReassignerNode(
+                    r.getString("node_identifier"),
+                    r.getLong("millis_since_last_update"));
+        }
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.raptor.metadata;
 
+import io.airlift.units.Duration;
+
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -43,4 +45,10 @@ public interface ShardManager
      * Assign a shard to a node.
      */
     void assignShard(UUID shardUuid, String nodeIdentifier);
+
+    /**
+     * Check if nodeIdentifier is the shard reassigner and update it if the existing one has gone stale
+     * @return true if nodeIdentifier is the shard reassigner, false otherwise
+     */
+    boolean compareAndUpdateShardReassigner(String nodeIdentifier, Duration interval);
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManagerDaoUtils.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManagerDaoUtils.java
@@ -48,6 +48,7 @@ public final class ShardManagerDaoUtils
         dao.createTableShardNodes();
         dao.createTableTableShards();
         dao.createTableExternalBatches();
+        dao.createShardReassigner();
     }
 
     private static void sleep(Duration duration)

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardReassigner.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardReassigner.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.storage;
+
+import com.facebook.presto.raptor.metadata.ForMetadata;
+import com.facebook.presto.raptor.metadata.MetadataDao;
+import com.facebook.presto.raptor.metadata.ShardManager;
+import com.facebook.presto.raptor.metadata.ShardNodes;
+import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import org.skife.jdbi.v2.IDBI;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Starts a reassigner on all coordinators. Only one coordinator performs reassignment.
+ * Keeps track of online nodes to identify if shards need to be reassigned
+ */
+public class ShardReassigner
+{
+    private static final Logger log = Logger.get(ShardReassigner.class);
+
+    private final ScheduledExecutorService shardReassigner = Executors.newScheduledThreadPool(1, daemonThreadsNamed("shard-reassigner"));
+    private final ScheduledExecutorService onlineNodesTracker = Executors.newScheduledThreadPool(1, daemonThreadsNamed("online-nodes-tracker"));
+
+    private final AtomicBoolean shardReassignerStarted = new AtomicBoolean();
+    private final AtomicBoolean onlineNodesTrackerStarted = new AtomicBoolean();
+
+    private final LoadingCache<String, Long> onlineNodes;
+    private final MetadataDao dao;
+
+    private final StorageService storageService;
+    private final NodeManager nodeManager;
+    private final ShardManager shardManager;
+    private final Duration shardReassignmentInterval;
+
+    @Inject
+    public ShardReassigner(@ForMetadata IDBI dbi, StorageService storageService, NodeManager nodeManager, ShardManager shardManager, StorageManagerConfig config)
+    {
+        this(dbi, storageService, nodeManager, shardManager, config.getShardReassignmentInterval());
+    }
+
+    public ShardReassigner(@ForMetadata IDBI dbi, StorageService storageService, NodeManager nodeManager, ShardManager shardManager, Duration shardReassignmentInterval)
+    {
+        this.dao = checkNotNull(dbi, "dbi is null").onDemand(MetadataDao.class);
+        this.storageService = checkNotNull(storageService, "storageService is null");
+        this.nodeManager = checkNotNull(nodeManager, "nodeManager is null");
+        this.shardManager = checkNotNull(shardManager, "shardManager is null");
+        this.shardReassignmentInterval = checkNotNull(shardReassignmentInterval, "shardReassignmentInterval is null");
+        this.onlineNodes = CacheBuilder.newBuilder()
+                .expireAfterWrite(shardReassignmentInterval.toMillis() * 10, MILLISECONDS) // evict nodes if they are not updated for a certain time
+                .build(new CacheLoader<String, Long>()
+                {
+                    @Override
+                    public Long load(String nodeIdentifier)
+                            throws Exception
+                    {
+                        return System.nanoTime();
+                    }
+                });
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        if (!storageService.isBackupAvailable() || !isCoordinator()) {
+            return;
+        }
+
+        if (onlineNodesTrackerStarted.compareAndSet(false, true)) {
+            startOnlineNodesTracker();
+        }
+
+        if (shardReassignerStarted.compareAndSet(false, true)) {
+            // start reassigner on all coordinators
+            startShardReassigner();
+        }
+    }
+
+    @PreDestroy
+    public void shutdown()
+    {
+        shardReassigner.shutdownNow();
+        onlineNodesTracker.shutdownNow();
+    }
+
+    private void startOnlineNodesTracker()
+    {
+        // Ensure we don't refresh more than once per second
+        long delay = Math.max(1000, shardReassignmentInterval.toMillis() / 10);
+        onlineNodesTracker.scheduleWithFixedDelay(this::updateOnlineNodes, 0, delay, MILLISECONDS);
+    }
+
+    private void updateOnlineNodes()
+    {
+        try {
+            nodeManager.getActiveNodes().stream().map(Node::getNodeIdentifier).forEach(onlineNodes::refresh);
+        }
+        catch (Throwable t) {
+            log.error(t, "Unexpected error in updating online nodes");
+        }
+    }
+
+    private void startShardReassigner()
+    {
+        shardReassigner.scheduleWithFixedDelay(() -> {
+            if (!isActiveReassigner()) {
+                return;
+            }
+            updateOnlineNodes();
+
+            try {
+                List<UUID> shardsToReassign = getShardsToReassign();
+                if (shardsToReassign.isEmpty()) {
+                    return;
+                }
+                Set<Node> activeDatasourceNodes = nodeManager.getActiveNodes();
+                log.info(format("Need to reassign %s shards: ", shardsToReassign.size()));
+                shardsToReassign.forEach(uuid -> reassignShard(uuid, activeDatasourceNodes));
+            }
+            catch (Throwable t) {
+                log.error(t, "Unexpected error in shard reassignment");
+            }
+        }, shardReassignmentInterval.toMillis(), shardReassignmentInterval.toMillis(), MILLISECONDS);
+    }
+
+    private List<UUID> getShardsToReassign()
+            throws ExecutionException
+    {
+        ImmutableList.Builder<UUID> shardsToReassign = ImmutableList.builder();
+        // Getting all shards can be expensive, so break it down by table
+        for (long tableId : dao.getAllTableIds()) {
+            for (ShardNodes shardNode : shardManager.getShardNodes(tableId)) {
+                if (!isAnyNodeOnline(shardNode.getNodeIdentifiers())) {
+                    shardsToReassign.add(shardNode.getShardUuid());
+                }
+            }
+        }
+        return shardsToReassign.build();
+    }
+
+    public Node reassignShard(UUID shardId)
+    {
+        return reassignShard(shardId, nodeManager.getActiveNodes());
+    }
+
+    private Node reassignShard(UUID shardId, Set<Node> activeDatasourceNodes)
+    {
+        if (activeDatasourceNodes.isEmpty()) {
+            throw new PrestoException(NO_NODES_AVAILABLE, "No nodes available to run query");
+        }
+
+        // Pick a random node and optimistically assign the shard to it.
+        // That node will restore the shard from the backup location.
+        Node node = selectRandom(activeDatasourceNodes);
+        shardManager.assignShard(shardId, node.getNodeIdentifier());
+        return node;
+    }
+
+    private boolean isCoordinator()
+    {
+        return nodeManager.getCoordinators().contains(nodeManager.getCurrentNode());
+    }
+
+    private boolean isAnyNodeOnline(Set<String> nodeIdentifiers)
+    {
+        for (String nodeId : nodeIdentifiers) {
+            Long lastUpdate = onlineNodes.getIfPresent(nodeId);
+            if (lastUpdate != null && Duration.nanosSince(lastUpdate).compareTo(shardReassignmentInterval) <= 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isActiveReassigner()
+    {
+        return shardManager.compareAndUpdateShardReassigner(nodeManager.getCurrentNode().getNodeIdentifier(), shardReassignmentInterval);
+    }
+
+    private static <T> T selectRandom(Iterable<T> elements)
+    {
+        List<T> list = ImmutableList.copyOf(elements);
+        return list.get(ThreadLocalRandom.current().nextInt(list.size()));
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
@@ -35,6 +35,7 @@ public class StorageManagerConfig
     private File backupDirectory;
     private Duration shardRecoveryTimeout = new Duration(30, TimeUnit.SECONDS);
     private Duration missingShardDiscoveryInterval = new Duration(5, TimeUnit.MINUTES);
+    private Duration shardReassignmentInterval = new Duration(10, TimeUnit.MINUTES);
     private DataSize orcMaxMergeDistance = new DataSize(1, MEGABYTE);
     private int recoveryThreads = 10;
     private long rowsPerShard = 1_000_000;
@@ -104,6 +105,19 @@ public class StorageManagerConfig
     public StorageManagerConfig setMissingShardDiscoveryInterval(Duration missingShardDiscoveryInterval)
     {
         this.missingShardDiscoveryInterval = missingShardDiscoveryInterval;
+        return this;
+    }
+
+    public Duration getShardReassignmentInterval()
+    {
+        return shardReassignmentInterval;
+    }
+
+    @Config("storage.shard-reassignment-interval")
+    @ConfigDescription("How often to check if all shards have an active node assignment")
+    public StorageManagerConfig setShardReassignmentInterval(Duration shardReassignmentInterval)
+    {
+        this.shardReassignmentInterval = shardReassignmentInterval;
         return this;
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageModule.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageModule.java
@@ -32,5 +32,6 @@ public class StorageModule
         binder.bind(StorageService.class).to(FileStorageService.class).in(Scopes.SINGLETON);
         binder.bind(ShardManager.class).to(DatabaseShardManager.class).in(Scopes.SINGLETON);
         binder.bind(ShardRecoveryManager.class).in(Scopes.SINGLETON);
+        binder.bind(ShardReassigner.class).in(Scopes.SINGLETON);
     }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardReassigner.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardReassigner.java
@@ -1,0 +1,65 @@
+package com.facebook.presto.raptor.storage;
+
+import com.facebook.presto.metadata.InMemoryNodeManager;
+import com.facebook.presto.raptor.metadata.DatabaseShardManager;
+import com.facebook.presto.raptor.metadata.ShardManager;
+import com.facebook.presto.raptor.metadata.ShardManagerDao;
+import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.NodeManager;
+import io.airlift.units.Duration;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.IDBI;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.io.Files.createTempDir;
+import static org.testng.Assert.assertTrue;
+
+public class TestShardReassigner
+{
+    private ShardReassigner reassigner;
+    private NodeManager nodeManager;
+    private Handle handle;
+
+    @BeforeMethod
+    public void setup()
+            throws Exception
+    {
+        File temporary = createTempDir();
+        File directory = new File(temporary, "data");
+        File backupDirectory = new File(temporary, "backup");
+        StorageService storageService = new FileStorageService(directory, Optional.of(backupDirectory));
+        storageService.start();
+
+        IDBI dbi = new DBI("jdbc:h2:mem:test" + System.nanoTime());
+        handle = dbi.open();
+        ShardManager shardManager = new DatabaseShardManager(dbi);
+        nodeManager = new InMemoryNodeManager();
+        reassigner = new ShardReassigner(dbi, storageService, nodeManager, shardManager, new Duration(5, TimeUnit.MINUTES));
+    }
+
+    @AfterMethod
+    public void tearDown()
+            throws Exception
+    {
+        handle.close();
+    }
+
+    @Test
+    public void testReassignment()
+            throws Exception
+    {
+        UUID uuid = UUID.randomUUID();
+        ShardManagerDao dao = handle.attach(ShardManagerDao.class);
+        dao.insertShard(uuid);
+        Node node = reassigner.reassignShard(uuid);
+        assertTrue(nodeManager.getActiveNodes().contains(node));
+    }
+}


### PR DESCRIPTION
Pick one of the coordinators as the active reassigner. This coordinator will be responsible for tracking the online nodes and identifying which shards need to be reassigned to a different node (so that the shard is recovered from backup on the newly reassigned node). This check is performed at a fixed interval. A node is considered online if it shows up in active nodes at least once in this interval.