### PR TITLE
Element type based array, map and row encoding

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursor.java
@@ -79,7 +79,6 @@ class ColumnarBinaryHiveRecordCursor<K>
         extends HiveRecordCursor
 {
     private final RecordReader<K, BytesRefArrayWritable> recordReader;
-    private final DateTimeZone sessionTimeZone;
     private final K key;
     private final BytesRefArrayWritable value;
 
@@ -120,7 +119,6 @@ class ColumnarBinaryHiveRecordCursor<K>
             List<HivePartitionKey> partitionKeys,
             List<HiveColumnHandle> columns,
             DateTimeZone hiveStorageTimeZone,
-            DateTimeZone sessionTimeZone,
             TypeManager typeManager)
     {
         checkNotNull(recordReader, "recordReader is null");
@@ -128,13 +126,11 @@ class ColumnarBinaryHiveRecordCursor<K>
         checkNotNull(splitSchema, "splitSchema is null");
         checkNotNull(partitionKeys, "partitionKeys is null");
         checkNotNull(columns, "columns is null");
-        checkNotNull(sessionTimeZone, "sessionTimeZone is null");
 
         this.recordReader = recordReader;
         this.totalBytes = totalBytes;
         this.key = recordReader.createKey();
         this.value = recordReader.createValue();
-        this.sessionTimeZone = sessionTimeZone;
 
         int size = columns.size();
 
@@ -550,7 +546,7 @@ class ColumnarBinaryHiveRecordCursor<K>
                 ByteArrayRef byteArrayRef = new ByteArrayRef();
                 byteArrayRef.setData(bytes);
                 lazyObject.init(byteArrayRef, start, length);
-                slices[column] = getBlockSlice(sessionTimeZone, lazyObject.getObject(), fieldInspectors[column]);
+                slices[column] = getBlockSlice(lazyObject.getObject(), fieldInspectors[column], types[column]);
             }
             else {
                 // TODO: zero length BINARY is not supported. See https://issues.apache.org/jira/browse/HIVE-2483

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarBinaryHiveRecordCursorProvider.java
@@ -60,7 +60,6 @@ public class ColumnarBinaryHiveRecordCursorProvider
                 partitionKeys,
                 columns,
                 hiveStorageTimeZone,
-                DateTimeZone.forID(session.getTimeZoneKey().getId()),
                 typeManager));
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursor.java
@@ -95,7 +95,6 @@ class ColumnarTextHiveRecordCursor<K>
 
     private final long totalBytes;
     private final DateTimeZone hiveStorageTimeZone;
-    private final DateTimeZone sessionTimeZone;
 
     private long completedBytes;
     private boolean closed;
@@ -107,7 +106,6 @@ class ColumnarTextHiveRecordCursor<K>
             List<HivePartitionKey> partitionKeys,
             List<HiveColumnHandle> columns,
             DateTimeZone hiveStorageTimeZone,
-            DateTimeZone sessionTimeZone,
             TypeManager typeManager)
     {
         checkNotNull(recordReader, "recordReader is null");
@@ -116,14 +114,12 @@ class ColumnarTextHiveRecordCursor<K>
         checkNotNull(partitionKeys, "partitionKeys is null");
         checkNotNull(columns, "columns is null");
         checkNotNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
-        checkNotNull(sessionTimeZone, "sessionTimeZone is null");
 
         this.recordReader = recordReader;
         this.totalBytes = totalBytes;
         this.key = recordReader.createKey();
         this.value = recordReader.createValue();
         this.hiveStorageTimeZone = hiveStorageTimeZone;
-        this.sessionTimeZone = sessionTimeZone;
 
         int size = columns.size();
 
@@ -490,7 +486,7 @@ class ColumnarTextHiveRecordCursor<K>
             ByteArrayRef byteArrayRef = new ByteArrayRef();
             byteArrayRef.setData(bytes);
             lazyObject.init(byteArrayRef, start, length);
-            slices[column] = getBlockSlice(sessionTimeZone, lazyObject.getObject(), fieldInspectors[column]);
+            slices[column] = getBlockSlice(lazyObject.getObject(), fieldInspectors[column], types[column]);
             wasNull = false;
         }
         else {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ColumnarTextHiveRecordCursorProvider.java
@@ -60,7 +60,6 @@ public class ColumnarTextHiveRecordCursorProvider
                 partitionKeys,
                 columns,
                 hiveStorageTimeZone,
-                DateTimeZone.forID(session.getTimeZoneKey().getId()),
                 typeManager));
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
@@ -93,7 +93,6 @@ class GenericHiveRecordCursor<K, V extends Writable>
 
     private final long totalBytes;
     private final DateTimeZone hiveStorageTimeZone;
-    private final DateTimeZone sessionTimeZone;
 
     private long completedBytes;
     private Object rowData;
@@ -106,7 +105,6 @@ class GenericHiveRecordCursor<K, V extends Writable>
             List<HivePartitionKey> partitionKeys,
             List<HiveColumnHandle> columns,
             DateTimeZone hiveStorageTimeZone,
