### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ before_install: free -m
 script: mvn test -P travis -Dair.check.skip-dependency=true
 env:
   global:
-    - MAVEN_OPTS="-Xmx256m"
+    - MAVEN_OPTS="-Xmx512m"

--- a/pom.xml
+++ b/pom.xml
@@ -923,7 +923,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration combine.children="append">
-                            <argLine>${argLine} -Duser.timezone=${test.timezone} -Xmx1280m -Xms1280m</argLine>
+                            <argLine>${argLine} -Duser.timezone=${test.timezone} -Xmx2g -Xms2g</argLine>
                             <parallel />
                             <threadCount>1</threadCount>
                         </configuration>


### PR DESCRIPTION
Travis build was broken because it was using too low Java heap size.
Delete travis profile and use default build profile to fix that.