### PR TITLE
Add an interface to rollback CREATE TABLE and INSERT INTO

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -135,6 +135,11 @@ public interface Metadata
     void commitCreateTable(OutputTableHandle tableHandle, Collection<Slice> fragments);
 
     /**
+     * Rollback a table creation
+     */
+    void rollbackCreateTable(OutputTableHandle tableHandle);
+
+    /**
      * Begin insert query
      */
     InsertTableHandle beginInsert(Session session, TableHandle tableHandle);
@@ -143,6 +148,11 @@ public interface Metadata
      * Commit insert query
      */
     void commitInsert(InsertTableHandle tableHandle, Collection<Slice> fragments);
+
+    /**
+     * Rollback insert query
+     */
+    void rollbackInsert(InsertTableHandle tableHandle);
 
     /**
      * Gets all the loaded catalogs

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -357,6 +357,12 @@ public class MetadataManager
     }
 
     @Override
+    public void rollbackCreateTable(OutputTableHandle tableHandle)
+    {
+        lookupConnectorFor(tableHandle).rollbackCreateTable(tableHandle.getConnectorHandle());
+    }
+
+    @Override
     public InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
     {
         // assume connectorId and catalog are the same
@@ -369,6 +375,12 @@ public class MetadataManager
     public void commitInsert(InsertTableHandle tableHandle, Collection<Slice> fragments)
     {
         lookupConnectorFor(tableHandle).commitInsert(tableHandle.getConnectorHandle(), fragments);
+    }
+
+    @Override
+    public void rollbackInsert(InsertTableHandle tableHandle)
+    {
+        lookupConnectorFor(tableHandle).rollbackInsert(tableHandle.getConnectorHandle());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -1521,6 +1521,20 @@ public class LocalExecutionPlanner
                     throw new AssertionError("Unhandled target type: " + target.getClass().getName());
                 }
             }
+
+            @Override
+            public void rollbackTable()
+            {
+                if (target instanceof CreateHandle) {
+                    metadata.rollbackCreateTable(((CreateHandle) target).getHandle());
+                }
+                else if (target instanceof InsertHandle) {
+                    metadata.rollbackInsert(((InsertHandle) target).getHandle());
+                }
+                else {
+                    throw new AssertionError("Unhandled target type: " + target.getClass().getName());
+                }
+            }
         };
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorMetadata.java
@@ -102,6 +102,13 @@ public interface ConnectorMetadata
     void commitCreateTable(ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments);
 
     /**
+     * Rollback a table creation
+     */
+    default void rollbackCreateTable(ConnectorOutputTableHandle tableHandle)
+    {
+    }
+
+    /**
      * Begin insert query
      */
     ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle);
@@ -110,6 +117,13 @@ public interface ConnectorMetadata
      * Commit insert query
      */
     void commitInsert(ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments);
+
+    /**
+     * Rollback insert query
+     */
+    default void rollbackInsert(ConnectorInsertTableHandle insertHandle)
+    {
+    }
 
     /**
      * Create the specified view. The data for the view is opaque to the connector.


### PR DESCRIPTION
Even though Presto now supports `rollback` at `ConnectorPageSink`, there're sill no proper interface to release resources created at `beginCreateTable` or `beginInsert` when `CREATE TABLE tbl AS` and `INSERT INTO` fails.

I know Presto will support transactions at connector API sometime. Until transactions are not fully supported, this could be proper  interim solution to cleanup resources.