### PR TITLE
Enforce JOINs to have the same output symbols after PredicatePushDown

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
@@ -94,6 +94,7 @@ public class PlanOptimizersFactory
 
         builder.add(new PredicatePushDown(metadata, sqlParser)); // Run predicate push down one more time in case we can leverage new information from layouts' effective predicate
         builder.add(new PruneUnreferencedOutputs());
+        builder.add(new UnaliasSymbolReferences());
         builder.add(new PruneRedundantProjections());
 
         // TODO: consider adding a formal final plan sanitization optimizer that prepares the plan for transmission/execution/logging

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -362,6 +362,12 @@ public class PredicatePushDown
                     criteria = builder.build();
                 }
                 output = new JoinNode(node.getId(), node.getType(), leftSource, rightSource, criteria, node.getLeftHashSymbol(), node.getRightHashSymbol());
+
+                // If more output symbols were added to support the JOIN, project out just the originals symbols
+                if (output.getOutputSymbols().size() > node.getOutputSymbols().size()) {
+                    output = new ProjectNode(idAllocator.getNextId(), output, node.getOutputSymbols().stream()
+                            .collect(Collectors.toMap(key -> key, Symbol::toQualifiedNameReference)));
+                }
             }
             if (!postJoinPredicate.equals(BooleanLiteral.TRUE_LITERAL)) {
                 output = new FilterNode(idAllocator.getNextId(), output, postJoinPredicate);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
@@ -23,6 +23,7 @@ import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @Immutable
@@ -64,6 +65,8 @@ public class ExchangeNode
         checkNotNull(hashSymbol, "hashSymbol is null");
         checkNotNull(outputs, "outputs is null");
         checkNotNull(inputs, "inputs is null");
+        checkArgument(inputs.stream().allMatch(inputSymbols -> inputSymbols.size() == outputs.size()), "Input symbols do not match output symbols");
+        checkArgument(sources.stream().map(PlanNode::getOutputSymbols).allMatch(sourceSymbols -> sourceSymbols.size() == outputs.size()), "Source symbols do not match output symbols");
 
         this.type = type;
         this.sources = sources;


### PR DESCRIPTION
After PredicatePushDown optimizer, JOINs may produce additional output symbols if the JOIN clause was rewritten. This impacts nodes such as ExchangeNode which require that the inputs from each underlying source matches the output.
In this diff, we enforce that JOINs always have the same output symbols after PredicatePushDown. We also add some checks to ExchangeNode to catch when the inputs do not match the outputs.