### PR TITLE
Allow invalid UTF-8 sequence in string functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dep.antlr.version>4.3</dep.antlr.version>
         <dep.airlift.version>0.108</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.slice.version>0.11</dep.slice.version>
+        <dep.slice.version>0.12-SNAPSHOT</dep.slice.version>
 
         <cli.skip-execute>true</cli.skip-execute>
         <cli.main-class>None</cli.main-class>

--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -14,7 +14,7 @@ String Functions
 
     These functions assume that the input strings contain valid UTF-8 encoded
     Unicode code points.  There are no explicit checks for valid UTF-8, and
-    the functions may return incorrect results or fail on invalid UTF-8.
+    the functions may return incorrect results on invalid UTF-8.
     Invalid UTF-8 data can be corrected with :func:`from_utf8`.
 
     Additionally, the functions operate on Unicode code points and not user

--- a/presto-docs/src/main/sphinx/release/release-0.102.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.102.rst
@@ -7,7 +7,7 @@ Unicode Support
 
 All string functions have been updated to support Unicode. The functions assume
 that the string contains valid UTF-8 encoded code points. There are no explicit
-checks for valid UTF-8, and the functions may return incorrect results or fail on
+checks for valid UTF-8, and the functions may return incorrect results on
 invalid UTF-8.  Invalid UTF-8 data can be corrected with :func:`from_utf8`.
 
 Additionally, the functions operate on Unicode code points and not user visible

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -37,6 +37,7 @@ import static com.facebook.presto.type.ArrayType.toStackRepresentation;
 import static com.facebook.presto.util.Failures.checkCondition;
 import static io.airlift.slice.SliceUtf8.countCodePoints;
 import static io.airlift.slice.SliceUtf8.lengthOfCodePoint;
+import static io.airlift.slice.SliceUtf8.lengthOfCodePointSafe;
 import static io.airlift.slice.SliceUtf8.offsetOfCodePoint;
 import static io.airlift.slice.SliceUtf8.toLowerCase;
 import static io.airlift.slice.SliceUtf8.toUpperCase;
@@ -106,8 +107,7 @@ public final class StringFunctions
             // After every code point insert `replace`
             int index = 0;
             while (index < str.length()) {
-                int startByte = str.getUnsignedByte(index);
-                int codePointLength = lengthOfCodePoint(startByte);
+                int codePointLength = lengthOfCodePointSafe(str, index);
                 // Append current code point
                 buffer.setBytes(indexBuffer, str, index, codePointLength);
                 indexBuffer += codePointLength;
@@ -162,12 +162,7 @@ public final class StringFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice reverse(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
-        try {
-            return SliceUtf8.reverse(slice);
-        }
-        catch (InvalidCodePointException | InvalidUtf8Exception e) {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
-        }
+        return SliceUtf8.reverse(slice);
     }
 
     @Description("returns index of first occurrence of a substring (or 0 if not found)")
@@ -369,12 +364,7 @@ public final class StringFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice leftTrim(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
-        try {
-            return SliceUtf8.leftTrim(slice);
-        }
-        catch (InvalidCodePointException | InvalidUtf8Exception e) {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
-        }
+        return SliceUtf8.leftTrim(slice);
     }
 
     @Description("removes whitespace from the end of a string")
@@ -382,12 +372,7 @@ public final class StringFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice rightTrim(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
-        try {
-            return SliceUtf8.rightTrim(slice);
-        }
-        catch (InvalidCodePointException | InvalidUtf8Exception e) {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
-        }
+        return SliceUtf8.rightTrim(slice);
     }
 
     @Description("removes whitespace from the beginning and end of a string")
@@ -395,12 +380,7 @@ public final class StringFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice trim(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
-        try {
-            return SliceUtf8.trim(slice);
-        }
-        catch (InvalidCodePointException | InvalidUtf8Exception e) {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
-        }
+        return SliceUtf8.trim(slice);
     }
 
     @Description("converts the string to lower case")
@@ -408,12 +388,7 @@ public final class StringFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice lower(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
-        try {
-            return toLowerCase(slice);
-        }
-        catch (InvalidCodePointException | InvalidUtf8Exception e) {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
-        }
+        return toLowerCase(slice);
     }
 
     @Description("converts the string to upper case")
@@ -421,12 +396,7 @@ public final class StringFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice upper(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
-        try {
-            return toUpperCase(slice);
-        }
-        catch (InvalidCodePointException | InvalidUtf8Exception e) {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
-        }
+        return toUpperCase(slice);
     }
 
     @Description("decodes the UTF-8 encoded string")


### PR DESCRIPTION
Change upper, lower, and reverse to skip invalid UTF-8 sequences.
Change trim functions to stop at an invalid UTF-8 sequence.