### PR TITLE
Create a new storage page sink if we hit the max row count

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -189,7 +189,7 @@ public class OrcStorageManager
     @Override
     public PageBuffer createPageBuffer()
     {
-        return new PageBuffer(maxBufferSize.toBytes());
+        return new PageBuffer(maxBufferSize.toBytes(), Integer.MAX_VALUE);
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/util/PageBuffer.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/util/PageBuffer.java
@@ -26,13 +26,16 @@ public class PageBuffer
 {
     private final long maxMemoryBytes;
     private final List<Page> pages = new ArrayList<>();
+    private final long maxRows;
 
     private long usedMemoryBytes;
     private long rowCount;
 
-    public PageBuffer(long maxMemoryBytes)
+    public PageBuffer(long maxMemoryBytes, long maxRows)
     {
         checkArgument(maxMemoryBytes > 0, "maxMemoryBytes must be positive");
+        checkArgument(maxRows > 0, "maxRows must be positive");
+        this.maxRows = maxRows;
         this.maxMemoryBytes = maxMemoryBytes;
     }
 
@@ -51,9 +54,14 @@ public class PageBuffer
         usedMemoryBytes = 0;
     }
 
+    public boolean canAddRows(int rowsToAdd)
+    {
+        return !isFull() && rowCount + rowsToAdd < maxRows;
+    }
+
     public boolean isFull()
     {
-        return usedMemoryBytes >= maxMemoryBytes;
+        return rowCount >= maxRows || usedMemoryBytes >= maxMemoryBytes;
     }
 
     public List<Page> getPages()


### PR DESCRIPTION
Instead of writing out chunks of sorted rows, create new storage page sink when we hit the limit, so that rows in a shard are sorted. 