### PR TITLE
Make SqlTask heartbeat update explicit

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -187,7 +187,9 @@ public class SqlTaskManager
     {
         checkNotNull(taskId, "taskId is null");
 
-        return tasks.getUnchecked(taskId).getTaskInfo();
+        SqlTask sqlTask = tasks.getUnchecked(taskId);
+        sqlTask.recordHeartbeat();
+        return sqlTask.getTaskInfo();
     }
 
     @Override
@@ -196,7 +198,9 @@ public class SqlTaskManager
         checkNotNull(taskId, "taskId is null");
         checkNotNull(currentState, "currentState is null");
 
-        return tasks.getUnchecked(taskId).getTaskInfo(currentState);
+        SqlTask sqlTask = tasks.getUnchecked(taskId);
+        sqlTask.recordHeartbeat();
+        return sqlTask.getTaskInfo(currentState);
     }
 
     @Override
@@ -208,7 +212,9 @@ public class SqlTaskManager
         checkNotNull(sources, "sources is null");
         checkNotNull(outputBuffers, "outputBuffers is null");
 
-        return tasks.getUnchecked(taskId).updateTask(session, fragment, sources, outputBuffers);
+        SqlTask sqlTask = tasks.getUnchecked(taskId);
+        sqlTask.recordHeartbeat();
+        return sqlTask.updateTask(session, fragment, sources, outputBuffers);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -39,7 +39,7 @@ public class TaskManagerConfig
 
     private DataSize sinkMaxBufferSize = new DataSize(32, Unit.MEGABYTE);
 
-    private Duration clientTimeout = new Duration(5, TimeUnit.MINUTES);
+    private Duration clientTimeout = new Duration(2, TimeUnit.MINUTES);
     private Duration infoMaxAge = new Duration(15, TimeUnit.MINUTES);
     private int writerCount = 1;
     private int httpNotificationThreads = 25;

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -37,7 +37,7 @@ public class TestTaskManagerConfig
                 .setMaxShardProcessorThreads(Runtime.getRuntime().availableProcessors() * 4)
                 .setMinDrivers(Runtime.getRuntime().availableProcessors() * 4 * 2)
                 .setInfoMaxAge(new Duration(15, TimeUnit.MINUTES))
-                .setClientTimeout(new Duration(5, TimeUnit.MINUTES))
+                .setClientTimeout(new Duration(2, TimeUnit.MINUTES))
                 .setMaxTaskMemoryUsage(new DataSize(256, Unit.MEGABYTE))
                 .setBigQueryMaxTaskMemoryUsage(null)
                 .setMaxTaskIndexMemoryUsage(new DataSize(64, Unit.MEGABYTE))


### PR DESCRIPTION
SqlTask implicitly updates the heartbeat when getting TaskInfo.  Since the TaskInfo is fetched while checking for abandoned tasks, the tasks can never be abandoned.