-            DateTimeZone sessionTimeZone,
             TypeManager typeManager)
     {
         checkNotNull(recordReader, "recordReader is null");
@@ -115,14 +113,12 @@ class GenericHiveRecordCursor<K, V extends Writable>
         checkNotNull(partitionKeys, "partitionKeys is null");
         checkNotNull(columns, "columns is null");
         checkNotNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
-        checkNotNull(sessionTimeZone, "sessionTimeZone is null");
 
         this.recordReader = recordReader;
         this.totalBytes = totalBytes;
         this.key = recordReader.createKey();
         this.value = recordReader.createValue();
         this.hiveStorageTimeZone = hiveStorageTimeZone;
-        this.sessionTimeZone = sessionTimeZone;
 
         this.deserializer = getDeserializer(splitSchema);
         this.rowInspector = getTableObjectInspector(deserializer);
@@ -406,7 +402,7 @@ class GenericHiveRecordCursor<K, V extends Writable>
             nulls[column] = true;
         }
         else if (isStructuralType(hiveTypes[column])) {
-            slices[column] = getBlockSlice(sessionTimeZone, fieldData, fieldInspectors[column]);
+            slices[column] = getBlockSlice(fieldData, fieldInspectors[column], types[column]);
             nulls[column] = false;
         }
         else {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursorProvider.java
@@ -53,7 +53,6 @@ public class GenericHiveRecordCursorProvider
                 partitionKeys,
                 columns,
                 hiveStorageTimeZone,
-                DateTimeZone.forID(session.getTimeZoneKey().getId()),
                 typeManager));
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfHiveRecordCursor.java
@@ -90,7 +90,6 @@ public class DwrfHiveRecordCursor
         extends HiveRecordCursor
 {
     private final RecordReader recordReader;
-    private final DateTimeZone sessionTimeZone;
 
     @SuppressWarnings("FieldCanBeLocal") // include names for debugging
     private final String[] names;
@@ -123,7 +122,6 @@ public class DwrfHiveRecordCursor
             List<HivePartitionKey> partitionKeys,
             List<HiveColumnHandle> columns,
             DateTimeZone hiveStorageTimeZone,
-            DateTimeZone sessionTimeZone,
             TypeManager typeManager)
     {
         checkNotNull(recordReader, "recordReader is null");
@@ -132,11 +130,9 @@ public class DwrfHiveRecordCursor
         checkNotNull(partitionKeys, "partitionKeys is null");
         checkNotNull(columns, "columns is null");
         checkNotNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
-        checkNotNull(sessionTimeZone, "sessionTimeZone is null");
 
         this.recordReader = recordReader;
         this.totalBytes = totalBytes;
-        this.sessionTimeZone = sessionTimeZone;
 
         int size = columns.size();
 
@@ -433,7 +429,7 @@ public class DwrfHiveRecordCursor
 
         HiveType type = hiveTypes[column];
         if (isStructuralType(type)) {
-            slices[column] = getBlockSlice(sessionTimeZone, lazyObject, fieldInspectors[column]);
+            slices[column] = getBlockSlice(lazyObject, fieldInspectors[column], types[column]);
         }
         else if (type.equals(HIVE_STRING)) {
             Text text = checkWritable(value, Text.class);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfRecordCursorProvider.java
@@ -98,7 +98,6 @@ public class DwrfRecordCursorProvider
                 partitionKeys,
                 columns,
                 hiveStorageTimeZone,
-                DateTimeZone.forID(session.getTimeZoneKey().getId()),
                 typeManager));
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcHiveRecordCursor.java
@@ -89,7 +89,6 @@ public class OrcHiveRecordCursor
         extends HiveRecordCursor
 {
     private final RecordReader recordReader;
-    private final DateTimeZone sessionTimeZone;
 
     @SuppressWarnings("FieldCanBeLocal") // include names for debugging
     private final String[] names;
@@ -122,7 +121,6 @@ public class OrcHiveRecordCursor
             List<HivePartitionKey> partitionKeys,
             List<HiveColumnHandle> columns,
             DateTimeZone hiveStorageTimeZone,
-            DateTimeZone sessionTimeZone,
             TypeManager typeManager)
     {
         checkNotNull(recordReader, "recordReader is null");
@@ -131,11 +129,9 @@ public class OrcHiveRecordCursor
         checkNotNull(partitionKeys, "partitionKeys is null");
         checkNotNull(columns, "columns is null");
         checkNotNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
-        checkNotNull(sessionTimeZone, "sessionTimeZone is null");
 
         this.recordReader = recordReader;
         this.totalBytes = totalBytes;
-        this.sessionTimeZone = sessionTimeZone;
 
         int size = columns.size();
 
@@ -431,7 +427,7 @@ public class OrcHiveRecordCursor
 
         HiveType type = hiveTypes[column];
         if (isStructuralType(type)) {
-            slices[column] = getBlockSlice(sessionTimeZone, object, fieldInspectors[column]);
+            slices[column] = getBlockSlice(object, fieldInspectors[column], types[column]);
         }
         else if (type.equals(HIVE_STRING)) {
             Text text = Types.checkType(object, Text.class, "materialized string value");

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
@@ -32,7 +32,7 @@ import com.facebook.presto.spi.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -157,12 +157,12 @@ public class OrcPageSourceFactory
             throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, splitError(e, path, start, length), e);
         }
 
-        ImmutableSet.Builder<Integer> includedColumns = ImmutableSet.builder();
+        ImmutableMap.Builder<Integer, Type> includedColumns = ImmutableMap.builder();
         ImmutableList.Builder<ColumnReference<HiveColumnHandle>> columnReferences = ImmutableList.builder();
         for (HiveColumnHandle column : columns) {
             if (!column.isPartitionKey()) {
-                includedColumns.add(column.getHiveColumnIndex());
                 Type type = typeManager.getType(column.getTypeSignature());
+                includedColumns.put(column.getHiveColumnIndex(), type);
                 columnReferences.add(new ColumnReference<>(column, column.getHiveColumnIndex(), type));
             }
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcRecordCursorProvider.java
@@ -106,7 +106,6 @@ public class OrcRecordCursorProvider
                 partitionKeys,
                 columns,
                 hiveStorageTimeZone,
-                DateTimeZone.forID(session.getTimeZoneKey().getId()),
                 typeManager));
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcBinaryBlockLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcBinaryBlockLoader.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.rcfile.RcFilePageSource.RcFileColumnsBatch;
 import com.facebook.presto.spi.block.LazyBlockLoader;
 import com.facebook.presto.spi.block.LazyFixedWidthBlock;
 import com.facebook.presto.spi.block.LazySliceArrayBlock;
+import com.facebook.presto.spi.type.Type;
 import com.google.common.base.Throwables;
 import io.airlift.slice.ByteArrays;
 import io.airlift.slice.Slice;
@@ -30,7 +31,6 @@ import org.apache.hadoop.hive.serde2.lazybinary.LazyBinaryFactory;
 import org.apache.hadoop.hive.serde2.lazybinary.LazyBinaryObject;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.io.WritableUtils;
-import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -61,11 +61,8 @@ public class RcBinaryBlockLoader
 {
     private static final byte HIVE_EMPTY_STRING_BYTE = (byte) 0xbf;
 
-    private final DateTimeZone sessionTimeZone;
-
-    public RcBinaryBlockLoader(DateTimeZone sessionTimeZone)
+    public RcBinaryBlockLoader()
     {
-        this.sessionTimeZone = sessionTimeZone;
     }
 
     @Override
@@ -102,13 +99,13 @@ public class RcBinaryBlockLoader
     }
 
     @Override
-    public LazyBlockLoader<LazySliceArrayBlock> variableWidthBlockLoader(RcFileColumnsBatch batch, int fieldId, HiveType hiveType, ObjectInspector fieldInspector)
+    public LazyBlockLoader<LazySliceArrayBlock> variableWidthBlockLoader(RcFileColumnsBatch batch, int fieldId, HiveType hiveType, ObjectInspector fieldInspector, Type type)
     {
         if (HIVE_STRING.equals(hiveType) || HIVE_BINARY.equals(hiveType)) {
             return new LazySliceBlockLoader(batch, fieldId);
         }
         if (isStructuralType(hiveType)) {
-            return new LazyJsonSliceBlockLoader(batch, fieldId, fieldInspector, sessionTimeZone);
+            return new LazyJsonSliceBlockLoader(batch, fieldId, fieldInspector, type);
         }
         throw new UnsupportedOperationException("Unsupported column type: " + hiveType);
     }
@@ -674,15 +671,15 @@ public class RcBinaryBlockLoader
         private final RcFileColumnsBatch batch;
         private final int fieldId;
         private final ObjectInspector fieldInspector;
-        private final DateTimeZone sessionTimeZone;
+        private final Type type;
         private boolean loaded;
 
-        private LazyJsonSliceBlockLoader(RcFileColumnsBatch batch, int fieldId, ObjectInspector fieldInspector, DateTimeZone sessionTimeZone)
+        private LazyJsonSliceBlockLoader(RcFileColumnsBatch batch, int fieldId, ObjectInspector fieldInspector, Type type)
         {
             this.batch = batch;
             this.fieldId = fieldId;
             this.fieldInspector = fieldInspector;
-            this.sessionTimeZone = sessionTimeZone;
+            this.type = type;
         }
 
         @Override
