### PR TITLE
Allow opening query detail page in new tab

### DIFF
--- a/presto-main/src/main/resources/webapp/index.html
+++ b/presto-main/src/main/resources/webapp/index.html
@@ -107,7 +107,14 @@ function renderDoneQueries(queries)
                               return "info";
                       }
                   })
-            .on("click", function(query) { window.location = "query.html?" + query.queryId });
+            .on("click", function(query) {
+                    var e = d3.event;
+                    if (e.ctrlKey || e.metaKey || e.which == 2) {
+                        window.open("query.html?" + query.queryId);
+                    } else {
+                        window.location = "query.html?" + query.queryId;
+                    }
+             });
 
     rows.exit()
             .remove();
@@ -159,7 +166,14 @@ function renderRunningQueries(queries)
     rows.enter()
             .append("tr")
             .attr("class", "info")
-            .on("click", function(query) { window.location = "query.html?" + query.queryId });
+            .on("click", function(query) {
+                    var e = d3.event;
+                    if (e.ctrlKey || e.metaKey || e.which == 2) {
+                        window.open("query.html?" + query.queryId);
+                    } else {
+                        window.location = "query.html?" + query.queryId;
+                    }
+             });
 
     var cells = rows.selectAll("td")
             .data(function (queryInfo)


### PR DESCRIPTION
This is a quick hack to @electrum's #2515. Fixing this correctly would require using `<a>`, which would in turn require changing the table html to `<div>`s