### PR TITLE
Add session property to set task.writer-count

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -19,7 +19,7 @@ public final class SystemSessionProperties
     private static final String OPTIMIZE_HASH_GENERATION = "optimize_hash_generation";
     private static final String DISTRIBUTED_JOIN = "distributed_join";
     private static final String HASH_PARTITION_COUNT = "hash_partition_count";
-    private static final String TASK_WRITER_COUNT = "task_writer_count";
+    private static final String WRITER_COUNT = "writer_count";
 
     private SystemSessionProperties() {}
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -19,6 +19,7 @@ public final class SystemSessionProperties
     private static final String OPTIMIZE_HASH_GENERATION = "optimize_hash_generation";
     private static final String DISTRIBUTED_JOIN = "distributed_join";
     private static final String HASH_PARTITION_COUNT = "hash_partition_count";
+    private static final String TASK_WRITER_COUNT = "task_writer_count";
 
     private SystemSessionProperties() {}
 
@@ -64,5 +65,15 @@ public final class SystemSessionProperties
     public static int getHashPartitionCount(Session session, int defaultValue)
     {
         return getNumber(HASH_PARTITION_COUNT, session, defaultValue);
+    }
+
+    public static int getTaskWriterCount(Session session, int defaultValue)
+    {
+        String writerCount = session.getSystemProperties().get(TASK_WRITER_COUNT);
+        if (writerCount == null) {
+            return defaultValue;
+        }
+
+        return Integer.valueOf(writerCount);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -19,7 +19,7 @@ public final class SystemSessionProperties
     private static final String OPTIMIZE_HASH_GENERATION = "optimize_hash_generation";
     private static final String DISTRIBUTED_JOIN = "distributed_join";
     private static final String HASH_PARTITION_COUNT = "hash_partition_count";
-    private static final String WRITER_COUNT = "writer_count";
+    private static final String TASK_WRITER_COUNT = "writer_count";
 
     private SystemSessionProperties() {}
 
@@ -69,6 +69,6 @@ public final class SystemSessionProperties
 
     public static int getTaskWriterCount(Session session, int defaultValue)
     {
-        return getNumber(WRITER_COUNT, session, defaultValue);
+        return getNumber(TASK_WRITER_COUNT, session, defaultValue);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -19,7 +19,7 @@ public final class SystemSessionProperties
     private static final String OPTIMIZE_HASH_GENERATION = "optimize_hash_generation";
     private static final String DISTRIBUTED_JOIN = "distributed_join";
     private static final String HASH_PARTITION_COUNT = "hash_partition_count";
-    private static final String TASK_WRITER_COUNT = "writer_count";
+    private static final String TASK_WRITER_COUNT = "task_writer_count";
 
     private SystemSessionProperties() {}
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -69,11 +69,6 @@ public final class SystemSessionProperties
 
     public static int getTaskWriterCount(Session session, int defaultValue)
     {
-        String writerCount = session.getSystemProperties().get(TASK_WRITER_COUNT);
-        if (writerCount == null) {
-            return defaultValue;
-        }
-
-        return Integer.valueOf(writerCount);
+        return getNumber(WRITER_COUNT, session, defaultValue);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -155,6 +155,7 @@ import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionT
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.CreateHandle;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.InsertHandle;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.WriterTarget;
+import static com.facebook.presto.SystemSessionProperties.getTaskWriterCount;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Functions.forMap;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -1298,7 +1299,7 @@ public class LocalExecutionPlanner
             Optional<Integer> sampleWeightChannel = node.getSampleWeightSymbol().map(exchange::symbolToChannel);
 
             // Set table writer count
-            context.setDriverInstanceCount(writerCount);
+            context.setDriverInstanceCount(getTaskWriterCount(session, writerCount));
 
             List<Integer> inputChannels = node.getColumns().stream()
                     .map(exchange::symbolToChannel)


### PR DESCRIPTION
Sometimes I want to modify this property but I really don't want to restart my cluster.
So I added it to system session property.
@nileema Do you think it's ok?