@@ -710,7 +707,7 @@ public class RcBinaryBlockLoader
                         ByteArrayRef byteArrayRef = new ByteArrayRef();
                         byteArrayRef.setData(bytes);
                         lazyObject.init(byteArrayRef, start, length);
-                        vector[i] = getBlockSlice(sessionTimeZone, lazyObject.getObject(), fieldInspector);
+                        vector[i] = getBlockSlice(lazyObject.getObject(), fieldInspector, type);
                     }
                 }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFileBlockLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFileBlockLoader.java
@@ -18,11 +18,12 @@ import com.facebook.presto.hive.rcfile.RcFilePageSource.RcFileColumnsBatch;
 import com.facebook.presto.spi.block.LazyBlockLoader;
 import com.facebook.presto.spi.block.LazyFixedWidthBlock;
 import com.facebook.presto.spi.block.LazySliceArrayBlock;
+import com.facebook.presto.spi.type.Type;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 
 public interface RcFileBlockLoader
 {
     LazyBlockLoader<LazyFixedWidthBlock> fixedWidthBlockLoader(RcFileColumnsBatch batch, int fieldId, HiveType hiveType);
 
-    LazyBlockLoader<LazySliceArrayBlock> variableWidthBlockLoader(RcFileColumnsBatch batch, int fieldId, HiveType hiveType, ObjectInspector fieldInspector);
+    LazyBlockLoader<LazySliceArrayBlock> variableWidthBlockLoader(RcFileColumnsBatch batch, int fieldId, HiveType hiveType, ObjectInspector fieldInspector, Type type);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSource.java
@@ -301,7 +301,8 @@ public class RcFilePageSource
                     LazyBlockLoader<LazySliceArrayBlock> loader = blockLoader.variableWidthBlockLoader(rcFileColumnsBatch,
                             fieldId,
                             hiveTypes.get(fieldId),
-                            fieldInspectors[fieldId]);
+                            fieldInspectors[fieldId],
+                            types.get(fieldId));
                     blocks[fieldId] = new LazySliceArrayBlock(currentPageSize, loader);
                 }
             }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSourceFactory.java
@@ -91,10 +91,10 @@ public class RcFilePageSourceFactory
 
         RcFileBlockLoader blockLoader;
         if (deserializerClassName.equals(LazyBinaryColumnarSerDe.class.getName())) {
-            blockLoader = new RcBinaryBlockLoader(DateTimeZone.forID(session.getTimeZoneKey().getId()));
+            blockLoader = new RcBinaryBlockLoader();
         }
         else if (deserializerClassName.equals(ColumnarSerDe.class.getName())) {
-            blockLoader = new RcTextBlockLoader(hiveStorageTimeZone, DateTimeZone.forID(session.getTimeZoneKey().getId()));
+            blockLoader = new RcTextBlockLoader(hiveStorageTimeZone);
         }
         else {
             return Optional.empty();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -28,6 +28,7 @@ import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.RowType;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -64,6 +65,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -208,7 +210,7 @@ public abstract class AbstractTestHiveFileFormats
             .add(new TestColumn("t_struct_bigint",
                     getStandardStructObjectInspector(ImmutableList.of("s_bigint"), ImmutableList.of(javaLongObjectInspector)),
                     new Long[] {1L},
-                    arraySliceOf(BIGINT, 1)))
+                    rowSliceOf(ImmutableList.of(BIGINT), 1)))
             .add(new TestColumn("t_complex",
                     getStandardMapObjectInspector(
                             javaStringObjectInspector,
@@ -220,10 +222,11 @@ public abstract class AbstractTestHiveFileFormats
                             )
                     ),
                     ImmutableMap.of("test", ImmutableList.<Object>of(new Integer[] {1})),
-                    mapSliceOf(VARCHAR, new ArrayType(new ArrayType(BIGINT)), "test", arraySliceOf(new ArrayType(BIGINT), arraySliceOf(BIGINT, 1)))
+                    mapSliceOf(VARCHAR, new ArrayType(new RowType(ImmutableList.of(BIGINT), Optional.empty())),
+                            "test", arraySliceOf(new ArrayType(new RowType(ImmutableList.of(BIGINT), Optional.empty())), rowSliceOf(ImmutableList.of(BIGINT), 1)))
             ))
             .add(new TestColumn("t_struct_nested", getStandardStructObjectInspector(ImmutableList.of("struct_field"),
-                    ImmutableList.of(getStandardListObjectInspector(javaStringObjectInspector))), ImmutableList.of(ImmutableList.of("1", "2", "3")) , rowSliceOf(ImmutableList.of(new ArrayType(VARCHAR)), arraySliceOf(VARCHAR, "1", "2", "3"))))
+                    ImmutableList.of(getStandardListObjectInspector(javaStringObjectInspector))), ImmutableList.of(ImmutableList.of("1", "2", "3")), rowSliceOf(ImmutableList.of(new ArrayType(VARCHAR)), arraySliceOf(VARCHAR, "1", "2", "3"))))
             .add(new TestColumn("t_struct_null", getStandardStructObjectInspector(ImmutableList.of("struct_field", "struct_field2"),
                     ImmutableList.of(javaStringObjectInspector, javaStringObjectInspector)), Arrays.asList(null, null), rowSliceOf(ImmutableList.of(VARCHAR, VARCHAR), null, null)))
             .build();

--- a/presto-main/src/main/java/com/facebook/presto/operator/ArrayUnnester.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ArrayUnnester.java
@@ -22,7 +22,7 @@ import io.airlift.slice.Slice;
 
 import javax.annotation.Nullable;
 
-import static com.facebook.presto.type.TypeUtils.readStructuralBlock;
+import static com.facebook.presto.type.TypeUtils.readArrayBlock;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ArrayUnnester
@@ -45,7 +45,7 @@ public class ArrayUnnester
             positionCount = 0;
         }
         else {
-            arrayBlock = readStructuralBlock(slice);
+            arrayBlock = readArrayBlock(arrayType.getElementType(), slice);
             positionCount = arrayBlock.getPositionCount();
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatUtils.java
@@ -16,12 +16,11 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 
-import static com.facebook.presto.type.TypeUtils.readStructuralBlock;
 import static com.facebook.presto.type.TypeUtils.buildStructuralSlice;
+import static com.facebook.presto.type.TypeUtils.readArrayBlock;
 
 public final class ArrayConcatUtils
 {
@@ -29,9 +28,9 @@ public final class ArrayConcatUtils
 
     public static Slice concat(Type elementType, Slice left, Slice right)
     {
-        Block leftBlock = readStructuralBlock(left);
-        Block rightBlock = readStructuralBlock(right);
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), leftBlock.getSizeInBytes() + rightBlock.getSizeInBytes());
+        Block leftBlock = readArrayBlock(elementType, left);
+        Block rightBlock = readArrayBlock(elementType, right);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), leftBlock.getPositionCount() + rightBlock.getPositionCount());
         for (int i = 0; i < leftBlock.getPositionCount(); i++) {
             elementType.appendTo(leftBlock, i, blockBuilder);
         }
@@ -43,8 +42,8 @@ public final class ArrayConcatUtils
 
     public static Slice appendElement(Type elementType, Slice in, long value)
     {
-        Block block = readStructuralBlock(in);
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), block.getSizeInBytes());
+        Block block = readArrayBlock(elementType, in);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             elementType.appendTo(block, i, blockBuilder);
         }
