### PR TITLE
Add string statistics to Orc reader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.orc;
 
-import com.facebook.presto.hive.$internal.com.google.common.annotations.VisibleForTesting;
 import com.facebook.presto.orc.metadata.BooleanStatistics;
 import com.facebook.presto.orc.metadata.ColumnStatistics;
 import com.facebook.presto.orc.metadata.RangeStatistics;
@@ -23,6 +22,7 @@ import com.facebook.presto.spi.SortedRangeSet;
 import com.facebook.presto.spi.TupleDomain;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Primitives;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 
 import java.util.List;
 import java.util.Map;
@@ -115,7 +114,7 @@ public class TupleDomainOrcPredicate<C>
             return createDomain(boxedJavaType, hasNullValue, columnStatistics.getDoubleStatistics());
         }
         else if (boxedJavaType == Slice.class && columnStatistics.getStringStatistics() != null) {
-            return createDomain(boxedJavaType, hasNullValue, columnStatistics.getStringStatistics(), Slices::utf8Slice);
+            return createDomain(boxedJavaType, hasNullValue, columnStatistics.getStringStatistics());
         }
         return Domain.create(SortedRangeSet.all(boxedJavaType), hasNullValue);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.primitives.Ints;
 import com.google.protobuf.CodedInputStream;
+import io.airlift.slice.Slice;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,9 +31,10 @@ import java.util.List;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static com.facebook.presto.orc.metadata.CompressionKind.UNCOMPRESSED;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZLIB;
+import static com.facebook.presto.orc.metadata.OrcMetadataReader.getMaxSlice;
+import static com.facebook.presto.orc.metadata.OrcMetadataReader.getMinSlice;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static io.airlift.slice.Slices.utf8Slice;
 
 public class DwrfMetadataReader
         implements MetadataReader
@@ -216,15 +218,10 @@ public class DwrfMetadataReader
             return null;
         }
 
-        // temporarily disable string statistics until we figure out the implications of how UTF-16
-        // strings are compared when they contain surrogate pairs and replacement characters
-        if (true) {
-            return null;
-        }
+        Slice minimum = stringStatistics.hasMinimum() ? getMinSlice(stringStatistics.getMinimum()) : null;
+        Slice maximum = stringStatistics.hasMaximum() ? getMaxSlice(stringStatistics.getMaximum()) : null;
 
-        return new StringStatistics(
-                stringStatistics.hasMinimum() ? utf8Slice(stringStatistics.getMinimum()) : null,
-                stringStatistics.hasMaximum() ? utf8Slice(stringStatistics.getMaximum()) : null);
+        return new StringStatistics(minimum, maximum);
     }
 
     private static OrcType toType(OrcProto.Type type)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -32,6 +32,7 @@ import static com.facebook.presto.orc.metadata.CompressionKind.UNCOMPRESSED;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZLIB;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.Slices.utf8Slice;
 
 public class DwrfMetadataReader
         implements MetadataReader
@@ -222,8 +223,8 @@ public class DwrfMetadataReader
         }
 
         return new StringStatistics(
-                stringStatistics.hasMinimum() ? stringStatistics.getMinimum() : null,
-                stringStatistics.hasMaximum() ? stringStatistics.getMaximum() : null);
+                stringStatistics.hasMinimum() ? utf8Slice(stringStatistics.getMinimum()) : null,
+                stringStatistics.hasMaximum() ? utf8Slice(stringStatistics.getMaximum()) : null);
     }
 
     private static OrcType toType(OrcProto.Type type)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -31,6 +31,7 @@ import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static com.facebook.presto.orc.metadata.CompressionKind.UNCOMPRESSED;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZLIB;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.Slices.utf8Slice;
 
 public class OrcMetadataReader
         implements MetadataReader
@@ -226,8 +227,8 @@ public class OrcMetadataReader
         }
 
         return new StringStatistics(
-                stringStatistics.hasMinimum() ? stringStatistics.getMinimum() : null,
-                stringStatistics.hasMaximum() ? stringStatistics.getMaximum() : null);
+                stringStatistics.hasMinimum() ? utf8Slice(stringStatistics.getMinimum()) : null,
+                stringStatistics.hasMaximum() ? utf8Slice(stringStatistics.getMaximum()) : null);
     }
 
     private static DateStatistics toDateStatistics(OrcProto.DateStatistics dateStatistics, boolean isRowGroup)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/StringStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/StringStatistics.java
@@ -13,26 +13,28 @@
  */
 package com.facebook.presto.orc.metadata;
 
