### PR TITLE
Added Support For EC2 Roles When using AWS

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -36,11 +36,13 @@ import com.amazonaws.services.s3.transfer.Transfer;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerConfiguration;
 import com.amazonaws.services.s3.transfer.Upload;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractSequentialIterator;
 import com.google.common.collect.Iterators;
 import com.google.common.primitives.Ints;
+import com.google.common.base.Strings;
 import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -142,7 +144,13 @@ public class PrestoS3FileSystem
         configuration.setSocketTimeout(Ints.checkedCast(socketTimeout.toMillis()));
         configuration.setMaxConnections(maxConnections);
 
+        //Prepare Credentials
+        if (Strings.isNullOrEmpty(conf.get("fs.s3n.awsAccessKeyId")) ||  Strings.isNullOrEmpty(conf.get("fs.s3n.awsSecretAccessKey"))) {
+        this.s3 = new AmazonS3Client(new InstanceProfileCredentialsProvider(), configuration);
+        }
+        else {
         this.s3 = new AmazonS3Client(getAwsCredentials(uri, conf), configuration);
+        }
 
         transferConfig.setMultipartUploadThreshold(minFileSize);
         transferConfig.setMinimumUploadPartSize(minPartSize);


### PR DESCRIPTION
AWS EC2 Instances launched with IAM Roles provide AWS Credentials through the InstanceCredentialProvider.

This change determines whether the credentials are defined in the XML and if not use the InstanceProfileCredentials.