### PR TITLE
Select Hive reader by serde name not instance

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursorProvider.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
-import static com.facebook.presto.hive.HiveUtil.getDeserializer;
+import static com.facebook.presto.hive.HiveUtil.isDeserializerClass;
 
 public class ColumnarBinaryHiveRecordCursorProvider
         implements HiveRecordCursorProvider
@@ -47,7 +47,7 @@ public class ColumnarBinaryHiveRecordCursorProvider
             DateTimeZone hiveStorageTimeZone,
             TypeManager typeManager)
     {
-        if (!usesColumnarBinarySerDe(schema)) {
+        if (!isDeserializerClass(schema, LazyBinaryColumnarSerDe.class)) {
             return Optional.empty();
         }
 
@@ -62,11 +62,6 @@ public class ColumnarBinaryHiveRecordCursorProvider
                 hiveStorageTimeZone,
                 DateTimeZone.forID(session.getTimeZoneKey().getId()),
                 typeManager));
-    }
-
-    private static boolean usesColumnarBinarySerDe(Properties schema)
-    {
-        return getDeserializer(schema) instanceof LazyBinaryColumnarSerDe;
     }
 
     @SuppressWarnings("unchecked")

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursorProvider.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
-import static com.facebook.presto.hive.HiveUtil.getDeserializer;
+import static com.facebook.presto.hive.HiveUtil.isDeserializerClass;
 
 public class ColumnarTextHiveRecordCursorProvider
         implements HiveRecordCursorProvider
@@ -47,7 +47,7 @@ public class ColumnarTextHiveRecordCursorProvider
             DateTimeZone hiveStorageTimeZone,
             TypeManager typeManager)
     {
-        if (!usesColumnarTextSerDe(schema)) {
+        if (!isDeserializerClass(schema, ColumnarSerDe.class)) {
             return Optional.empty();
         }
 
@@ -62,11 +62,6 @@ public class ColumnarTextHiveRecordCursorProvider
                 hiveStorageTimeZone,
                 DateTimeZone.forID(session.getTimeZoneKey().getId()),
                 typeManager));
-    }
-
-    private static boolean usesColumnarTextSerDe(Properties schema)
-    {
-        return getDeserializer(schema) instanceof ColumnarSerDe;
     }
 
     @SuppressWarnings("unchecked")

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -269,11 +269,22 @@ public final class HiveUtil
         return getTableObjectInspector(getTableMetadata(table)).getAllStructFieldRefs();
     }
 
