### PR TITLE
Make only StatementResource update `lastHeartbeat'

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
@@ -29,6 +29,8 @@ public interface QueryManager
 
     QueryInfo getQueryInfo(QueryId queryId);
 
+    void recordHeartbeat(QueryId queryId);
+
     QueryInfo createQuery(Session session, String query);
 
     void cancelQuery(QueryId queryId);

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -225,8 +225,20 @@ public class SqlQueryManager
             throw new NoSuchElementException();
         }
 
-        query.recordHeartbeat();
         return query.getQueryInfo();
+    }
+
+    @Override
+    public void recordHeartbeat(QueryId queryId)
+    {
+        checkNotNull(queryId, "queryId is null");
+
+        QueryExecution query = queries.get(queryId);
+        if (query == null) {
+            return;
+        }
+
+        query.recordHeartbeat();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
@@ -287,6 +287,7 @@ public class StatementResource
             if (lastResultPath != null && requestedPath.equals(lastResultPath)) {
                 // tell query manager we are still interested in the query
                 queryManager.getQueryInfo(queryId);
+                queryManager.recordHeartbeat(queryId);
                 return lastResult;
             }
 
@@ -311,6 +312,7 @@ public class StatementResource
             // get the query info before returning
             // force update if query manager is closed
             QueryInfo queryInfo = queryManager.getQueryInfo(queryId);
+            queryManager.recordHeartbeat(queryId);
 
             // if we have received all of the output data and the query is not marked as done, wait for the query to finish
             if (exchangeClient.isClosed() && !queryInfo.getState().isDone()) {


### PR DESCRIPTION
I found Presto's client-timeout feature didn't work. After the client library process had gone, `queryStats.lastHeartbeat` was kept updated.

I noticed that `queryStats.lastHeartbeat` was updated even when calling `/v1/query` to monitor the progress of queries (We directly call the API repeatedly to monitor queries). Also, `/v1/query` is called even by WebUI and the client-timeout feature won't work when the users keep viewing the page.

So I tried fixing this issue, but not sure if it's the best way. I welcome feedback from you, thanks.
