### PR TITLE
Relax partitioning criteria

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -50,6 +50,7 @@ import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
@@ -664,9 +665,10 @@ public class AddExchanges
 
         public boolean isPartitionedOnKeys(List<Symbol> keys)
         {
+            // partitioned on (k_1, k_2, ..., k_n) => partitioned on (k_1, k_2, ..., k_n, k_n+1, ...)
             return isPartitioned() &&
                     partitioning.getKeys().isPresent() &&
-                    partitioning.getKeys().get().equals(keys);
+                    ImmutableSet.copyOf(keys).containsAll(partitioning.getKeys().get());
         }
 
         public boolean isUnpartitioned()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -960,6 +960,13 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testGroupByOnSupersetOfPartitioning()
+            throws Exception
+    {
+        assertQuery("SELECT orderdate, c, count(*) FROM (SELECT orderdate, count(*) c FROM orders GROUP BY orderdate) GROUP BY orderdate, c");
+    }
+
+    @Test
     public void testInlineView()
             throws Exception
     {


### PR DESCRIPTION
A plan that is partitioned on a set of columns C satisfies partitioning requirements on any superset of C.

This change removes unnecessary shuffles for certain queries. E.g.,

```sql
   SELECT orderdate, c
   FROM (
      SELECT orderdate, count(*) c FROM tpch.sf1.orders
      GROUP BY orderdate)
   GROUP BY orderdate, c;
```
Before:

```
 Fragment 3 [SINGLE]
     Output layout: [orderdate, count]
     - Output[orderdate, c] => [orderdate:date, count:bigint]
             c := count
         - RemoteSource[2] => [orderdate:date, count:bigint]

 Fragment 2 [FIXED]
     Output layout: [orderdate, count]
     - Aggregate(FINAL)[orderdate, count] => [orderdate:date, count:bigint]
         - RemoteSource[1] => [orderdate:date, count:bigint]

 Fragment 1 [FIXED]
     Output layout: [orderdate, count]
     Output partitioning: [orderdate, count]
     - Aggregate(PARTIAL)[orderdate, count] => [orderdate:date, count:bigint]
         - Aggregate(FINAL)[orderdate] => [orderdate:date, count:bigint]
                 count := "count"("count_18")
             - RemoteSource[0] => [orderdate:date, count_18:bigint]

 Fragment 0 [SOURCE]
     Output layout: [orderdate, count_18]
     Output partitioning: [orderdate]
     - Aggregate(PARTIAL)[orderdate] => [orderdate:date, count_18:bigint]
             count_18 := "count"(*)
         - TableScan[tpch:tpch:orders:sf1.0, original constraint=true] => [orderdate:date]
                 orderdate := tpch:tpch:orderdate:4
```

After:

```
 Fragment 2 [SINGLE]
     Output layout: [orderdate, count]
     - Output[orderdate, c] => [orderdate:date, count:bigint]
             c := count
         - RemoteSource[1] => [orderdate:date, count:bigint]

 Fragment 1 [FIXED]
     Output layout: [orderdate, count]
     - Aggregate[orderdate, count] => [orderdate:date, count:bigint]
         - Aggregate(FINAL)[orderdate] => [orderdate:date, count:bigint]
                 count := "count"("count_18")
             - RemoteSource[0] => [orderdate:date, count_18:bigint]

 Fragment 0 [SOURCE]
     Output layout: [orderdate, count_18]
     Output partitioning: [orderdate]
     - Aggregate(PARTIAL)[orderdate] => [orderdate:date, count_18:bigint]
             count_18 := "count"(*)
         - TableScan[tpch:tpch:orders:sf1.0, original constraint=true] => [orderdate:date]
                 orderdate := tpch:tpch:orderdate:4
```