@@ -56,8 +55,8 @@ public final class ArrayConcatUtils
 
     public static Slice appendElement(Type elementType, Slice in, boolean value)
     {
-        Block block = readStructuralBlock(in);
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), block.getSizeInBytes());
+        Block block = readArrayBlock(elementType, in);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             elementType.appendTo(block, i, blockBuilder);
         }
@@ -69,8 +68,8 @@ public final class ArrayConcatUtils
 
     public static Slice appendElement(Type elementType, Slice in, double value)
     {
-        Block block = readStructuralBlock(in);
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), block.getSizeInBytes());
+        Block block = readArrayBlock(elementType, in);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             elementType.appendTo(block, i, blockBuilder);
         }
@@ -82,8 +81,8 @@ public final class ArrayConcatUtils
 
     public static Slice appendElement(Type elementType, Slice in, Slice value)
     {
-        Block block = readStructuralBlock(in);
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), block.getSizeInBytes());
+        Block block = readArrayBlock(elementType, in);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             elementType.appendTo(block, i, blockBuilder);
         }
@@ -95,8 +94,8 @@ public final class ArrayConcatUtils
 
     public static Slice prependElement(Type elementType, Slice value, Slice in)
     {
-        Block block = readStructuralBlock(in);
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), block.getSizeInBytes());
+        Block block = readArrayBlock(elementType, in);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
 
         elementType.writeSlice(blockBuilder, value);
         for (int i = 0; i < block.getPositionCount(); i++) {
@@ -108,8 +107,8 @@ public final class ArrayConcatUtils
 
     public static Slice prependElement(Type elementType, long value, Slice in)
     {
-        Block block = readStructuralBlock(in);
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), block.getSizeInBytes());
+        Block block = readArrayBlock(elementType, in);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
 
         elementType.writeLong(blockBuilder, value);
         for (int i = 0; i < block.getPositionCount(); i++) {
@@ -121,8 +120,8 @@ public final class ArrayConcatUtils
 
     public static Slice prependElement(Type elementType, boolean value, Slice in)
     {
-        Block block = readStructuralBlock(in);
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), block.getSizeInBytes());
+        Block block = readArrayBlock(elementType, in);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
 
         elementType.writeBoolean(blockBuilder, value);
         for (int i = 0; i < block.getPositionCount(); i++) {
@@ -134,8 +133,8 @@ public final class ArrayConcatUtils
 
     public static Slice prependElement(Type elementType, double value, Slice in)
     {
-        Block block = readStructuralBlock(in);
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), block.getSizeInBytes());
+        Block block = readArrayBlock(elementType, in);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
 
         elementType.writeDouble(blockBuilder, value);
         for (int i = 0; i < block.getPositionCount(); i++) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayContains.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayContains.java
@@ -32,7 +32,7 @@ import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.type.TypeUtils.createBlock;
 import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
