### PR TITLE
Correct handling of string functions for Unicode (non-ASCII) strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <dep.antlr.version>4.3</dep.antlr.version>
         <dep.airlift.version>0.107</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
+        <dep.slice.version>0.11-SNAPSHOT</dep.slice.version>
 
         <cli.skip-execute>true</cli.skip-execute>
         <cli.main-class>None</cli.main-class>

--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -112,3 +112,19 @@ String Functions
 .. function:: upper(string) -> varchar
 
     Converts ``string`` to uppercase.
+
+.. function:: to_utf8(string) -> varbinary
+
+    Encodes ``string`` into a UTF-8 varbinary representation.
+
+.. function:: from_utf8(binary) -> varchar
+
+    Decodes a UTF-8 encoded string from ``binary``. Invalid UTF-8 sequences
+    are replaced with the Unicode replacement character ``U+FFFD``.
+
+.. function:: from_utf8(binary, replace) -> varchar
+
+    Decodes a UTF-8 encoded string from ``binary``. Invalid UTF-8 sequences
+    are replaced with `replace`. The replacement string `replace` must either
+    be a single character or empty (in which case invalid characters are
+    removed).

--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -10,13 +10,23 @@ The ``||`` operator performs concatenation.
 String Functions
 ----------------
 
-.. warning::
+.. note::
 
-    Currently, all of the string functions work incorrectly for Unicode (non-ASCII)
-    strings. They operate as if strings are a sequence of UTF-8  bytes rather
-    than a sequence of Unicode characters. For example, :func:`length` returns
-    the number of bytes in the UTF-8 representation of the string rather than
-    the number of unicode characters.
+    These functions assume that the input strings contain valid UTF-8 encoded
+    Unicode code points.  There are no explicit checks for valid UTF-8, and
+    the functions may return incorrect results or fail on invalid UTF-8.
+    Invalid UTF-8 data can be corrected with :func:`from_utf8`.
+
+    Additionally, the functions operate on Unicode code points and not user
+    visible *characters* (or *grapheme clusters*).  Some languages combine
+    multiple code points into a single user-perceived *character*, the basic
+    unit of a writing system for a language, but the functions will treat each
+    code point as a separate unit.
+
+    The :func:`lower` and :func:`upper` functions do not perform
+    locale-sensitive, context-sensitive, or one-to-many mappings required for
+    some languages. Specifically, this will return incorrect results for
+    Lithuanian, Turkish and Azeri.
 
 .. function:: chr(n) -> varchar
 
@@ -36,9 +46,15 @@ String Functions
 
     Converts ``string`` to lowercase.
 
+.. note::
+
+    This method does not perform perform locale-sensitive, context-sensitive,
+    or one-to-many mappings required for some languages.  Specifically, this
+    will return incorrect results for Lithuanian, Turkish and Azeri.
+
 .. function:: ltrim(string) -> varchar
 
-    Removes leading spaces from ``string``.
+    Removes leading whitespace from ``string``.
 
 .. function:: replace(string, search) -> varchar
 
@@ -54,7 +70,7 @@ String Functions
 
 .. function:: rtrim(string) -> varchar
 
-    Removes trailing spaces from ``string``.
+    Removes trailing whitespace from ``string``.
 
 .. function:: split(string, delimiter) -> array<varchar>
 
@@ -91,7 +107,7 @@ String Functions
 
 .. function:: trim(string) -> varchar
 
-    Removes leading and trailing spaces from ``string``.
+    Removes leading and trailing whitespace from ``string``.
 
 .. function:: upper(string) -> varchar
 

--- a/presto-docs/src/main/sphinx/release/release-0.102.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.102.rst
@@ -2,10 +2,25 @@
 Release 0.102
 =============
 
+Unicode Support
+---------------
+
+All string functions have been updated to support Unicode. The functions assume
+that the string contains valid UTF-8 encoded code points. There are no explicit
+checks for valid UTF-8, and the functions may return incorrect results or fail on
+invalid UTF-8.  Invalid UTF-8 data can be corrected with :func:`from_utf8`.
+
+Additionally, the functions operate on Unicode code points and not user visible
+*characters* (or *grapheme clusters*).  Some languages combine multiple code points
+into a single user-perceived *character*, the basic unit of a writing system for a
+language, but the functions will treat each code point as a separate unit.
+
+
 General Changes
 ---------------
 
 * Support returning booleans as numbers in JDBC driver
+* Add :func:`from_utf8` and :func:`to_utf8` functions.
 
 Hive Changes
 ------------

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -17,24 +17,33 @@ import com.facebook.presto.operator.Description;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.type.SqlType;
-import com.google.common.base.Ascii;
-import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
+import io.airlift.slice.InvalidCodePointException;
+import io.airlift.slice.InvalidUtf8Exception;
 import io.airlift.slice.Slice;
