### PR TITLE
When scheduling only wait for RemoteSourceNodes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -24,7 +24,6 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -198,7 +197,7 @@ public class QueryStateMachine
                 totalUserTime += stageStats.getTotalUserTime().roundTo(NANOSECONDS);
                 totalBlockedTime += stageStats.getTotalBlockedTime().roundTo(NANOSECONDS);
 
-                if (Iterables.any(stageInfo.getPlan().getSources(), Predicates.instanceOf(TableScanNode.class))) {
+                if (stageInfo.getPlan().getPartitionedSourceNode() instanceof TableScanNode) {
                     rawInputDataSize += stageStats.getRawInputDataSize().toBytes();
                     rawInputPositions += stageStats.getRawInputPositions();
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubPlan.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubPlan.java
@@ -67,9 +67,7 @@ public class SubPlan
 
     public void sanityCheck()
     {
-        Multiset<PlanFragmentId> exchangeIds = fragment.getSources().stream()
-                .filter(RemoteSourceNode.class::isInstance)
-                .map(RemoteSourceNode.class::cast)
+        Multiset<PlanFragmentId> exchangeIds = fragment.getRemoteSourceNodes().stream()
                 .map(RemoteSourceNode::getSourceFragmentIds)
                 .flatMap(List::stream)
                 .collect(toImmutableMultiset());


### PR DESCRIPTION
Several parts of the scheduler system would use PlanFragment.getSources
to find all nodes to schedule, and this method would look for all leaf nodes
which are not in a black list. This black list was error prone and is missing
ValuesNode.  This missing entry causes the scheduler to wait for ValuesNodes
to be scheduled which never happens since values nodes are not schduled.

The getSources is not really needed as all callers are searching for
RemoteSourceNodes, so there is simply a method for that now.