### PR TITLE
Allow COORDINATOR ONLY plan fragment to remain for the source

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -234,8 +234,8 @@ public class PlanFragmenter
         public FragmentProperties setSourceDistribution(PlanNodeId source)
         {
             if (distribution.isPresent()) {
-                // If already SINGLE, leave it as is (this is for single-node execution)
-                checkState(distribution.get() == PlanDistribution.SINGLE,
+                // If already SINGLE or COORDINATOR_ONLY, leave it as is (this is for single-node execution)
+                checkState(distribution.get() == PlanDistribution.SINGLE || distribution.get() == PlanDistribution.COORDINATOR_ONLY,
                         "Cannot overwrite distribution with %s (currently set to %s)",
                         PlanDistribution.SOURCE,
                         distribution.get());


### PR DESCRIPTION
This occurs when the LocalQueryRunner executes a query with a TableCommit.