### PR TITLE
Remove incorrect check when expiring queries

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -329,11 +329,7 @@ public class SqlQueryManager
             QueryId queryId = queryInfo.getQueryId();
 
             log.debug("Remove query %s", queryId);
-            QueryExecution query = queries.remove(queryId);
-            if (query != null) {
-                log.error("Query %s is %s, but still has a QueryExecution registered", queryId, queryInfo.getState());
-                query.fail(new AbandonedException("Query " + queryId, queryInfo.getQueryStats().getLastHeartbeat(), DateTime.now()));
-            }
+            queries.remove(queryId);
             expirationQueue.remove();
         }
     }


### PR DESCRIPTION
A query that's in the expiration queue will necessarily have an associated
query execution, so checking whether queries.remove() returns non-null and
logging an error is incorrect.