+import io.airlift.slice.SliceUtf8;
 import io.airlift.slice.Slices;
 
 import javax.annotation.Nullable;
 
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.type.ArrayType.toStackRepresentation;
 import static com.facebook.presto.util.Failures.checkCondition;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static io.airlift.slice.SliceUtf8.countCodePoints;
+import static io.airlift.slice.SliceUtf8.lengthOfCodePoint;
+import static io.airlift.slice.SliceUtf8.offsetOfCodePoint;
+import static io.airlift.slice.SliceUtf8.toLowerCase;
+import static io.airlift.slice.SliceUtf8.toUpperCase;
 
+/**
+ * Current implementation is based on code points from Unicode and does ignore grapheme cluster boundaries.
+ * Therefore only some methods work correctly with grapheme cluster boundaries.
+ */
 public final class StringFunctions
 {
     private StringFunctions() {}
@@ -44,18 +53,11 @@ public final class StringFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice chr(@SqlType(StandardTypes.BIGINT) long codepoint)
     {
-        char[] utf16 = codePointChars(codepoint);
-        ByteBuffer utf8 = UTF_8.encode(CharBuffer.wrap(utf16));
-        return Slices.wrappedBuffer(utf8.array(), 0, utf8.limit());
-    }
-
-    private static char[] codePointChars(long codepoint)
-    {
         try {
-            return Character.toChars(Ints.checkedCast(codepoint));
+            return SliceUtf8.codePointToUtf8(Ints.saturatedCast(codepoint));
         }
-        catch (IllegalArgumentException e) {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Not a valid Unicode code point: " + codepoint);
+        catch (InvalidCodePointException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Not a valid Unicode code point: " + codepoint, e);
         }
     }
 
@@ -70,12 +72,12 @@ public final class StringFunctions
         return concat;
     }
 
-    @Description("length of the given string")
+    @Description("count of code points of the given string")
     @ScalarFunction
     @SqlType(StandardTypes.BIGINT)
     public static long length(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
-        return slice.length();
+        return countCodePoints(slice);
     }
 
     @Description("greedily removes occurrences of a pattern in a string")
@@ -91,22 +93,78 @@ public final class StringFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice replace(@SqlType(StandardTypes.VARCHAR) Slice str, @SqlType(StandardTypes.VARCHAR) Slice search, @SqlType(StandardTypes.VARCHAR) Slice replace)
     {
-        String replaced = str.toString(UTF_8).replace(
-                search.toString(UTF_8),
-                replace.toString(UTF_8));
-        return Slices.copiedBuffer(replaced, UTF_8);
+        // Empty search?
+        if (search.length() == 0) {
+            // With empty `search` we insert `replace` in front of every character and and the end
+            Slice buffer = Slices.allocate((countCodePoints(str) + 1) * replace.length() + str.length());
+            // Always start with replace
+            buffer.setBytes(0, replace);
+            int indexBuffer = replace.length();
+            // After every code point insert `replace`
+            int index = 0;
+            while (index < str.length()) {
+                int startByte = str.getUnsignedByte(index);
+                int codePointLength = lengthOfCodePoint(startByte);
+                // Append current code point
+                buffer.setBytes(indexBuffer, str, index, codePointLength);
+                indexBuffer += codePointLength;
+                // Append `replace`
+                buffer.setBytes(indexBuffer, replace);
+                indexBuffer += replace.length();
+                // Advance pointer to current code point
+                index += codePointLength;
+            }
+
+            return buffer;
+        }
+        // Allocate a reasonable buffer
+        Slice buffer = Slices.allocate(str.length());
+
+        int index = 0;
+        int indexBuffer = 0;
+        while (index < str.length()) {
+            int matchIndex = str.indexOf(search, index);
+            // Found a match?
+            if (matchIndex < 0) {
+                // No match found so copy the rest of string
+                int bytesToCopy = str.length() - index;
+                buffer = Slices.ensureSize(buffer, indexBuffer + bytesToCopy);
+                buffer.setBytes(indexBuffer, str, index, bytesToCopy);
+                indexBuffer += bytesToCopy;
+
+                break;
+            }
+
+            int bytesToCopy = matchIndex - index;
+            buffer = Slices.ensureSize(buffer, indexBuffer + bytesToCopy + replace.length());
+            // Non empty match?
+            if (bytesToCopy > 0) {
+                buffer.setBytes(indexBuffer, str, index, bytesToCopy);
+                indexBuffer += bytesToCopy;
+            }
+            // Non empty replace?
+            if (replace.length() > 0) {
+                buffer.setBytes(indexBuffer, replace);
+                indexBuffer += replace.length();
+            }
+            // Continue searching after match
+            index = matchIndex + search.length();
+        }
+
+        return buffer.slice(0, indexBuffer);
     }
 
-    @Description("reverses the given string")
+    @Description("reverse all code points in a given string")
     @ScalarFunction
     @SqlType(StandardTypes.VARCHAR)
     public static Slice reverse(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
-        Slice reverse = Slices.allocate(slice.length());
-        for (int i = 0, j = slice.length() - 1; i < slice.length(); i++, j--) {
-            reverse.setByte(j, slice.getByte(i));
+        try {
+            return SliceUtf8.reverse(slice);
         }
-        return reverse;
+        catch (InvalidCodePointException | InvalidUtf8Exception e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 
     @Description("returns index of first occurrence of a substring (or 0 if not found)")
@@ -114,66 +172,107 @@ public final class StringFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long stringPosition(@SqlType(StandardTypes.VARCHAR) Slice string, @SqlType(StandardTypes.VARCHAR) Slice substring)
     {
-        if (substring.length() > string.length()) {
+        if (substring.length() == 0) {
+            return 1;
+        }
+
+        int index = string.indexOf(substring);
+        if (index < 0) {
             return 0;
         }
-
-        for (int i = 0; i <= (string.length() - substring.length()); i++) {
-            if (string.equals(i, substring.length(), substring, 0, substring.length())) {
-                return i + 1;
-            }
-        }
-
-        return 0;
+        return countCodePoints(string, 0, index) + 1;
     }
 
     @Description("suffix starting at given index")
     @ScalarFunction
     @SqlType(StandardTypes.VARCHAR)
-    public static Slice substr(@SqlType(StandardTypes.VARCHAR) Slice slice, @SqlType(StandardTypes.BIGINT) long start)
+    public static Slice substr(@SqlType(StandardTypes.VARCHAR) Slice utf8, @SqlType(StandardTypes.BIGINT) long start)
     {
-        return substr(slice, start, slice.length());
+        if ((start == 0) || utf8.length() == 0) {
+            return Slices.EMPTY_SLICE;
+        }
+
+        int startCodePoint = Ints.saturatedCast(start);
+
+        if (startCodePoint > 0) {
+            int indexStart = offsetOfCodePoint(utf8, startCodePoint - 1);
+            if (indexStart < 0) {
+                // before beginning of string
+                return Slices.EMPTY_SLICE;
+            }
+            int indexEnd = utf8.length();
+
+            return utf8.slice(indexStart, indexEnd - indexStart);
+        }
+
+        // negative start is relative to end of string
+        int codePoints = countCodePoints(utf8);
+        startCodePoint += codePoints;
+
+        // before beginning of string
+        if (startCodePoint < 0) {
+            return Slices.EMPTY_SLICE;
+        }
+
+        int indexStart = offsetOfCodePoint(utf8, startCodePoint);
+        int indexEnd = utf8.length();
+
+        return utf8.slice(indexStart, indexEnd - indexStart);
     }
 
     @Description("substring of given length starting at an index")
     @ScalarFunction
     @SqlType(StandardTypes.VARCHAR)
-    public static Slice substr(@SqlType(StandardTypes.VARCHAR) Slice slice, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)
+    public static Slice substr(@SqlType(StandardTypes.VARCHAR) Slice utf8, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)
     {
-        if ((start == 0) || (length <= 0)) {
+        if (start == 0 || (length <= 0) || (utf8.length() == 0)) {
             return Slices.EMPTY_SLICE;
         }
 
-        if (start > 0) {
-            // make start zero-based
-            start--;
-        }
-        else {
-            // negative start is relative to end of string
-            start += slice.length();
-            if (start < 0) {
+        int startCodePoint = Ints.saturatedCast(start);
+        int lengthCodePoints = Ints.saturatedCast(length);
+
+        if (startCodePoint > 0) {
+            int indexStart = offsetOfCodePoint(utf8, startCodePoint - 1);
+            if (indexStart < 0) {
+                // before beginning of string
                 return Slices.EMPTY_SLICE;
             }
+            int indexEnd = offsetOfCodePoint(utf8, indexStart, lengthCodePoints);
+            if (indexEnd < 0) {
+                // after end of string
+                indexEnd = utf8.length();
+            }
+
+            return utf8.slice(indexStart, indexEnd - indexStart);
         }
 
-        if ((start + length) > slice.length()) {
-            length = slice.length() - start;
-        }
+        // negative start is relative to end of string
+        int codePoints = countCodePoints(utf8);
+        startCodePoint += codePoints;
 
-        if (start >= slice.length()) {
+        // before beginning of string
+        if (startCodePoint < 0) {
             return Slices.EMPTY_SLICE;
         }
 
-        return slice.slice((int) start, (int) length);
+        int indexStart = offsetOfCodePoint(utf8, startCodePoint);
+        int indexEnd;
+        if (startCodePoint + lengthCodePoints < codePoints) {
+            indexEnd = offsetOfCodePoint(utf8, indexStart, lengthCodePoints);
+        }
+        else {
+            indexEnd = utf8.length();
+        }
+
+        return utf8.slice(indexStart, indexEnd - indexStart);
     }
 
     @ScalarFunction
     @SqlType("array<varchar>")
     public static Slice split(@SqlType(StandardTypes.VARCHAR) Slice string, @SqlType(StandardTypes.VARCHAR) Slice delimiter)
     {
-        List<String> result = Splitter.on(delimiter.toStringUtf8())
-                .splitToList(string.toStringUtf8());
-        return toStackRepresentation(result, VARCHAR);
+        return split(string, delimiter, string.length() + 1);
     }
 
     @ScalarFunction
@@ -182,13 +281,37 @@ public final class StringFunctions
     {
         checkCondition(limit > 0, INVALID_FUNCTION_ARGUMENT, "Limit must be positive");
         checkCondition(limit <= Integer.MAX_VALUE, INVALID_FUNCTION_ARGUMENT, "Limit is too large");
-        List<String> result = Splitter.on(delimiter.toStringUtf8())
-                .limit((int) limit)
-                .splitToList(string.toStringUtf8());
-        return toStackRepresentation(result, VARCHAR);
+        checkCondition(delimiter.length() > 0, INVALID_FUNCTION_ARGUMENT, "The delimiter may not be the empty string");
+        // If limit is one, the last and only element is the complete string
+        if (limit == 1) {
+            return toStackRepresentation(ImmutableList.of(string), VARCHAR);
+        }
+
+        // todo this should write directly into a block
+        List<Slice> parts = new ArrayList<>();
+
+        int index = 0;
+        while (index < string.length()) {
+            int splitIndex = string.indexOf(delimiter, index);
+            // Found split?
+            if (splitIndex < 0) {
+                break;
+            }
+            // Add the part from current index to found split
+            parts.add(string.slice(index, splitIndex - index));
+            // Continue searching after delimiter
+            index = splitIndex + delimiter.length();
+            // Reached limit-1 parts so we can stop
+            if (parts.size() == limit - 1) {
+                break;
+            }
+        }
+        // Rest of string
+        parts.add(string.slice(index, string.length() - index));
+
+        return toStackRepresentation(parts, VARCHAR);
     }
 
-    // TODO: Implement a more efficient string search
     @Nullable
     @Description("splits a string by a delimiter and returns the specified field (counting from one)")
     @ScalarFunction
@@ -196,28 +319,37 @@ public final class StringFunctions
     public static Slice splitPart(@SqlType(StandardTypes.VARCHAR) Slice string, @SqlType(StandardTypes.VARCHAR) Slice delimiter, @SqlType(StandardTypes.BIGINT) long index)
     {
         checkCondition(index > 0, INVALID_FUNCTION_ARGUMENT, "Index must be greater than zero");
-
+        // Empty delimiter? Then every character will be a split
         if (delimiter.length() == 0) {
-            if (index > string.length()) {
-                // index is too big, null is returned
+            int startCodePoint = Ints.checkedCast(index);
+
+            int indexStart = offsetOfCodePoint(string, startCodePoint - 1);
+            if (indexStart < 0) {
+                // index too big
                 return null;
             }
-            return string.slice((int) (index - 1), 1);
+            int length = lengthOfCodePoint(string, indexStart);
+            if (indexStart + length > string.length()) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Invalid UTF-8 encoding");
+            }
+            return string.slice(indexStart, length);
         }
 
-        int previousIndex = 0;
         int matchCount = 0;
 
-        for (int i = 0; i <= (string.length() - delimiter.length()); i++) {
-            if (string.equals(i, delimiter.length(), delimiter, 0, delimiter.length())) {
-                matchCount++;
-                if (matchCount == index) {
-                    return string.slice(previousIndex, i - previousIndex);
-                }
-                // noinspection AssignmentToForLoopParameter
-                i += (delimiter.length() - 1);
-                previousIndex = i + 1;
+        int previousIndex = 0;
+        while (previousIndex < string.length()) {
+            int matchIndex = string.indexOf(delimiter, previousIndex);
+            // No match
+            if (matchIndex < 0) {
+                break;
             }
+            // Reached the requested part?
+            if (++matchCount == index) {
+                return string.slice(previousIndex, matchIndex - previousIndex);
+            }
+            // Continue searching after the delimiter
+            previousIndex = matchIndex + delimiter.length();
         }
 
         if (matchCount == index - 1) {
@@ -229,81 +361,68 @@ public final class StringFunctions
         return null;
     }
 
-    @Description("removes spaces from the beginning of a string")
+    @Description("removes whitespace from the beginning of a string")
     @ScalarFunction("ltrim")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice leftTrim(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
-        int start = firstNonSpace(slice);
-        return slice.slice(start, slice.length() - start);
+        try {
+            return SliceUtf8.leftTrim(slice);
+        }
+        catch (InvalidCodePointException | InvalidUtf8Exception e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 
-    @Description("removes spaces from the end of a string")
+    @Description("removes whitespace from the end of a string")
     @ScalarFunction("rtrim")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice rightTrim(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
-        int end = lastNonSpace(slice);
-        return slice.slice(0, end + 1);
+        try {
+            return SliceUtf8.rightTrim(slice);
+        }
+        catch (InvalidCodePointException | InvalidUtf8Exception e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 
-    @Description("removes spaces from the beginning and end of a string")
+    @Description("removes whitespace from the beginning and end of a string")
     @ScalarFunction
     @SqlType(StandardTypes.VARCHAR)
     public static Slice trim(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
-        int start = firstNonSpace(slice);
-        if (start == slice.length()) {
-            return Slices.EMPTY_SLICE;
+        try {
+            return SliceUtf8.trim(slice);
         }
-
-        int end = lastNonSpace(slice);
-        assert (end >= 0) && (end >= start);
-
-        return slice.slice(start, (end - start) + 1);
+        catch (InvalidCodePointException | InvalidUtf8Exception e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 
-    private static int firstNonSpace(Slice slice)
-    {
-        for (int i = 0; i < slice.length(); i++) {
-            if (slice.getByte(i) != ' ') {
-                return i;
-            }
-        }
-        return slice.length();
-    }
-
-    private static int lastNonSpace(Slice slice)
-    {
-        for (int i = slice.length() - 1; i >= 0; i--) {
-            if (slice.getByte(i) != ' ') {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    @Description("converts the alphabets in a string to lower case")
+    @Description("converts the string to lower case")
     @ScalarFunction
     @SqlType(StandardTypes.VARCHAR)
     public static Slice lower(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
-        Slice upper = Slices.allocate(slice.length());
-        for (int i = 0; i < slice.length(); i++) {
-            upper.setByte(i, Ascii.toLowerCase((char) slice.getByte(i)));
+        try {
+            return toLowerCase(slice);
         }
-        return upper;
+        catch (InvalidCodePointException | InvalidUtf8Exception e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 
-    @Description("converts all the alphabets in the string to upper case")
+    @Description("converts the string to upper case")
     @ScalarFunction
     @SqlType(StandardTypes.VARCHAR)
     public static Slice upper(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
-        Slice upper = Slices.allocate(slice.length());
-        for (int i = 0; i < slice.length(); i++) {
-            upper.setByte(i, Ascii.toUpperCase((char) slice.getByte(i)));
+        try {
+            return toUpperCase(slice);
         }
-        return upper;
+        catch (InvalidCodePointException | InvalidUtf8Exception e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/StringFunctionsBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/StringFunctionsBenchmark.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.operator.scalar.StringFunctions.leftTrim;
+import static com.facebook.presto.operator.scalar.StringFunctions.length;
+import static com.facebook.presto.operator.scalar.StringFunctions.lower;
+import static com.facebook.presto.operator.scalar.StringFunctions.reverse;
+import static com.facebook.presto.operator.scalar.StringFunctions.rightTrim;
+import static com.facebook.presto.operator.scalar.StringFunctions.substr;
+import static com.facebook.presto.operator.scalar.StringFunctions.trim;
+import static com.facebook.presto.operator.scalar.StringFunctions.upper;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Character.MAX_CODE_POINT;
+import static java.lang.Character.SURROGATE;
+import static java.lang.Character.getType;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Thread)
+@OutputTimeUnit(NANOSECONDS)
+@BenchmarkMode(AverageTime)
+@Fork(1)
+@Warmup(iterations = 4, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 5, time = 500, timeUnit = MILLISECONDS)
+public class StringFunctionsBenchmark
+{
+    @Benchmark
+    public long benchmarkLength(BenchmarkData data)
+    {
+        return length(data.getSlice());
+    }
+
+    @Benchmark
+    public Slice benchmarkSubstringStart(BenchmarkData data)
+    {
+        Slice slice = data.getSlice();
+        int length = data.getLength();
+        return substr(slice, (length / 2) - 1);
+    }
+
+    @Benchmark
+    public Slice benchmarkSubstringStartLength(BenchmarkData data)
+    {
+        Slice slice = data.getSlice();
+        int length = data.getLength();
+        return substr(slice, (length / 2) - 1, length / 2);
+    }
+
+    @Benchmark
+    public Slice benchmarkSubstringStartFromEnd(BenchmarkData data)
+    {
+        Slice slice = data.getSlice();
+        int length = data.getLength();
+        return substr(slice, -((length / 2) + 1));
+    }
+
+    @Benchmark
+    public Slice benchmarkSubstringStartLengthFromEnd(BenchmarkData data)
+    {
+        Slice slice = data.getSlice();
+        int length = data.getLength();
+        return substr(slice, -((length / 2) + 1), length / 2);
+    }
+
+    @Benchmark
+    public Slice benchmarkReverse(BenchmarkData data)
+    {
+        return reverse(data.getSlice());
+    }
+
+    @Benchmark
+    public Slice benchmarkLeftTrim(WhitespaceData data)
+    {
+        return leftTrim(data.getLeftWhitespace());
+    }
+
+    @Benchmark
+    public Slice benchmarkRightTrim(WhitespaceData data)
+    {
+        return rightTrim(data.getRightWhitespace());
+    }
+
+    @Benchmark
+    public Slice benchmarkTrim(WhitespaceData data)
+    {
+        return trim(data.getBothWhitespace());
+    }
+
+    @Benchmark
+    public Slice benchmarkUpper(BenchmarkData data)
+    {
+        return upper(data.getSlice());
+    }
+
+    @Benchmark
+    public Slice benchmarkLower(BenchmarkData data)
+    {
+        return lower(data.getSlice());
+    }
+
+    @State(Thread)
+    public static class BenchmarkData
+    {
+        private static final int[] ASCII_CODE_POINTS;
+        private static final int[] ALL_CODE_POINTS;
+
+        static {
+            ASCII_CODE_POINTS = IntStream.range(0, 0x7F)
+                    .toArray();
+            ALL_CODE_POINTS = IntStream.range(0, MAX_CODE_POINT)
+                    .filter(codePoint -> getType(codePoint) != SURROGATE)
+                    .toArray();
+        }
+
+        @Param({ "2", "5", "10", "100", "1000", "10000" })
+        private int length;
+
+        @Param({ "true", "false" })
+        private boolean ascii;
+
+        private Slice slice;
+        private int[] codePoints;
+
+        @Setup
+        public void setup()
+        {
+            int[] codePointSet = ascii ? ASCII_CODE_POINTS : ALL_CODE_POINTS;
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+
+            codePoints = new int[length];
+            DynamicSliceOutput sliceOutput = new DynamicSliceOutput(length * 4);
+            for (int i = 0; i < codePoints.length; i++) {
+                int codePoint = codePointSet[random.nextInt(codePointSet.length)];
+                codePoints[i] = codePoint;
+                sliceOutput.appendBytes(new String(Character.toChars(codePoint)).getBytes(StandardCharsets.UTF_8));
+            }
+            slice = sliceOutput.slice();
+        }
+
+        public Slice getSlice()
+        {
+            return slice;
+        }
+
+        public int getLength()
+        {
+            return length;
+        }
+    }
+
+    @State(Thread)
+    public static class WhitespaceData
+    {
+        private static final int[] ASCII_WHITESPACE;
+        private static final int[] ALL_WHITESPACE;
+
+        static {
+            ASCII_WHITESPACE = IntStream.range(0, 0x7F)
+                    .filter(Character::isWhitespace)
+                    .toArray();
+            ALL_WHITESPACE = IntStream.range(0, MAX_CODE_POINT)
+                    .filter(Character::isWhitespace)
+                    .toArray();
+        }
+
+        @Param({ "2", "5", "10", "100", "1000", "10000" })
+        private int length;
+
+        @Param({ "true", "false" })
+        private boolean ascii;
+
+        private Slice leftWhitespace;
+        private Slice rightWhitespace;
+        private Slice bothWhitespace;
+
+        @Setup
+        public void setup()
+        {
+            Slice whitespace = createRandomUtf8Slice(ascii ? ASCII_WHITESPACE : ALL_WHITESPACE, length + 1);
+            leftWhitespace = Slices.copyOf(whitespace);
+            leftWhitespace.setByte(leftWhitespace.length() - 1, 'X');
+            rightWhitespace = Slices.copyOf(whitespace);
+            rightWhitespace.setByte(0, 'X');
+            bothWhitespace = Slices.copyOf(whitespace);
+            bothWhitespace.setByte(length / 2, 'X');
+        }
+
+        private static Slice createRandomUtf8Slice(int[] codePointSet, int length)
+        {
+            int[] codePoints = new int[length];
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+            for (int i = 0; i < codePoints.length; i++) {
+                int codePoint = codePointSet[random.nextInt(codePointSet.length)];
+                codePoints[i] = codePoint;
+            }
+            return utf8Slice(new String(codePoints, 0, codePoints.length));
+        }
+
+        public int getLength()
+        {
+            return length;
+        }
+
+        public Slice getLeftWhitespace()
+        {
+            return leftWhitespace;
+        }
+
+        public Slice getRightWhitespace()
+        {
+            return rightWhitespace;
+        }
+
+        public Slice getBothWhitespace()
+        {
+            return bothWhitespace;
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + StringFunctionsBenchmark.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}


### PR DESCRIPTION
Currently, all of the string functions work incorrectly for Unicode (non-ASCII) strings (see  #2579)
To fix this, @fmeiser rewrote most of the methods to work correctly for Unicode. For the methods which already worked with non-ASCII, he added tests. All methods work directly with `Slice` without converting to `String`.

I split original pull request (#2591) into two parts.  One part, I added to Slice directly (https://github.com/airlift/slice/pull/38), so it could access the internal of Slice, which result in a small speed boost.  The other part is here.  Additionally, I added more tests and a benchmark.

Benchmark results
```
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLeftTrim                          true         2  avgt        5      20.222       18.583  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLeftTrim                          true         5  avgt        5      31.776       14.151  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLeftTrim                          true        10  avgt        5      59.151       25.197  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLeftTrim                          true       100  avgt        5     445.298       44.887  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLeftTrim                          true      1000  avgt        5    4220.048      387.372  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLeftTrim                          true     10000  avgt        5   41436.997     6748.643  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLeftTrim                         false         2  avgt        5      36.761       19.102  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLeftTrim                         false         5  avgt        5      60.048       15.565  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLeftTrim                         false        10  avgt        5     100.922       24.394  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLeftTrim                         false       100  avgt        5     733.359       22.232  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLeftTrim                         false      1000  avgt        5    8330.696      177.062  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLeftTrim                         false     10000  avgt        5  105107.335     5595.990  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLength                            true         2  avgt        5       4.927        0.153  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLength                            true         5  avgt        5       4.568        0.140  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLength                            true        10  avgt        5       6.630        0.250  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLength                            true       100  avgt        5      33.386        0.911  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLength                            true      1000  avgt        5     224.277       10.458  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLength                            true     10000  avgt        5    2205.505      161.019  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLength                           false         2  avgt        5       4.080        0.297  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLength                           false         5  avgt        5      13.217        0.323  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLength                           false        10  avgt        5      14.578        0.711  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLength                           false       100  avgt        5      80.661        2.248  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLength                           false      1000  avgt        5     761.991       30.133  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLength                           false     10000  avgt        5    8226.699       81.321  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLower                             true         2  avgt        5      42.576        2.118  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLower                             true         5  avgt        5      65.601        3.301  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLower                             true        10  avgt        5     102.730       11.801  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLower                             true       100  avgt        5     769.916       17.984  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLower                             true      1000  avgt        5    8224.269      217.953  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLower                             true     10000  avgt        5   74965.387     4825.826  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLower                            false         2  avgt        5      52.088        0.915  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLower                            false         5  avgt        5     105.048        8.148  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLower                            false        10  avgt        5     193.123       13.632  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLower                            false       100  avgt        5    1569.459      127.311  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLower                            false      1000  avgt        5   17690.420     1098.144  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkLower                            false     10000  avgt        5  185126.292    10332.891  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkReverse                           true         2  avgt        5      25.245        9.516  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkReverse                           true         5  avgt        5      38.720       21.166  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkReverse                           true        10  avgt        5      57.678       30.383  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkReverse                           true       100  avgt        5     343.552        5.923  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkReverse                           true      1000  avgt        5    3676.776      540.327  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkReverse                           true     10000  avgt        5   46689.527    13522.092  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkReverse                          false         2  avgt        5      28.990       16.642  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkReverse                          false         5  avgt        5      46.178       27.107  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkReverse                          false        10  avgt        5      79.428       80.178  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkReverse                          false       100  avgt        5     508.880      298.995  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkReverse                          false      1000  avgt        5    5623.366     1715.816  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkReverse                          false     10000  avgt        5   75638.802    19926.038  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkRightTrim                         true         2  avgt        5      13.378        5.616  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkRightTrim                         true         5  avgt        5      22.950       19.878  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkRightTrim                         true        10  avgt        5      31.974       25.273  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkRightTrim                         true       100  avgt        5     212.902       12.214  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkRightTrim                         true      1000  avgt        5    1888.830       94.442  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkRightTrim                         true     10000  avgt        5   18814.020     1200.260  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkRightTrim                        false         2  avgt        5      36.954       20.222  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkRightTrim                        false         5  avgt        5      70.683       16.365  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkRightTrim                        false        10  avgt        5     122.992       15.054  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkRightTrim                        false       100  avgt        5     721.577      144.570  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkRightTrim                        false      1000  avgt        5    7427.438      583.645  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkRightTrim                        false     10000  avgt        5   98015.484     6136.921  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStart                    true         2  avgt        5       2.798        0.163  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStart                    true         5  avgt        5       5.267        0.144  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStart                    true        10  avgt        5      18.864       11.269  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStart                    true       100  avgt        5      29.027       19.471  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStart                    true      1000  avgt        5     157.819       27.130  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStart                    true     10000  avgt        5    1280.307      100.259  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStart                   false         2  avgt        5       2.803        0.090  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStart                   false         5  avgt        5       5.269        0.243  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStart                   false        10  avgt        5      33.788       16.033  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStart                   false       100  avgt        5      94.022       16.719  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStart                   false      1000  avgt        5     619.170       44.939  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStart                   false     10000  avgt        5    5476.401      266.483  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartFromEnd             true         2  avgt        5       8.878        0.519  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartFromEnd             true         5  avgt        5      20.183        7.732  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartFromEnd             true        10  avgt        5      21.114        5.898  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartFromEnd             true       100  avgt        5      73.295       28.279  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartFromEnd             true      1000  avgt        5     383.032       26.316  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartFromEnd             true     10000  avgt        5    3507.865      183.545  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartFromEnd            false         2  avgt        5       7.596        0.398  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartFromEnd            false         5  avgt        5      39.385       28.400  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartFromEnd            false        10  avgt        5      52.014       22.878  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartFromEnd            false       100  avgt        5     177.969       25.920  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartFromEnd            false      1000  avgt        5    1325.836      137.824  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartFromEnd            false     10000  avgt        5   12168.301     1280.519  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLength              true         2  avgt        5       2.779        0.179  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLength              true         5  avgt        5      26.832       12.733  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLength              true        10  avgt        5      32.499       22.123  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLength              true       100  avgt        5      51.984        9.618  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLength              true      1000  avgt        5     274.754       21.501  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLength              true     10000  avgt        5    2513.272      160.565  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLength             false         2  avgt        5       2.808        0.121  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLength             false         5  avgt        5      47.729       23.736  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLength             false        10  avgt        5      65.283       23.358  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLength             false       100  avgt        5     160.441       17.009  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLength             false      1000  avgt        5     965.220       58.410  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLength             false     10000  avgt        5    9237.194      497.736  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLengthFromEnd       true         2  avgt        5      26.134       10.500  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLengthFromEnd       true         5  avgt        5      36.046       17.350  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLengthFromEnd       true        10  avgt        5      38.347       14.512  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLengthFromEnd       true       100  avgt        5      90.389       25.483  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLengthFromEnd       true      1000  avgt        5     511.703       27.230  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLengthFromEnd       true     10000  avgt        5    4750.136      440.145  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLengthFromEnd      false         2  avgt        5      35.049       20.179  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLengthFromEnd      false         5  avgt        5      67.110       24.906  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLengthFromEnd      false        10  avgt        5      97.434       22.444  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLengthFromEnd      false       100  avgt        5     267.049       27.025  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLengthFromEnd      false      1000  avgt        5    1842.101      140.554  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkSubstringStartLengthFromEnd      false     10000  avgt        5   17421.955      525.860  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkTrim                              true         2  avgt        5      14.986        0.743  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkTrim                              true         5  avgt        5      27.355        0.339  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkTrim                              true        10  avgt        5      44.679        1.630  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkTrim                              true       100  avgt        5     415.864       23.629  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkTrim                              true      1000  avgt        5    3735.030      163.791  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkTrim                              true     10000  avgt        5   42947.000    21308.508  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkTrim                             false         2  avgt        5      23.956        1.923  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkTrim                             false         5  avgt        5      41.364        3.133  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkTrim                             false        10  avgt        5      69.545        3.745  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkTrim                             false       100  avgt        5     609.266       16.541  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkTrim                             false      1000  avgt        5    7155.778      334.445  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkTrim                             false     10000  avgt        5  101488.696     5323.441  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkUpper                             true         2  avgt        5      46.959       37.490  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkUpper                             true         5  avgt        5      67.280       52.553  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkUpper                             true        10  avgt        5     103.150       58.757  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkUpper                             true       100  avgt        5     704.528       38.133  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkUpper                             true      1000  avgt        5    7471.537      437.504  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkUpper                             true     10000  avgt        5   69990.883     4131.438  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkUpper                            false         2  avgt        5      62.522        2.174  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkUpper                            false         5  avgt        5      93.060       56.668  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkUpper                            false        10  avgt        5     148.329       69.036  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkUpper                            false       100  avgt        5    1662.402       84.428  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkUpper                            false      1000  avgt        5   17539.205      495.578  ns/op
c.f.p.o.s.StringFunctionsBenchmark.benchmarkUpper                            false     10000  avgt        5  186298.605    10171.332  ns/op
```
