### PR TITLE
Presto main module minor fixes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/MapUnnester.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MapUnnester.java
@@ -57,13 +57,13 @@ public class MapUnnester
         try {
             String value = jsonParser.getCurrentName();
             if (keyType.getJavaType() == long.class) {
-                keyType.writeLong(keyBlockBuilder, Long.valueOf(value));
+                keyType.writeLong(keyBlockBuilder, Long.parseLong(value));
             }
             else if (keyType.getJavaType() == double.class) {
-                keyType.writeDouble(keyBlockBuilder, Double.valueOf(value));
+                keyType.writeDouble(keyBlockBuilder, Double.parseDouble(value));
             }
             else if (keyType.getJavaType() == boolean.class) {
-                keyType.writeBoolean(keyBlockBuilder, Boolean.valueOf(value));
+                keyType.writeBoolean(keyBlockBuilder, Boolean.parseBoolean(value));
             }
             else if (keyType.getJavaType() == Slice.class) {
                 Slice slice;

--- a/presto-main/src/main/java/com/facebook/presto/operator/MarkDistinctOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MarkDistinctOperator.java
@@ -86,7 +86,6 @@ public class MarkDistinctOperator
         this.operatorContext = checkNotNull(operatorContext, "operatorContext is null");
 
         this.types = ImmutableList.copyOf(checkNotNull(types, "types is null"));
-        checkArgument(markDistinctChannels.length >= 0, "markDistinctChannels is empty");
         checkNotNull(hashChannel, "hashChannel is null");
 
         ImmutableList.Builder<Type> distinctTypes = ImmutableList.builder();

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTask.java
@@ -481,6 +481,11 @@ public class HttpRemoteTask
             // mark task as canceled (if not already done)
             TaskInfo taskInfo = getTaskInfo();
             URI uri = taskInfo.getSelf();
+
+            if (uri == null) {
+                return;
+            }
+
             updateTaskInfo(new TaskInfo(taskInfo.getTaskId(),
                     taskInfo.getNodeInstanceId(),
                     TaskInfo.MAX_VERSION,
@@ -491,10 +496,6 @@ public class HttpRemoteTask
                     taskInfo.getNoMoreSplits(),
                     taskInfo.getStats(),
                     ImmutableList.<ExecutionFailureInfo>of()));
-
-            if (uri == null) {
-                return;
-            }
 
             // send abort to task and ignore response
             final long start = System.nanoTime();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -623,7 +623,7 @@ class QueryPlanner
 
         PlanNode planNode;
         if (limit.isPresent()) {
-            planNode = new TopNNode(idAllocator.getNextId(), subPlan.getRoot(), Long.valueOf(limit.get()), orderBySymbols.build(), orderings.build(), false);
+            planNode = new TopNNode(idAllocator.getNextId(), subPlan.getRoot(), Long.parseLong(limit.get()), orderBySymbols.build(), orderings.build(), false);
         }
         else {
             planNode = new SortNode(idAllocator.getNextId(), subPlan.getRoot(), orderBySymbols.build(), orderings.build());
@@ -645,7 +645,7 @@ class QueryPlanner
     private PlanBuilder limit(PlanBuilder subPlan, List<SortItem> orderBy, Optional<String> limit)
     {
         if (orderBy.isEmpty() && limit.isPresent()) {
-            long limitValue = Long.valueOf(limit.get());
+            long limitValue = Long.parseLong(limit.get());
             return new PlanBuilder(subPlan.getTranslations(), new LimitNode(idAllocator.getNextId(), subPlan.getRoot(), limitValue), subPlan.getSampleWeight());
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeJsonUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeJsonUtils.java
@@ -133,13 +133,13 @@ public final class TypeJsonUtils
     {
         BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus());
         if (type.getJavaType() == boolean.class) {
-            type.writeBoolean(blockBuilder, Boolean.valueOf(jsonKey));
+            type.writeBoolean(blockBuilder, Boolean.parseBoolean(jsonKey));
         }
         else if (type.getJavaType() == long.class) {
-            type.writeLong(blockBuilder, Long.valueOf(jsonKey));
+            type.writeLong(blockBuilder, Long.parseLong(jsonKey));
         }
         else if (type.getJavaType() == double.class) {
-            type.writeDouble(blockBuilder, Double.valueOf(jsonKey));
+            type.writeDouble(blockBuilder, Double.parseDouble(jsonKey));
         }
         else if (type.getJavaType() == Slice.class) {
             type.writeSlice(blockBuilder, Slices.utf8Slice(jsonKey));


### PR DESCRIPTION
This PR fixes some minor issues with the ``presto-main`` module. To be specific,
- Removes some unnecessary boxing/unboxing 
- Fixes a bug where a ``uri`` field is checked against being null after it's used
- Removes an unnecessary "array length is positive" check, which is always true by the [JLS](http://docs.oracle.com/javase/specs/jls/se7/html/jls-10.html#jls-10.7). In fact a check for the same condition already exists [elsewhere](https://github.com/facebook/presto/blob/master/presto-main/src/main/java/com/facebook/presto/operator/MarkDistinctOperator.java#L47).