### PR TITLE
Fix precomputed hash optimization

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
@@ -45,6 +45,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public final class TypeUtils
 {
     public static final int EXPECTED_ARRAY_SIZE = 1024;
+    public static final int NULL_HASH_CODE = 0;
 
     private TypeUtils()
     {
@@ -53,7 +54,7 @@ public final class TypeUtils
     public static int hashPosition(Type type, Block block, int position)
     {
         if (block.isNull(position)) {
-            return 0;
+            return NULL_HASH_CODE;
         }
         return type.hash(block, position);
     }


### PR DESCRIPTION
The precomputed hash optimization skips rows where any column is NULL.
This results in an uninitialized read in PrecomputedHashGenerator, which
causes all of those rows to hash to zero, which in turn causes
GroupByHash to de-generate into a linked list resulting in O(n^2)
running time.