### PR TITLE
Fix NPE when row expression appears at group by

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -39,6 +39,7 @@ import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullIfExpression;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.Row;
 import com.facebook.presto.sql.tree.SearchedCaseExpression;
 import com.facebook.presto.sql.tree.SimpleCaseExpression;
 import com.facebook.presto.sql.tree.SortItem;
@@ -408,6 +409,13 @@ public class AggregationAnalyzer
             }
 
             return true;
+        }
+
+        @Override
+        public Boolean visitRow(Row node, final Void context)
+        {
+            return node.getItems().stream()
+                    .allMatch(item -> process(item, context));
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -469,6 +469,14 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testGroupByWithRowExpression()
+            throws Exception
+    {
+        // TODO: verify output
+        analyze("SELECT (a, b) FROM t1 GROUP BY a, b");
+    }
+
+    @Test
     public void testHaving()
             throws Exception
     {


### PR DESCRIPTION
It caused NPE when distinct appears at group by clause.

```
java.lang.NullPointerException
	at com.facebook.presto.sql.analyzer.AggregationAnalyzer.analyze(AggregationAnalyzer.java:128)
	at com.facebook.presto.sql.analyzer.TupleAnalyzer.verifyAggregations(TupleAnalyzer.java:982)
	at com.facebook.presto.sql.analyzer.TupleAnalyzer.analyzeAggregations(TupleAnalyzer.java:945)
	at com.facebook.presto.sql.analyzer.TupleAnalyzer.visitQuerySpecification(TupleAnalyzer.java:352)
	at com.facebook.presto.sql.analyzer.TupleAnalyzer.visitQuerySpecification(TupleAnalyzer.java:132)
	at com.facebook.presto.sql.tree.QuerySpecification.accept(QuerySpecification.java:98)
	at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitQuery(StatementAnalyzer.java:502)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitQuery(StatementAnalyzer.java:114)
	at com.facebook.presto.sql.tree.Query.accept(Query.java:80)
	at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
	at com.facebook.presto.sql.analyzer.Analyzer.analyze(Analyzer.java:52)
	at com.facebook.presto.sql.analyzer.TestAnalyzer.analyze(TestAnalyzer.java:848)
	at com.facebook.presto.sql.analyzer.TestAnalyzer.testGroupByWithDistinct(TestAnalyzer.java:476)
```