### PR TITLE
Add JMX predicate pushdown for node

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/jmx/JmxSplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/jmx/JmxSplitManager.java
@@ -21,19 +21,22 @@ import com.facebook.presto.spi.ConnectorSplitManager;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.FixedSplitSource;
-import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.TupleDomain;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
 import javax.inject.Inject;
 
 import java.util.List;
 
+import static com.facebook.presto.spi.TupleDomain.withFixedValues;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.Types.checkType;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.airlift.slice.Slices.utf8Slice;
 
 public class JmxSplitManager
         implements ConnectorSplitManager
@@ -54,7 +57,7 @@ public class JmxSplitManager
         checkNotNull(tupleDomain, "tupleDomain is null");
         JmxTableHandle jmxTableHandle = checkType(table, JmxTableHandle.class, "table");
 
-        List<ConnectorPartition> partitions = ImmutableList.<ConnectorPartition>of(new JmxPartition(jmxTableHandle));
+        List<ConnectorPartition> partitions = ImmutableList.<ConnectorPartition>of(new JmxPartition(jmxTableHandle, tupleDomain));
         return new ConnectorPartitionResult(partitions, tupleDomain);
     }
 
@@ -67,28 +70,46 @@ public class JmxSplitManager
         }
 
         ConnectorPartition partition = Iterables.getOnlyElement(partitions);
-        JmxTableHandle tableHandle = checkType(partition, JmxPartition.class, "partition").getTableHandle();
+        JmxPartition jmxPartition = checkType(partition, JmxPartition.class, "partition");
+        JmxTableHandle tableHandle = jmxPartition.getTableHandle();
+        TupleDomain<ConnectorColumnHandle> predicate = jmxPartition.getPredicate();
 
