### PR TITLE
Lower Hive metadata refresh interval

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.96.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.96.rst
@@ -6,3 +6,4 @@ Hive Changes
 ------------
 
 * Add support for tables partitioned by ``DATE``.
+* Lower the Hive metadata refresh interval from 2 min to 1 sec.

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -55,7 +55,7 @@ public class HiveClientConfig
     private boolean allowCorruptWritesForTesting;
 
     private Duration metastoreCacheTtl = new Duration(1, TimeUnit.HOURS);
-    private Duration metastoreRefreshInterval = new Duration(2, TimeUnit.MINUTES);
+    private Duration metastoreRefreshInterval = new Duration(1, TimeUnit.SECONDS);
     private int maxMetastoreRefreshThreads = 100;
     private HostAndPort metastoreSocksProxy;
     private Duration metastoreTimeout = new Duration(10, TimeUnit.SECONDS);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -406,8 +406,6 @@ public class CachingHiveMetastore
                         try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.create_table(table);
                         }
-                        tableNamesCache.invalidate(table.getDbName());
-                        viewNamesCache.invalidate(table.getDbName());
                         return null;
                     }));
         }
@@ -426,6 +424,10 @@ public class CachingHiveMetastore
             }
             throw Throwables.propagate(e);
         }
+        finally {
+            tableNamesCache.invalidate(table.getDbName());
+            viewNamesCache.invalidate(table.getDbName());
+        }
     }
 
     @Override
@@ -439,9 +441,6 @@ public class CachingHiveMetastore
                         try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
                             client.drop_table(databaseName, tableName, true);
                         }
-                        tableCache.invalidate(new HiveTableName(databaseName, tableName));
-                        tableNamesCache.invalidate(databaseName);
-                        viewNamesCache.invalidate(databaseName);
                         return null;
                     }));
         }
@@ -456,6 +455,11 @@ public class CachingHiveMetastore
                 Thread.currentThread().interrupt();
             }
             throw Throwables.propagate(e);
+        }
+        finally {
+            tableCache.invalidate(new HiveTableName(databaseName, tableName));
+            tableNamesCache.invalidate(databaseName);
+            viewNamesCache.invalidate(databaseName);
         }
     }
 
@@ -473,9 +477,6 @@ public class CachingHiveMetastore
                             table.setTableName(newTableName);
                             client.alter_table(databaseName, tableName, table);
                         }
-                        tableCache.invalidate(new HiveTableName(databaseName, tableName));
-                        tableNamesCache.invalidate(databaseName);
-                        viewNamesCache.invalidate(databaseName);
                         return null;
                     }));
         }
@@ -490,6 +491,11 @@ public class CachingHiveMetastore
                 Thread.currentThread().interrupt();
             }
             throw Throwables.propagate(e);
+        }
+        finally {
+            tableCache.invalidate(new HiveTableName(databaseName, tableName));
+            tableNamesCache.invalidate(databaseName);
+            viewNamesCache.invalidate(databaseName);
         }
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -47,7 +47,7 @@ public class TestHiveClientConfig
                 .setAllowRenameTable(false)
                 .setAllowCorruptWritesForTesting(false)
                 .setMetastoreCacheTtl(new Duration(1, TimeUnit.HOURS))
-                .setMetastoreRefreshInterval(new Duration(2, TimeUnit.MINUTES))
+                .setMetastoreRefreshInterval(new Duration(1, TimeUnit.SECONDS))
                 .setMaxMetastoreRefreshThreads(100)
                 .setMetastoreSocksProxy(null)
                 .setMetastoreTimeout(new Duration(10, TimeUnit.SECONDS))


### PR DESCRIPTION
1) Lower Hive metadata refresh interval from 2 min to 1 sec
2) Invalidate Hive metadata cache for failed operations by moving the invalidation calls to the "finally" block