### PR TITLE
Fix InvalidRange error and SocketTimeoutException in PrestoS3FileSystem

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -524,9 +524,14 @@ public class PrestoS3FileSystem
                 long skip = pos - position;
                 if (skip <= max(in.available(), MAX_SKIP_SIZE.toBytes())) {
                     // already buffered or seek is small enough
-                    if (in.skip(skip) == skip) {
-                        position = pos;
-                        return;
+                    try {
+                        if (in.skip(skip) == skip) {
+                            position = pos;
+                            return;
+                        }
+                    }
+                    catch (IOException ignored) {
+                        // will retry by re-opening the stream
                     }
                 }
             }


### PR DESCRIPTION
This PR fixes the following errors which may happen when querying data in S3 and cause query to fail.

* When calling [S3.getObject(...).withRange(start, end)](https://github.com/facebook/presto/blob/master/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java#L607), if `start` exceeds the length of object, AWS will return an InvalidRange error with status code `416`. This shouldn't cause the query to fail.
* When calling [skip()](https://github.com/facebook/presto/blob/master/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java#L527) on S3 inputstream, sometimes we may get SocketTimeoutException or other I/O exception. This currently cause the whole query to fail, but we can recovery it by reopening the inputstream.