### PR TITLE
Update cassandra-driver-core version to 2.1.5.

### DIFF
--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <cassandra.version>2.1.0</cassandra.version>
-        <datastax.version>2.1.1</datastax.version>
+        <datastax.version>2.1.5</datastax.version>
     </properties>
 
     <dependencies>

--- a/presto-cassandra/src/test/java/com/datastax/driver/core/RowUtil.java
+++ b/presto-cassandra/src/test/java/com/datastax/driver/core/RowUtil.java
@@ -30,6 +30,6 @@ public final class RowUtil
     {
         ColumnDefinitions definitions = new ColumnDefinitions(new Definition[] {new Definition("keyspace", "table", "column", DataType.ascii())});
         ByteBuffer data = ByteBuffer.wrap(value.getBytes(UTF_8));
-        return ArrayBackedRow.fromData(definitions, protocolVersion, ImmutableList.of(data));
+        return ArrayBackedRow.fromData(definitions, null, ProtocolVersion.fromInt(protocolVersion), ImmutableList.of(data));
     }
 }

--- a/presto-cassandra/src/test/java/com/datastax/driver/core/TestHost.java
+++ b/presto-cassandra/src/test/java/com/datastax/driver/core/TestHost.java
@@ -20,6 +20,6 @@ public class TestHost
 {
     public TestHost(InetSocketAddress address)
     {
-        super(address, new ConvictionPolicy.Simple.Factory());
+        super(address, new ConvictionPolicy.Simple.Factory(), null);
     }
 }


### PR DESCRIPTION
IllegalArgumentException: rpc_address is not a column defined in this metadata affects current 2.1.1 version (https://datastax-oss.atlassian.net/browse/JAVA-546)