### PR TITLE
Handle ORC files with corrupt checkpoints

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/checkpoint/Checkpoints.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/checkpoint/Checkpoints.java
@@ -47,8 +47,8 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.ROW_GROUP_DICTI
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.ROW_GROUP_DICTIONARY_LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.SECONDARY;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.equalTo;
+import static java.lang.String.format;
 
 public final class Checkpoints
 {
@@ -64,6 +64,7 @@ public final class Checkpoints
             List<ColumnEncoding> columnEncodings,
             Map<StreamId, Stream> streams,
             Map<Integer, List<RowGroupIndex>> columnIndexes)
+            throws InvalidCheckpointException
     {
         ImmutableSetMultimap.Builder<Integer, StreamKind> streamKindsBuilder = ImmutableSetMultimap.builder();
         for (Stream stream : streams.values()) {
@@ -124,12 +125,13 @@ public final class Checkpoints
             // it will write checkpoints for all streams, but in other cases it will write only the streams that exist.
             // We detect this case by checking that all offsets in the initial position list are zero, and if so, we
             // clear the extra offsets
-            checkState(!columnPositionsList.hasNextPosition() || Iterables.all(positionsList, equalTo(0)),
-                    "Column %s, of type %s, contains %s offset positions, but only %s positions were consumed",
-                    column,
-                    columnType,
-                    positionsList.size(),
-                    columnPositionsList.getIndex());
+            if (columnPositionsList.hasNextPosition() && !Iterables.all(positionsList, equalTo(0))) {
+                throw new InvalidCheckpointException(format("Column %s, of type %s, contains %s offset positions, but only %s positions were consumed",
+                        column,
+                        columnType,
+                        positionsList.size(),
+                        columnPositionsList.getIndex()));
+            }
         }
         return checkpoints.build();
     }
@@ -414,9 +416,11 @@ public final class Checkpoints
 
         public int nextPosition()
         {
-            checkState(hasNextPosition(), "Not enough positions for column %s, of type %s, checkpoints",
-                    column,
-                    columnType);
+            if (!hasNextPosition()) {
+                throw new InvalidCheckpointException("Not enough positions for column %s, of type %s, checkpoints",
+                        column,
+                        columnType);
+            }
 
             return positionsList.get(index++);
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/checkpoint/InvalidCheckpointException.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/checkpoint/InvalidCheckpointException.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.checkpoint;
+
+import static java.lang.String.format;
+
+public class InvalidCheckpointException
+        extends RuntimeException
+{
+    public InvalidCheckpointException(String message, Object... arguments)
+    {
+        super(format(message, arguments));
+    }
+}


### PR DESCRIPTION
When ORC switched to low memory mode it can create invalid checkpoints.  When
reading the file if the checkpoints can not be decoded, treat the entire strip
as a single row group.  DWRF files with a row group dictionary still fail
because the row group dictionary length is contained in the checkpoint stream.