### PR TITLE
Update Hive CDH 4 plugin to CDH 4.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
             <dependency>
                 <groupId>com.facebook.presto.hadoop</groupId>
                 <artifactId>hadoop-cdh4</artifactId>
-                <version>0.6</version>
+                <version>0.7</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This fixes the socket leak in DFSClient (HDFS-5671).