-    @SuppressWarnings("deprecation")
-    public static Deserializer getDeserializer(Properties schema)
+    public static boolean isDeserializerClass(Properties schema, Class<?> deserializerClass)
+    {
+        return getDeserializerClassName(schema).equals(deserializerClass.getName());
+    }
+
+    public static String getDeserializerClassName(Properties schema)
     {
         String name = schema.getProperty(SERIALIZATION_LIB);
         checkCondition(name != null, HIVE_INVALID_METADATA, "Table or partition is missing Hive deserializer property: %s", SERIALIZATION_LIB);
+        return name;
+    }
+
+    @SuppressWarnings("deprecation")
+    public static Deserializer getDeserializer(Properties schema)
+    {
+        String name = getDeserializerClassName(schema);
 
         Deserializer deserializer = createDeserializer(getDeserializerClass(name));
         initializeDeserializer(deserializer, schema);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ParquetRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ParquetRecordCursorProvider.java
@@ -21,14 +21,13 @@ import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
-import org.apache.hadoop.hive.serde2.Deserializer;
 import org.joda.time.DateTimeZone;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
-import static com.facebook.presto.hive.HiveUtil.getDeserializer;
+import static com.facebook.presto.hive.HiveUtil.isDeserializerClass;
 import static com.google.common.base.Predicates.not;
 import static com.google.common.collect.Iterables.filter;
 
@@ -50,9 +49,7 @@ public class ParquetRecordCursorProvider
             DateTimeZone hiveStorageTimeZone,
             TypeManager typeManager)
     {
-        @SuppressWarnings("deprecation")
-        Deserializer deserializer = getDeserializer(schema);
-        if (!(deserializer instanceof ParquetHiveSerDe)) {
+        if (!isDeserializerClass(schema, ParquetHiveSerDe.class)) {
             return Optional.empty();
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfPageSourceFactory.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.units.DataSize;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.serde2.Deserializer;
 import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
@@ -35,11 +34,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
-import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxMergeDistance;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxBufferSize;
+import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxMergeDistance;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcStreamBufferSize;
 import static com.facebook.presto.hive.HiveSessionProperties.isOptimizedReaderEnabled;
-import static com.facebook.presto.hive.HiveUtil.getDeserializer;
+import static com.facebook.presto.hive.HiveUtil.isDeserializerClass;
 import static com.facebook.presto.hive.orc.OrcPageSourceFactory.createOrcPageSource;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -90,9 +89,7 @@ public class DwrfPageSourceFactory
             return Optional.empty();
         }
 
-        @SuppressWarnings("deprecation")
-        Deserializer deserializer = getDeserializer(schema);
-        if (!(deserializer instanceof OrcSerde)) {
+        if (!isDeserializerClass(schema, OrcSerde.class)) {
             return Optional.empty();
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfRecordCursorProvider.java
@@ -32,7 +32,6 @@ import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hadoop.hive.serde2.ReaderWriterProfiler;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
@@ -48,8 +47,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
-import static com.facebook.presto.hive.HiveUtil.getDeserializer;
 import static com.facebook.presto.hive.HiveUtil.getTableObjectInspector;
+import static com.facebook.presto.hive.HiveUtil.isDeserializerClass;
 import static com.google.common.collect.Iterables.all;
 
 public class DwrfRecordCursorProvider
@@ -70,9 +69,7 @@ public class DwrfRecordCursorProvider
             DateTimeZone hiveStorageTimeZone,
             TypeManager typeManager)
     {
-        @SuppressWarnings("deprecation")
-        Deserializer deserializer = getDeserializer(schema);
-        if (!(deserializer instanceof OrcSerde)) {
+        if (!isDeserializerClass(schema, OrcSerde.class)) {
             return Optional.empty();
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
-import org.apache.hadoop.hive.serde2.Deserializer;
 import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
@@ -52,11 +51,11 @@ import java.util.Properties;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_MISSING_DATA;
-import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxMergeDistance;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxBufferSize;
+import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxMergeDistance;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcStreamBufferSize;
 import static com.facebook.presto.hive.HiveSessionProperties.isOptimizedReaderEnabled;
-import static com.facebook.presto.hive.HiveUtil.getDeserializer;
+import static com.facebook.presto.hive.HiveUtil.isDeserializerClass;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.nullToEmpty;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -109,9 +108,7 @@ public class OrcPageSourceFactory
             return Optional.empty();
         }
 
-        @SuppressWarnings("deprecation")
-        Deserializer deserializer = getDeserializer(schema);
-        if (!(deserializer instanceof OrcSerde)) {
+        if (!isDeserializerClass(schema, OrcSerde.class)) {
             return Optional.empty();
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcRecordCursorProvider.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hive.ql.io.orc.OrcProto.Type;
 import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
 import org.apache.hadoop.hive.ql.io.orc.Reader;
 import org.apache.hadoop.hive.ql.io.orc.RecordReader;
-import org.apache.hadoop.hive.serde2.Deserializer;
 import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
@@ -40,7 +39,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
-import static com.facebook.presto.hive.HiveUtil.getDeserializer;
+import static com.facebook.presto.hive.HiveUtil.isDeserializerClass;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -85,9 +84,7 @@ public class OrcRecordCursorProvider
             return Optional.empty();
         }
 
-        @SuppressWarnings("deprecation")
-        Deserializer deserializer = getDeserializer(schema);
-        if (!(deserializer instanceof OrcSerde)) {
+        if (!isDeserializerClass(schema, OrcSerde.class)) {
             return Optional.empty();
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSourceFactory.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.io.RCFile;
-import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe;
 import org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe;
 import org.joda.time.DateTimeZone;
@@ -39,7 +38,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static com.facebook.presto.hive.HiveSessionProperties.isOptimizedReaderEnabled;
-import static com.facebook.presto.hive.HiveUtil.getDeserializer;
+import static com.facebook.presto.hive.HiveUtil.getDeserializerClassName;
 import static com.facebook.presto.hive.HiveUtil.setReadColumns;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Predicates.not;
@@ -88,14 +87,13 @@ public class RcFilePageSourceFactory
             return Optional.empty();
         }
 
-        @SuppressWarnings("deprecation")
-        Deserializer deserializer = getDeserializer(schema);
+        String deserializerClassName = getDeserializerClassName(schema);
 
         RcFileBlockLoader blockLoader;
-        if (deserializer instanceof LazyBinaryColumnarSerDe) {
+        if (deserializerClassName.equals(LazyBinaryColumnarSerDe.class.getName())) {
             blockLoader = new RcBinaryBlockLoader(DateTimeZone.forID(session.getTimeZoneKey().getId()));
         }
-        else if (deserializer instanceof ColumnarSerDe) {
+        else if (deserializerClassName.equals(ColumnarSerDe.class.getName())) {
             blockLoader = new RcTextBlockLoader(hiveStorageTimeZone, DateTimeZone.forID(session.getTimeZoneKey().getId()));
         }
         else {


### PR DESCRIPTION
Instead of the expensive and error process of selecting the Hive reader by
instantiating a serde and then checking for a type, just check the class name
of the serde.

Fixes #1734