### PR TITLE
presto-jdbc: PrestoResultSet.getInt fails with Boolean values

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
@@ -220,7 +220,10 @@ public class PrestoResultSet
             throws SQLException
     {
         Object value = column(columnIndex);
-        return (value != null) ? ((Number) value).intValue() : 0;
+        if (value == null) return 0;
+        if (value instanceof Number) return ((Number) value).intValue();
+        return ((Boolean) value) == true ? 1 : 0;
+
     }
 
     @Override


### PR DESCRIPTION
Check if value is not a boolean. We cannot cast Integer to boolean also I decided to write it instead of creating new method getBoolean. #2732