-import static com.facebook.presto.type.TypeUtils.readStructuralBlock;
+import static com.facebook.presto.type.TypeUtils.readArrayBlock;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public final class ArrayContains
@@ -81,7 +81,7 @@ public final class ArrayContains
 
     public static boolean contains(Type type, Slice slice, Slice value)
     {
-        Block arrayBlock = readStructuralBlock(slice);
+        Block arrayBlock = readArrayBlock(type, slice);
         Block valueBlock = createBlock(type, value);
         for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
             if (type.equalTo(arrayBlock, i, valueBlock, 0)) {
@@ -93,7 +93,7 @@ public final class ArrayContains
 
     public static boolean contains(Type type, Slice slice, long value)
     {
-        Block arrayBlock = readStructuralBlock(slice);
+        Block arrayBlock = readArrayBlock(type, slice);
         Block valueBlock = createBlock(type, value);
         for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
             if (type.equalTo(arrayBlock, i, valueBlock, 0)) {
@@ -105,7 +105,7 @@ public final class ArrayContains
 
     public static boolean contains(Type type, Slice slice, boolean value)
     {
-        Block arrayBlock = readStructuralBlock(slice);
+        Block arrayBlock = readArrayBlock(type, slice);
         Block valueBlock = createBlock(type, value);
         for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
             if (type.equalTo(arrayBlock, i, valueBlock, 0)) {
@@ -117,7 +117,7 @@ public final class ArrayContains
 
     public static boolean contains(Type type, Slice slice, double value)
     {
-        Block arrayBlock = readStructuralBlock(slice);
+        Block arrayBlock = readArrayBlock(type, slice);
         Block valueBlock = createBlock(type, value);
         for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
             if (type.equalTo(arrayBlock, i, valueBlock, 0)) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFunctions.java
@@ -15,12 +15,12 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 
 import com.facebook.presto.type.SqlType;
 import io.airlift.slice.Slice;
 
 import static com.facebook.presto.type.TypeUtils.buildStructuralSlice;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
 
 public final class ArrayFunctions
 {
@@ -32,7 +32,7 @@ public final class ArrayFunctions
     @SqlType("array<unknown>")
     public static Slice arrayConstructor()
     {
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), 0);
+        BlockBuilder blockBuilder = UNKNOWN.createBlockBuilder(new BlockBuilderStatus(), 0);
         return buildStructuralSlice(blockBuilder);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
@@ -20,7 +20,6 @@ import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableList;
@@ -34,9 +33,9 @@ import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.metadata.Signature.orderableTypeParameter;
-import static com.facebook.presto.type.TypeUtils.readStructuralBlock;
 import static com.facebook.presto.type.TypeUtils.buildStructuralSlice;
 import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
+import static com.facebook.presto.type.TypeUtils.readArrayBlock;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
@@ -87,7 +86,7 @@ public final class ArraySortFunction
 
     public static Slice sort(Type type, Slice encodedArray)
     {
-        Block block = readStructuralBlock(encodedArray);
+        Block block = readArrayBlock(type, encodedArray);
 
         List<Integer> positions = Ints.asList(new int[block.getPositionCount()]);
         for (int i = 0; i < block.getPositionCount(); i++) {
@@ -104,7 +103,7 @@ public final class ArraySortFunction
             }
         });
 
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), block.getSizeInBytes());
+        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount());
 
         for (int position : positions) {
             type.appendTo(block, position, blockBuilder);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySubscriptOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySubscriptOperator.java
@@ -33,9 +33,9 @@ import java.util.Map;
 import static com.facebook.presto.metadata.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.metadata.Signature.typeParameter;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
-import static com.facebook.presto.type.TypeUtils.readStructuralBlock;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
+import static com.facebook.presto.type.TypeUtils.readArrayBlock;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -72,12 +72,12 @@ public class ArraySubscriptOperator
 
     public static void arrayWithUnknownType(Type elementType, Slice array, long index)
     {
-        readBlockAndCheckIndex(array, index);
+        readBlockAndCheckIndex(elementType, array, index);
     }
 
     public static Long longSubscript(Type elementType, Slice array, long index)
     {
-        Block block = readBlockAndCheckIndex(array, index);
+        Block block = readBlockAndCheckIndex(elementType, array, index);
         int position = Ints.checkedCast(index - 1);
         if (block.isNull(position)) {
             return null;
@@ -88,7 +88,7 @@ public class ArraySubscriptOperator
 
     public static Boolean booleanSubscript(Type elementType, Slice array, long index)
     {
-        Block block = readBlockAndCheckIndex(array, index);
+        Block block = readBlockAndCheckIndex(elementType, array, index);
         int position = Ints.checkedCast(index - 1);
         if (block.isNull(position)) {
             return null;
@@ -99,7 +99,7 @@ public class ArraySubscriptOperator
 
     public static Double doubleSubscript(Type elementType, Slice array, long index)
     {
-        Block block = readBlockAndCheckIndex(array, index);
+        Block block = readBlockAndCheckIndex(elementType, array, index);
         int position = Ints.checkedCast(index - 1);
         if (block.isNull(position)) {
             return null;
@@ -110,7 +110,7 @@ public class ArraySubscriptOperator
 
     public static Slice sliceSubscript(Type elementType, Slice array, long index)
     {
-        Block block = readBlockAndCheckIndex(array, index);
+        Block block = readBlockAndCheckIndex(elementType, array, index);
         int position = Ints.checkedCast(index - 1);
         if (block.isNull(position)) {
             return null;
@@ -119,12 +119,12 @@ public class ArraySubscriptOperator
         return elementType.getSlice(block, position);
     }
 
-    public static Block readBlockAndCheckIndex(Slice array, long index)
+    public static Block readBlockAndCheckIndex(Type elementType, Slice array, long index)
     {
         if (index <= 0) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Index out of bounds");
         }
-        Block block = readStructuralBlock(array);
+        Block block = readArrayBlock(elementType, array);
         if (index > block.getPositionCount()) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Index out of bounds");
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToArrayCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToArrayCast.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.facebook.presto.type.ArrayType;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
@@ -70,7 +69,7 @@ public class JsonToArrayCast
             if (array == null) {
                 return null;
             }
-            return toStackRepresentation((List<?>) array, ((ArrayType) arrayType).getElementType());
+            return toStackRepresentation((List<?>) array, arrayType.getTypeParameters().get(0));
         }
         catch (RuntimeException e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to " + arrayType, e);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToMapCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToMapCast.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.facebook.presto.type.MapType;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
@@ -71,7 +70,7 @@ public class JsonToMapCast
             if (map == null) {
                 return null;
             }
-            return toStackRepresentation((Map<?, ?>) map, ((MapType) mapType).getKeyType(), ((MapType) mapType).getValueType());
+            return toStackRepresentation((Map<?, ?>) map, mapType.getTypeParameters().get(0), mapType.getTypeParameters().get(1));
         }
         catch (RuntimeException e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to " + mapType, e);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
@@ -20,9 +20,6 @@ import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.TypeParameter;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -37,9 +34,9 @@ import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
 import static com.facebook.presto.metadata.Signature.typeParameter;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.StandardTypes.MAP;
-import static com.facebook.presto.type.TypeUtils.buildStructuralSlice;
+import static com.facebook.presto.type.TypeUtils.buildMapSlice;
 import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
-import static com.facebook.presto.type.TypeUtils.readStructuralBlock;
+import static com.facebook.presto.type.TypeUtils.readArrayBlock;
 import static com.facebook.presto.util.Failures.checkCondition;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
@@ -94,19 +91,16 @@ public final class MapConstructor
 
     public static Slice createMap(Type keyType, Type valueType, Slice keys, Slice values)
     {
-        Block keyBlock = readStructuralBlock(keys);
-        Block valueBlock = readStructuralBlock(values);
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), keyBlock.getSizeInBytes() + valueBlock.getSizeInBytes());
+        Block keyBlock = readArrayBlock(keyType, keys);
+        Block valueBlock = readArrayBlock(valueType, values);
 
         checkCondition(keyBlock.getPositionCount() == valueBlock.getPositionCount(), INVALID_FUNCTION_ARGUMENT, "Key and value arrays must be the same length");
         for (int i = 0; i < keyBlock.getPositionCount(); i++) {
             if (keyBlock.isNull(i)) {
                 throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "map key cannot be null");
             }
-            keyType.appendTo(keyBlock, i, blockBuilder);
-            valueType.appendTo(valueBlock, i, blockBuilder);
         }
 
-        return buildStructuralSlice(blockBuilder);
+        return buildMapSlice(keyBlock, valueBlock);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapKeys.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapKeys.java
@@ -18,9 +18,6 @@ import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.ParametricScalar;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableList;
@@ -32,7 +29,7 @@ import java.util.Map;
 import static com.facebook.presto.metadata.Signature.typeParameter;
 import static com.facebook.presto.type.TypeUtils.buildStructuralSlice;
 import static com.facebook.presto.type.TypeUtils.parameterizedTypeName;
-import static com.facebook.presto.type.TypeUtils.readStructuralBlock;
+import static com.facebook.presto.type.TypeUtils.readMapBlocks;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -41,7 +38,7 @@ public class MapKeys
 {
     public static final MapKeys MAP_KEYS = new MapKeys();
     private static final Signature SIGNATURE = new Signature("map_keys", ImmutableList.of(typeParameter("K"), typeParameter("V")), "array<K>", ImmutableList.of("map<K,V>"), false, false);
-    private static final MethodHandle METHOD_HANDLE = methodHandle(MapKeys.class, "getKeys", Type.class, Slice.class);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(MapKeys.class, "getKeys", Type.class, Type.class, Slice.class);
 
     @Override
     public Signature getSignature()
@@ -73,20 +70,16 @@ public class MapKeys
         checkArgument(arity == 1, "map_keys expects only one argument");
         Type keyType = types.get("K");
         Type valueType = types.get("V");
-        MethodHandle methodHandle = METHOD_HANDLE.bindTo(keyType);
+        MethodHandle methodHandle = METHOD_HANDLE.bindTo(keyType).bindTo(valueType);
         Signature signature = new Signature("map_keys",
                 parameterizedTypeName("array", keyType.getTypeSignature()),
                 parameterizedTypeName("map", keyType.getTypeSignature(), valueType.getTypeSignature()));
         return new FunctionInfo(signature, getDescription(), isHidden(), methodHandle, isDeterministic(), true, ImmutableList.of(false));
     }
 
-    public static Slice getKeys(Type keyType, Slice map)
+    public static Slice getKeys(Type keyType, Type valueType, Slice map)
     {
-        Block block = readStructuralBlock(map);
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), block.getSizeInBytes());
-        for (int i = 0; i < block.getPositionCount(); i += 2) {
-            keyType.appendTo(block, i, blockBuilder);
-        }
-        return buildStructuralSlice(blockBuilder);
+        Block[] blocks = readMapBlocks(keyType, valueType, map);
+        return buildStructuralSlice(blocks[0]);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowFieldAccessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowFieldAccessor.java
@@ -30,8 +30,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.metadata.FunctionRegistry.mangleFieldAccessor;
-import static com.facebook.presto.type.TypeUtils.readStructuralBlock;
 import static com.facebook.presto.type.RowType.RowField;
+import static com.facebook.presto.type.TypeUtils.readRowBlock;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -104,21 +104,21 @@ public class RowFieldAccessor
 
     public static Long longAccessor(Type type, Integer field, Slice row)
     {
-        return type.getLong(readStructuralBlock(row), field);
+        return type.getLong(readRowBlock(row), field);
     }
 
     public static Boolean booleanAccessor(Type type, Integer field, Slice row)
     {
-        return type.getBoolean(readStructuralBlock(row), field);
+        return type.getBoolean(readRowBlock(row), field);
     }
 
     public static Double doubleAccessor(Type type, Integer field, Slice row)
     {
-        return type.getDouble(readStructuralBlock(row), field);
+        return type.getDouble(readRowBlock(row), field);
     }
 
     public static Slice sliceAccessor(Type type, Integer field, Slice row)
     {
-        return type.getSlice(readStructuralBlock(row), field);
+        return type.getSlice(readRowBlock(row), field);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/RowType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RowType.java
@@ -33,7 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.type.TypeUtils.readStructuralBlock;
+import static com.facebook.presto.type.TypeUtils.readRowBlock;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -88,7 +88,7 @@ public class RowType
         }
 
         Slice slice = getSlice(block, position);
-        Block arrayBlock = readStructuralBlock(slice);
+        Block arrayBlock = readRowBlock(slice);
         List<Object> values = Lists.newArrayListWithCapacity(arrayBlock.getPositionCount());
 
         for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
@@ -181,8 +181,8 @@ public class RowType
     {
         Slice leftSlice = getSlice(leftBlock, leftPosition);
         Slice rightSlice = getSlice(rightBlock, rightPosition);
-        Block leftArray = readStructuralBlock(leftSlice);
-        Block rightArray = readStructuralBlock(rightSlice);
+        Block leftArray = readRowBlock(leftSlice);
+        Block rightArray = readRowBlock(rightSlice);
 
         for (int i = 0; i < leftArray.getPositionCount(); i++) {
             checkElementNotNull(leftArray.isNull(i));
@@ -200,7 +200,7 @@ public class RowType
     public int hash(Block block, int position)
     {
         Slice value = getSlice(block, position);
-        Block arrayBlock = readStructuralBlock(value);
+        Block arrayBlock = readRowBlock(value);
         int result = 1;
         for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
             checkElementNotNull(arrayBlock.isNull(i));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -85,21 +85,18 @@ public class TestArrayOperators
 
         DynamicSliceOutput output = new DynamicSliceOutput(100);
         output.appendInt(2) // size of root array
-                .appendInt(33) // length of the first sub array bytes
-                .appendInt(21) // length of the second sub array bytes
+                .appendInt(25) // length of the first sub array bytes
+                .appendInt(17) // length of the second sub array bytes
                 .appendByte(0) // null flags
-                .appendInt(54) // length of root array bytes
+                .appendInt(42) // length of root array bytes
 
                     .appendInt(2) // size of the first array
-                    .appendInt(8) // length of long value 1
-                    .appendInt(8) // length of long value 2
                     .appendByte(0) // null flags
                     .appendInt(16) // length of values
                     .appendLong(1) // value 1
                     .appendLong(2) // value 2
 
                     .appendInt(1) // size of the second array
-                    .appendInt(8) // length of long value 3
                     .appendByte(0) // null flags
                     .appendInt(8) // length of values
                     .appendLong(3); // value 3

--- a/presto-main/src/test/java/com/facebook/presto/type/TestBigintArrayType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestBigintArrayType.java
@@ -16,7 +16,6 @@ package com.facebook.presto.type;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
@@ -27,7 +26,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.type.ArrayType.toStackRepresentation;
 import static com.facebook.presto.type.TypeUtils.buildStructuralSlice;
-import static com.facebook.presto.type.TypeUtils.readStructuralBlock;
+import static com.facebook.presto.type.TypeUtils.readArrayBlock;
 
 public class TestBigintArrayType
         extends AbstractTestType
@@ -50,8 +49,8 @@ public class TestBigintArrayType
     @Override
     protected Object getGreaterValue(Object value)
     {
-        Block block = readStructuralBlock(((Slice) value));
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), block.getSizeInBytes() + 8);
+        Block block = readArrayBlock(BIGINT, ((Slice) value));
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             BIGINT.appendTo(block, i, blockBuilder);
         }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -76,20 +76,20 @@ public class TestMapOperators
         Slice slice = toStackRepresentation(ImmutableMap.of(1.0, array), DoubleType.DOUBLE, new ArrayType(BigintType.BIGINT));
 
         DynamicSliceOutput output = new DynamicSliceOutput(100);
-        output.appendInt(2) // size of map * 2
-                .appendInt(8) // length of double value 1.0
-                .appendInt(33) // length of array
+        output.appendInt(1) // number of element
                 .appendByte(0) // null flags
-                .appendInt(41) // length of data
+                .appendInt(8) // length of data
                 .appendDouble(1.0) // value 1
-
-                .appendInt(2)
-                .appendInt(8)
-                .appendInt(8)
-                .appendByte(0)
-                .appendInt(16)
-                .appendLong(1)
-                .appendLong(2);
+                // encoded value block
+                .appendInt(1) // number of element
+                .appendInt(25)
+                .appendByte(0) // null flags
+                    .appendInt(25)
+                    .appendInt(2)
+                    .appendByte(0)
+                    .appendInt(16)
+                    .appendLong(1)
+                    .appendLong(2);
 
         assertEquals(slice, output.slice());
     }

--- a/presto-ml/src/main/java/com/facebook/presto/ml/MLFunctions.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/MLFunctions.java
@@ -17,7 +17,6 @@ import com.facebook.presto.ml.type.RegressorType;
 import com.facebook.presto.operator.scalar.ScalarFunction;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.StandardTypes;
@@ -31,7 +30,7 @@ import io.airlift.slice.Slices;
 import static com.facebook.presto.ml.type.ClassifierType.BIGINT_CLASSIFIER;
 import static com.facebook.presto.ml.type.ClassifierType.VARCHAR_CLASSIFIER;
 import static com.facebook.presto.ml.type.RegressorType.REGRESSOR;
-import static com.facebook.presto.type.TypeUtils.buildStructuralSlice;
+import static com.facebook.presto.type.TypeUtils.buildMapSlice;
 import static com.facebook.presto.util.Types.checkType;
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -162,13 +161,14 @@ public final class MLFunctions
 
     private static Slice featuresHelper(double... features)
     {
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), features.length * (8 + 8));
+        BlockBuilder keyBuilder = BigintType.BIGINT.createBlockBuilder(new BlockBuilderStatus(), features.length);
+        BlockBuilder valueBuilder = DoubleType.DOUBLE.createBlockBuilder(new BlockBuilderStatus(), features.length);
 
         for (int i = 0; i < features.length; i++) {
-            BigintType.BIGINT.writeLong(blockBuilder, i);
-            DoubleType.DOUBLE.writeDouble(blockBuilder, features[i]);
+            BigintType.BIGINT.writeLong(keyBuilder, i);
+            DoubleType.DOUBLE.writeDouble(valueBuilder, features[i]);
         }
 
-        return buildStructuralSlice(blockBuilder);
+        return buildMapSlice(keyBuilder, valueBuilder);
     }
 }

--- a/presto-ml/src/main/java/com/facebook/presto/ml/ModelUtils.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/ModelUtils.java
@@ -31,9 +31,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.facebook.presto.type.TypeUtils.readStructuralBlock;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.type.TypeUtils.readMapBlocks;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -207,9 +207,9 @@ public final class ModelUtils
         Map<Integer, Double> features = new HashMap<>();
 
         if (map != Slices.EMPTY_SLICE) {
-            Block block = readStructuralBlock(map);
-            for (int position = 0; position < block.getPositionCount(); position += 2) {
-                features.put((int) BIGINT.getLong(block, position), DOUBLE.getDouble(block, position + 1));
+            Block[] blocks = readMapBlocks(BIGINT, DOUBLE, map);
+            for (int position = 0; position < blocks[0].getPositionCount(); position++) {
+                features.put((int) BIGINT.getLong(blocks[0], position), DOUBLE.getDouble(blocks[1], position));
             }
         }
         return new FeatureVector(features);

--- a/presto-ml/src/test/java/com/facebook/presto/ml/TestLearnAggregations.java
+++ b/presto-ml/src/test/java/com/facebook/presto/ml/TestLearnAggregations.java
@@ -25,7 +25,6 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.StandardTypes;
@@ -43,7 +42,7 @@ import java.util.Random;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.type.TypeUtils.appendToBlockBuilder;
-import static com.facebook.presto.type.TypeUtils.buildStructuralSlice;
+import static com.facebook.presto.type.TypeUtils.buildMapSlice;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -107,9 +106,11 @@ public class TestLearnAggregations
 
     private static Slice mapSliceOf(Type keyType, Type valueType, Object key, Object value)
     {
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), 1024);
-        appendToBlockBuilder(keyType, key, blockBuilder);
-        appendToBlockBuilder(valueType, value, blockBuilder);
-        return buildStructuralSlice(blockBuilder);
+        BlockBuilder keyBuilder = keyType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder valueBuilder = valueType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        appendToBlockBuilder(keyType, key, keyBuilder);
+        appendToBlockBuilder(valueType, value, valueBuilder);
+
+        return buildMapSlice(keyBuilder, valueBuilder);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -19,6 +19,7 @@ import com.facebook.presto.orc.metadata.Metadata;
 import com.facebook.presto.orc.metadata.MetadataReader;
 import com.facebook.presto.orc.metadata.PostScript;
 import com.facebook.presto.orc.stream.OrcInputStream;
+import com.facebook.presto.spi.type.Type;
 import com.google.common.base.Joiner;
 import com.google.common.primitives.Ints;
 import io.airlift.log.Logger;
@@ -29,7 +30,7 @@ import org.joda.time.DateTimeZone;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
@@ -152,14 +153,14 @@ public class OrcReader
         return bufferSize;
     }
 
-    public OrcRecordReader createRecordReader(Set<Integer> includedColumns, OrcPredicate predicate, DateTimeZone hiveStorageTimeZone)
+    public OrcRecordReader createRecordReader(Map<Integer, Type> includedColumns, OrcPredicate predicate, DateTimeZone hiveStorageTimeZone)
             throws IOException
     {
         return createRecordReader(includedColumns, predicate, 0, orcDataSource.getSize(), hiveStorageTimeZone);
     }
 
     public OrcRecordReader createRecordReader(
-            Set<Integer> includedColumns,
+            Map<Integer, Type> includedColumns,
             OrcPredicate predicate,
             long offset,
             long length,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/block/BlockReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/block/BlockReader.java
@@ -38,5 +38,5 @@ public interface BlockReader
     default Slice toSlice()
     {
         throw new UnsupportedOperationException();
-    };
+    }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/block/BlockReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/block/BlockReaders.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc.block;
 
 import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTimeZone;
 
 public final class BlockReaders
@@ -25,7 +26,8 @@ public final class BlockReaders
     public static BlockReader createBlockReader(
             StreamDescriptor streamDescriptor,
             boolean checkForNulls,
-            DateTimeZone hiveStorageTimeZone)
+            DateTimeZone hiveStorageTimeZone,
+            Type type)
     {
         switch (streamDescriptor.getStreamType()) {
             case BOOLEAN:
@@ -48,11 +50,11 @@ public final class BlockReaders
             case DATE:
                 return new DateBlockReader(streamDescriptor);
             case STRUCT:
-                return new StructBlockReader(streamDescriptor, checkForNulls, hiveStorageTimeZone);
+                return new StructBlockReader(streamDescriptor, checkForNulls, hiveStorageTimeZone, type);
             case LIST:
-                return new ListBlockReader(streamDescriptor, checkForNulls, hiveStorageTimeZone);
+                return new ListBlockReader(streamDescriptor, checkForNulls, hiveStorageTimeZone, type);
             case MAP:
-                return new MapBlockReader(streamDescriptor, checkForNulls, hiveStorageTimeZone);
+                return new MapBlockReader(streamDescriptor, checkForNulls, hiveStorageTimeZone, type);
             case UNION:
             case DECIMAL:
             case VARCHAR:

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BlockStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BlockStreamReader.java
@@ -21,6 +21,7 @@ import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanStream;
 import com.facebook.presto.orc.stream.StreamSource;
 import com.facebook.presto.orc.stream.StreamSources;
+import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTimeZone;
 
 import javax.annotation.Nonnull;
@@ -62,10 +63,10 @@ public class BlockStreamReader
 
     private List<ColumnEncoding> encoding;
 
-    public BlockStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+    public BlockStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone, Type type)
     {
         this.streamDescriptor = checkNotNull(streamDescriptor, "stream is null");
-        this.blockReader = createBlockReader(streamDescriptor, false, hiveStorageTimeZone);
+        this.blockReader = createBlockReader(streamDescriptor, false, hiveStorageTimeZone, type);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StreamReaders.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc.reader;
 
 import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTimeZone;
 
 public final class StreamReaders
@@ -22,7 +23,7 @@ public final class StreamReaders
     {
     }
 
-    public static StreamReader createStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+    public static StreamReader createStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone, Type type)
     {
         switch (streamDescriptor.getStreamType()) {
             case BOOLEAN:
@@ -46,7 +47,7 @@ public final class StreamReaders
             case STRUCT:
             case LIST:
             case MAP:
-                return new BlockStreamReader(streamDescriptor, hiveStorageTimeZone);
+                return new BlockStreamReader(streamDescriptor, hiveStorageTimeZone, type);
             case UNION:
             case DECIMAL:
             case VARCHAR:

--- a/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
@@ -245,10 +245,10 @@ public abstract class AbstractTestOrcReader
                         Collections.nCopies(1_000_000, null))),
                 200_000);
 
-        tester.assertRoundTrip(javaIntObjectInspector, values, transform(values, value -> value == null ? null : (long) value));
+        tester.assertRoundTrip(javaIntObjectInspector, values, transform(values, value -> value == null ? null : (long) value), BIGINT);
 
         Iterable<String> stringValue = transform(values, value -> value == null ? null : String.valueOf(value));
-        tester.assertRoundTrip(javaStringObjectInspector, stringValue, stringValue);
+        tester.assertRoundTrip(javaStringObjectInspector, stringValue, stringValue, VARCHAR);
     }
 
     @Test

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -124,8 +124,9 @@ public class OrcStorageManager
             OrcReader reader = new OrcReader(dataSource, new OrcMetadataReader());
 
             Map<Long, Integer> indexMap = columnIdIndex(reader.getColumnNames());
-            ImmutableSet.Builder<Integer> includedColumns = ImmutableSet.builder();
+            ImmutableMap.Builder<Integer, Type> includedColumns = ImmutableMap.builder();
             ImmutableList.Builder<Integer> columnIndexes = ImmutableList.builder();
+            int typeIndex = 0;
             for (long columnId : columnIds) {
                 Integer index = indexMap.get(columnId);
                 if (index == null) {
@@ -133,8 +134,9 @@ public class OrcStorageManager
                 }
                 else {
                     columnIndexes.add(index);
-                    includedColumns.add(index);
+                    includedColumns.put(index, columnTypes.get(typeIndex));
                 }
+                typeIndex++;
             }
 
             OrcPredicate predicate = getPredicate(effectivePredicate, indexMap);

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardStats.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardStats.java
@@ -29,13 +29,13 @@ import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_ERROR;
 import static java.lang.Double.isInfinite;
@@ -69,7 +69,7 @@ public final class ShardStats
             throws IOException
     {
         int columnIndex = columnIndex(orcReader.getColumnNames(), columnId);
-        Set<Integer> includedColumns = ImmutableSet.of(columnIndex);
+        Map<Integer, Type> includedColumns = ImmutableMap.of(columnIndex, type);
         OrcRecordReader reader = orcReader.createRecordReader(includedColumns, OrcPredicate.TRUE, UTC);
 
         if (type.equals(BooleanType.BOOLEAN)) {

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
@@ -18,13 +18,14 @@ import com.facebook.presto.orc.OrcPredicate;
 import com.facebook.presto.orc.OrcReader;
 import com.facebook.presto.orc.OrcRecordReader;
 import com.facebook.presto.orc.metadata.OrcMetadataReader;
-import com.google.common.collect.ImmutableSet;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.testng.Assert.assertEquals;
@@ -33,7 +34,7 @@ final class OrcTestingUtil
 {
     private OrcTestingUtil() {}
 
-    public static OrcRecordReader createReader(OrcDataSource dataSource, List<Long> columnIds)
+    public static OrcRecordReader createReader(OrcDataSource dataSource, List<Long> columnIds, List<Type> types)
             throws IOException
     {
         OrcReader orcReader = new OrcReader(dataSource, new OrcMetadataReader());
@@ -41,11 +42,11 @@ final class OrcTestingUtil
         List<String> columnNames = orcReader.getColumnNames();
         assertEquals(columnNames.size(), columnIds.size());
 
-        Set<Integer> includedColumns = new HashSet<>();
+        Map<Integer, Type> includedColumns = new HashMap<>();
         int ordinal = 0;
         for (long columnId : columnIds) {
             assertEquals(columnNames.get(ordinal), String.valueOf(columnId));
-            includedColumns.add(ordinal);
+            includedColumns.put(ordinal, types.get(ordinal));
             ordinal++;
         }
 
@@ -59,10 +60,10 @@ final class OrcTestingUtil
 
         assertEquals(orcReader.getColumnNames().size(), 0);
 
-        return createRecordReader(orcReader, ImmutableSet.of());
+        return createRecordReader(orcReader, ImmutableMap.of());
     }
 
-    public static OrcRecordReader createRecordReader(OrcReader orcReader, Set<Integer> includedColumns)
+    public static OrcRecordReader createRecordReader(OrcReader orcReader, Map<Integer, Type> includedColumns)
             throws IOException
     {
         return orcReader.createRecordReader(includedColumns, OrcPredicate.TRUE, DateTimeZone.UTC);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
@@ -186,7 +186,7 @@ public class TestOrcStorageManager
         recoveryManager.restoreFromBackup(shardUuid);
 
         try (OrcDataSource dataSource = manager.openShard(shardUuid)) {
-            OrcRecordReader reader = createReader(dataSource, columnIds);
+            OrcRecordReader reader = createReader(dataSource, columnIds, columnTypes);
 
             assertEquals(reader.nextBatch(), 2);
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardWriter.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardWriter.java
@@ -86,7 +86,7 @@ public class TestShardWriter
         }
 
         try (FileOrcDataSource dataSource = new FileOrcDataSource(file, new DataSize(1, Unit.MEGABYTE))) {
-            OrcRecordReader reader = createReader(dataSource, columnIds);
+            OrcRecordReader reader = createReader(dataSource, columnIds, columnTypes);
             assertEquals(reader.getTotalRowCount(), 3);
             assertEquals(reader.getPosition(), 0);
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractFixedWidthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractFixedWidthType.java
@@ -16,7 +16,9 @@ package com.facebook.presto.spi.type;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.BlockEncoding;
 import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
+import com.facebook.presto.spi.block.FixedWidthBlockEncoding;
 import io.airlift.slice.Slice;
 
 public abstract class AbstractFixedWidthType
@@ -59,5 +61,11 @@ public abstract class AbstractFixedWidthType
     public final Slice getSlice(Block block, int position)
     {
         return block.getSlice(position, 0, getFixedSize());
+    }
+
+    @Override
+    public BlockEncoding getEncoding()
+    {
+        return new FixedWidthBlockEncoding(fixedSize);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractType.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockEncoding;
 import io.airlift.slice.Slice;
 
 import java.util.ArrayList;
@@ -137,6 +138,12 @@ public abstract class AbstractType
 
     @Override
     public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BlockEncoding getEncoding()
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractVariableWidthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractVariableWidthType.java
@@ -15,7 +15,9 @@ package com.facebook.presto.spi.type;
 
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.BlockEncoding;
 import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
+import com.facebook.presto.spi.block.VariableWidthBlockEncoding;
 
 public abstract class AbstractVariableWidthType
         extends AbstractType
@@ -38,5 +40,11 @@ public abstract class AbstractVariableWidthType
     public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
         return createBlockBuilder(blockBuilderStatus, expectedEntries, EXPECTED_BYTES_PER_ENTRY);
+    }
+
+    @Override
+    public BlockEncoding getEncoding()
+    {
+        return new VariableWidthBlockEncoding();
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/Type.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/Type.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.BlockEncoding;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.airlift.slice.Slice;
 
@@ -141,4 +142,9 @@ public interface Type
      * Compare the values in the specified block at the specified positions equal.
      */
     int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition);
+
+    /**
+     * Get the encoding for this type.
+     */
+    BlockEncoding getEncoding();
 }


### PR DESCRIPTION
Currently Array, Map and Row types' encodings are based on VariableWidthBlockEncoding regardless their containg types.
This is basically simple and easy to understand and implement.
But in some cases, ex an array of BIGINT, using VariableWidthBlockEncoding could waste space and computation time.
Even if the overhead is very little, we can avoid it by using containg types' block encodings.

There is no change at Row type as it's tuple of mixed types, but there would be a fundamental change at the Map type.
Before this, Map type was list of [k1,v1,k2,v2,...] encoded with VariableWidthBlockEncoding.
Now Map type is concated bytes of [k1,k2,...][v1,v2,...] encoded with each types' encoding.