-        ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
-        for (Node node : nodeManager.getActiveNodes()) {
-            splits.add(new JmxSplit(tableHandle, ImmutableList.of(node.getHostAndPort())));
-        }
-        return new FixedSplitSource(connectorId, splits.build());
+        //TODO is there a better way to get the node column?
+        JmxColumnHandle nodeColumnHandle = tableHandle.getColumns().get(0);
+
+        ImmutableList<ConnectorSplit> splits = nodeManager.getActiveNodes()
+                .stream()
+                .filter(node -> {
+                            TupleDomain<ConnectorColumnHandle> exactNodeMatch = withFixedValues(ImmutableMap.of(nodeColumnHandle, utf8Slice(node.getNodeIdentifier())));
+                            return predicate.overlaps(exactNodeMatch);
+                        }
+                )
+                .map(node -> new JmxSplit(tableHandle, ImmutableList.of(node.getHostAndPort())))
+                .collect(toImmutableList());
+
+        return new FixedSplitSource(connectorId, splits);
     }
 
     public static class JmxPartition
             implements ConnectorPartition
     {
         private final JmxTableHandle tableHandle;
+        private final TupleDomain<ConnectorColumnHandle> predicate;
 
-        public JmxPartition(JmxTableHandle tableHandle)
+        public JmxPartition(JmxTableHandle tableHandle, TupleDomain<ConnectorColumnHandle> predicate)
         {
             this.tableHandle = checkNotNull(tableHandle, "tableHandle is null");
+            this.predicate = checkNotNull(predicate, "predicate is null");
         }
 
         public JmxTableHandle getTableHandle()
         {
             return tableHandle;
+        }
+
+        public TupleDomain<ConnectorColumnHandle> getPredicate()
+        {
+            return predicate;
         }
 
         @Override
@@ -108,6 +129,7 @@ public class JmxSplitManager
         {
             return toStringHelper(this)
                     .add("tableHandle", tableHandle)
+                    .add("predicate", predicate)
                     .toString();
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/split/TestJmxSplitManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/split/TestJmxSplitManager.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.split;
+
+import com.facebook.presto.connector.jmx.JmxColumnHandle;
+import com.facebook.presto.connector.jmx.JmxConnectorId;
+import com.facebook.presto.connector.jmx.JmxSplitManager;
+import com.facebook.presto.connector.jmx.JmxTableHandle;
+import com.facebook.presto.spi.ConnectorPartitionResult;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.TupleDomain;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slices;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+
+public class TestJmxSplitManager
+{
+    private Set<Node> nodes = new HashSet<>();
+    private final Node localNode = new TestingNode("host1");
+    private JmxColumnHandle columnHandle;
+    private JmxTableHandle tableHandle;
+    private JmxSplitManager splitManager;
+
+    @BeforeTest
+    public void setup()
+    {
+        nodes.add(localNode);
+        nodes.add(new TestingNode("host2"));
+        nodes.add(new TestingNode("host3"));
+
+        String connectorId = "test_connector";
+        columnHandle = new JmxColumnHandle(connectorId, "node", VARCHAR, 0);
+        tableHandle = new JmxTableHandle(connectorId, "objectName", ImmutableList.of(columnHandle));
+        splitManager = new JmxSplitManager(new JmxConnectorId(connectorId), new TestingNodeManager());
+    }
+
+    @Test
+    public void testPredicatePushdown()
+            throws Exception
+    {
+        for (Node node : nodes) {
+            String nodeIdentifier = node.getNodeIdentifier();
+            TupleDomain nodeTupleDomain = TupleDomain.withFixedValues(ImmutableMap.of(columnHandle, Slices.utf8Slice(nodeIdentifier)));
+            ConnectorPartitionResult connectorPartitionResult = splitManager.getPartitions(tableHandle, nodeTupleDomain);
+            ConnectorSplitSource splitSource = splitManager.getPartitionSplits(tableHandle, connectorPartitionResult.getPartitions());
+            List<ConnectorSplit> allSplits = getAllSplits(splitSource);
+            assertEquals(allSplits.size(), 1);
+            assertEquals(allSplits.get(0).getAddresses().size(), 1);
+            assertEquals(allSplits.get(0).getAddresses().get(0).getHostText(), nodeIdentifier);
+        }
+    }
+
+    @Test
+    public void testNoPredicate()
+            throws Exception
+    {
+        ConnectorPartitionResult connectorPartitionResult = splitManager.getPartitions(tableHandle, TupleDomain.all());
+        ConnectorSplitSource splitSource = splitManager.getPartitionSplits(tableHandle, connectorPartitionResult.getPartitions());
+        List<ConnectorSplit> allSplits = getAllSplits(splitSource);
+        assertEquals(allSplits.size(), nodes.size());
+
+        Set<String> actualNodes = nodes.stream().map(node -> node.getNodeIdentifier()).collect(toImmutableSet());
+        Set<String> expectedNodes = new HashSet<>();
+        for (ConnectorSplit split : allSplits) {
+            List<HostAddress> addresses = split.getAddresses();
+            assertEquals(addresses.size(), 1);
+            expectedNodes.add(addresses.get(0).getHostText());
+        }
+        assertEquals(actualNodes, expectedNodes);
+    }
+
+    private static List<ConnectorSplit> getAllSplits(ConnectorSplitSource splitSource)
+            throws InterruptedException
+    {
+        ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
+        while (!splitSource.isFinished()) {
+            List<ConnectorSplit> batch = splitSource.getNextBatch(1000);
+            splits.addAll(batch);
+        }
+        return splits.build();
+    }
+
+    private class TestingNodeManager
+            implements NodeManager
+    {
+        @Override
+        public Set<Node> getActiveNodes()
+        {
+            return nodes;
+        }
+
+        @Override
+        public Set<Node> getActiveDatasourceNodes(String datasourceName)
+        {
+            return nodes;
+        }
+
+        @Override
+        public Node getCurrentNode()
+        {
+            return localNode;
+        }
+
+        @Override
+        public Set<Node> getCoordinators()
+        {
+            return ImmutableSet.of(localNode);
+        }
+    }
+
+    private static class TestingNode
+            implements Node
+    {
+        private final String hostname;
+
+        public TestingNode(String hostname)
+        {
+            this.hostname = hostname;
+        }
+
+        @Override
+        public HostAddress getHostAndPort()
+        {
+            return HostAddress.fromParts(hostname, 8080);
+        }
+
+        @Override
+        public URI getHttpUri()
+        {
+            return URI.create(format("http://%s:8080", hostname));
+        }
+
+        @Override
+        public String getNodeIdentifier()
+        {
+            return hostname;
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses #2286 and implements predicate pushdown for the node column for the jmx split manager.