-public class StringStatistics
-        implements RangeStatistics<String>
-{
-    private final String minimum;
-    private final String maximum;
+import io.airlift.slice.Slice;
 
-    public StringStatistics(String minimum, String maximum)
+public class StringStatistics
+        implements RangeStatistics<Slice>
+{
+    private final Slice minimum;
+    private final Slice maximum;
+
+    public StringStatistics(Slice minimum, Slice maximum)
     {
         this.minimum = minimum;
         this.maximum = maximum;
     }
 
     @Override
-    public String getMin()
+    public Slice getMin()
     {
         return minimum;
     }
 
     @Override
-    public String getMax()
+    public Slice getMax()
     {
         return maximum;
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
@@ -180,6 +180,13 @@ public abstract class AbstractTestOrcReader
     }
 
     @Test
+    public void testDoubleNaNInfinity()
+            throws Exception
+    {
+        tester.testRoundTrip(javaDoubleObjectInspector, ImmutableList.of(Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY), DOUBLE);
+    }
+
+    @Test
     public void testStringDirectSequence()
             throws Exception
     {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
@@ -187,6 +187,13 @@ public abstract class AbstractTestOrcReader
     }
 
     @Test
+    public void testStringUnicode()
+            throws Exception
+    {
+        tester.testRoundTrip(javaStringObjectInspector, limit(cycle(ImmutableList.of("apple", "apple pie", "apple\uD835\uDC03", "apple\uFFFD")), 30_000), VARCHAR);
+    }
+
+    @Test
     public void testStringDirectSequence()
             throws Exception
     {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -124,7 +124,7 @@ public class OrcTester
         orcTester.listTestsEnabled = true;
         orcTester.nullTestsEnabled = true;
         orcTester.skipBatchTestsEnabled = true;
-        orcTester.formats = ImmutableSet.of(DWRF);
+        orcTester.formats = ImmutableSet.of(ORC_12);
         orcTester.compressions = ImmutableSet.of(ZLIB);
         return orcTester;
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.Domain;
 import com.facebook.presto.spi.Range;
 import com.facebook.presto.spi.SortedRangeSet;
 import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.orc.TupleDomainOrcPredicate.getDomain;
@@ -164,7 +165,9 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics stringColumnStats(Long numberOfValues, String minimum, String maximum)
     {
-        return new ColumnStatistics(numberOfValues, null, null, null, new StringStatistics(minimum, maximum), null);
+        Slice minSlice = (minimum == null ? null : Slices.utf8Slice(minimum));
+        Slice maxSlice = (maximum == null ? null : Slices.utf8Slice(maximum));
+        return new ColumnStatistics(numberOfValues, null, null, null, new StringStatistics(minSlice, maxSlice), null);
     }
 
     @Test

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
@@ -23,10 +23,11 @@ import com.facebook.presto.spi.Domain;
 import com.facebook.presto.spi.Range;
 import com.facebook.presto.spi.SortedRangeSet;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.orc.TupleDomainOrcPredicate.getDomain;
+import static com.facebook.presto.orc.metadata.OrcMetadataReader.getMaxSlice;
+import static com.facebook.presto.orc.metadata.OrcMetadataReader.getMinSlice;
 import static com.facebook.presto.spi.Domain.all;
 import static com.facebook.presto.spi.Domain.create;
 import static com.facebook.presto.spi.Domain.none;
@@ -165,9 +166,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics stringColumnStats(Long numberOfValues, String minimum, String maximum)
     {
-        Slice minSlice = (minimum == null ? null : Slices.utf8Slice(minimum));
-        Slice maxSlice = (maximum == null ? null : Slices.utf8Slice(maximum));
-        return new ColumnStatistics(numberOfValues, null, null, null, new StringStatistics(minSlice, maxSlice), null);
+        return new ColumnStatistics(numberOfValues, null, null, null, new StringStatistics(getMinSlice(minimum), getMaxSlice(maximum)), null);
     }
 
     @Test

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc;
 import com.facebook.presto.orc.metadata.ColumnStatistics;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
+import io.airlift.slice.Slices;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
@@ -269,12 +270,12 @@ public final class TestingOrcPredicate
             // statistics can be missing for any reason
             if (columnStatistics.getStringStatistics() != null) {
                 // verify min
-                if (!columnStatistics.getStringStatistics().getMin().equals(Ordering.natural().nullsLast().min(chunk))) {
+                if (!columnStatistics.getStringStatistics().getMin().equals(Slices.utf8Slice(Ordering.natural().nullsLast().min(chunk)))) {
                     return false;
                 }
 
                 // verify max
-                if (!columnStatistics.getStringStatistics().getMax().equals(Ordering.natural().nullsFirst().max(chunk))) {
+                if (!columnStatistics.getStringStatistics().getMax().equals(Slices.utf8Slice(Ordering.natural().nullsFirst().max(chunk)))) {
                     return false;
                 }
             }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestOrcMetadataReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestOrcMetadataReader.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.orc.metadata.OrcMetadataReader.concatSlices;
+import static com.facebook.presto.orc.metadata.OrcMetadataReader.firstSurrogateCharacter;
+import static com.facebook.presto.orc.metadata.OrcMetadataReader.getMaxSlice;
+import static com.facebook.presto.orc.metadata.OrcMetadataReader.getMinSlice;
+import static java.lang.Character.MAX_CODE_POINT;
+import static java.lang.Character.MIN_CODE_POINT;
+import static org.testng.Assert.assertEquals;
+
+public class TestOrcMetadataReader
+{
+    @Test
+    public void testGetMinSlice()
+            throws Exception
+    {
+        int startCodePoint = MIN_CODE_POINT;
+        int endCodePoint = MAX_CODE_POINT;
+        Slice minSlice = Slices.utf8Slice("");
+
+        for (int i = startCodePoint; i < endCodePoint; i++) {
+            String value = new String(new int[] { i }, 0, 1);
+            if (firstSurrogateCharacter(value) == -1) {
+                assertEquals(getMinSlice(value), Slices.utf8Slice(value));
+            }
+            else {
+                assertEquals(getMinSlice(value), minSlice);
+            }
+        }
+
+        // Test with prefix
+        String prefix = "apple";
+        for (int i = startCodePoint; i < endCodePoint; i++) {
+            String value = prefix + new String(new int[] { i }, 0, 1);
+            if (firstSurrogateCharacter(value) == -1) {
+                assertEquals(getMinSlice(value), Slices.utf8Slice(value));
+            }
+            else {
+                assertEquals(getMinSlice(value), Slices.utf8Slice(prefix));
+            }
+        }
+    }
+
+    @Test
+    public void testGetMaxSlice()
+            throws Exception
+    {
+        int startCodePoint = MIN_CODE_POINT;
+        int endCodePoint = MAX_CODE_POINT;
+        Slice maxByte = Slices.wrappedBuffer(new byte[] { (byte) 0xFF });
+
+        for (int i = startCodePoint; i < endCodePoint; i++) {
+            String value = new String(new int[] { i }, 0, 1);
+            if (firstSurrogateCharacter(value) == -1) {
+                assertEquals(getMaxSlice(value), Slices.utf8Slice(value));
+            }
+            else {
+                assertEquals(getMaxSlice(value), maxByte);
+            }
+        }
+
+        // Test with prefix
+        String prefix = "apple";
+        Slice maxSlice = concatSlices(Slices.utf8Slice(prefix), maxByte);
+        for (int i = startCodePoint; i < endCodePoint; i++) {
+            String value = prefix + new String(new int[] { i }, 0, 1);
+            if (firstSurrogateCharacter(value) == -1) {
+                assertEquals(getMaxSlice(value), Slices.utf8Slice(value));
+            }
+            else {
+                assertEquals(getMaxSlice(value), maxSlice);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Quoting @martint  from an earlier PR: 

The writer performs comparisons using java Strings to determine the minimum and maximum
values. This results in weird behaviors in the presence of surrogate pairs and special characters.

For example, unicode codepoint 0x1D403 has the following representations:
- UTF-16: [0xD835, 0xDC03]
- UTF-8:  [0xF0, 0x9D, 0x90, 0x83]

while codepoint 0xFFFD (the replacement character) has the following representations:
- UTF-16: [0xFFFD]
- UTF-8:  [0xEF, 0xBF, 0xBD]

when comparisons between strings containing these characters are done with Java Strings (UTF-16),
0x1D403 < 0xFFFD, but when comparisons are done using raw codepoints or UTF-8, 0x1D403 > 0xFFFD

This PR fixes the Orc ColumnStatistics for strings using the following logic: 
- if a min string has a surrogate character, the min string is truncated at the first occurrence of the  surrogate character (to exclude the surrogate character)
- if a max string has a surrogate character, the max string is truncated at the first occurrence the surrogate character and 0xFF byte is appended to it.