### PR TITLE
Improve HttpRemoteTask update loop

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTask.java
@@ -584,6 +584,7 @@ public class HttpRemoteTask
         {
             try (SetThreadName ignored = new SetThreadName("UpdateResponseHandler-%s", taskId)) {
                 try {
+                    currentRequest = null;
                     updateTaskInfo(value, sources);
                     updateErrorTracker.requestSucceeded();
                 }
@@ -598,6 +599,8 @@ public class HttpRemoteTask
         {
             try (SetThreadName ignored = new SetThreadName("UpdateResponseHandler-%s", taskId)) {
                 try {
+                    currentRequest = null;
+
                     // on failure assume we need to update again
                     needsUpdate.set(true);
 
@@ -799,7 +802,7 @@ public class HttpRemoteTask
             }
             catch (Throwable t) {
                 // this should never happen
-                callback.failed(t);
+                callback.fatal(t);
             }
         }
 


### PR DESCRIPTION
Always clear currentRequest when request is complete
Treat more errors a fatal
