### PR TITLE
Make system.runtime.queries run on coordinator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <air.check.skip-checkstyle>false</air.check.skip-checkstyle>
 
         <dep.antlr.version>4.3</dep.antlr.version>
-        <dep.airlift.version>0.108</dep.airlift.version>
+        <dep.airlift.version>0.109-SNAPSHOT</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.12</dep.slice.version>
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcModule.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcModule.java
@@ -18,7 +18,7 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class JdbcModule
         implements Module
@@ -40,6 +40,6 @@ public class JdbcModule
         binder.bind(JdbcHandleResolver.class).in(Scopes.SINGLETON);
         binder.bind(JdbcRecordSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(JdbcConnector.class).in(Scopes.SINGLETON);
-        bindConfig(binder).to(JdbcMetadataConfig.class);
+        configBinder(binder).bindConfig(JdbcMetadataConfig.class);
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingH2JdbcModule.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingH2JdbcModule.java
@@ -21,7 +21,7 @@ import org.h2.Driver;
 
 import java.util.Map;
 
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static java.lang.String.format;
 
 class TestingH2JdbcModule
@@ -30,7 +30,7 @@ class TestingH2JdbcModule
     @Override
     public void configure(Binder binder)
     {
-        bindConfig(binder).to(BaseJdbcConfig.class);
+        configBinder(binder).bindConfig(BaseJdbcConfig.class);
     }
 
     @Provides

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
@@ -33,7 +33,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static org.weakref.jmx.ObjectNames.generatedNameOf;

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ExecutorService;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.configuration.ConfigurationModule.bindConfig;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static java.util.concurrent.Executors.newFixedThreadPool;
@@ -62,7 +63,7 @@ public class CassandraClientModule
 
         binder.bind(CassandraThriftConnectionFactory.class).in(Scopes.SINGLETON);
 
-        bindConfig(binder).to(CassandraClientConfig.class);
+        configBinder(binder).bindConfig(CassandraClientConfig.class);
 
         binder.bind(CassandraThriftConnectionFactory.class).in(Scopes.SINGLETON);
 

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleModule.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleModule.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.configuration.ConfigurationModule.bindConfig;
 import static io.airlift.json.JsonBinder.jsonBinder;
 import static io.airlift.json.JsonCodec.listJsonCodec;
@@ -55,7 +56,7 @@ public class ExampleModule
         binder.bind(ExampleSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(ExampleRecordSetProvider.class).in(Scopes.SINGLETON);
         binder.bind(ExampleHandleResolver.class).in(Scopes.SINGLETON);
-        bindConfig(binder).to(ExampleConfig.class);
+        configBinder(binder).bindConfig(ExampleConfig.class);
 
         jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
         jsonCodecBinder(binder).bindMapJsonCodec(String.class, listJsonCodec(ExampleTable.class));

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleModule.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleModule.java
@@ -27,7 +27,6 @@ import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
 import static io.airlift.json.JsonBinder.jsonBinder;
 import static io.airlift.json.JsonCodec.listJsonCodec;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -43,7 +43,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newFixedThreadPool;
@@ -73,8 +73,8 @@ public class HiveClientModule
         binder.bind(HdfsConfiguration.class).to(HiveHdfsConfiguration.class).in(Scopes.SINGLETON);
         binder.bind(HdfsEnvironment.class).in(Scopes.SINGLETON);
         binder.bind(DirectoryLister.class).to(HadoopDirectoryLister.class).in(Scopes.SINGLETON);
-        bindConfig(binder).to(HiveClientConfig.class);
-        bindConfig(binder).to(HivePluginConfig.class);
+        configBinder(binder).bindConfig(HiveClientConfig.class);
+        configBinder(binder).bindConfig(HivePluginConfig.class);
 
         if (metastore != null) {
             binder.bind(HiveMetastore.class).toInstance(metastore);

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorModule.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorModule.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.configuration.ConfigurationModule.bindConfig;
 import static io.airlift.json.JsonBinder.jsonBinder;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
@@ -50,7 +51,7 @@ public class KafkaConnectorModule
 
         binder.bind(KafkaSimpleConsumerManager.class).in(Scopes.SINGLETON);
 
-        bindConfig(binder).to(KafkaConnectorConfig.class);
+        configBinder(binder).bindConfig(KafkaConnectorConfig.class);
 
         jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
         jsonCodecBinder(binder).bindJsonCodec(KafkaTopicDescription.class);

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorModule.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorModule.java
@@ -29,7 +29,6 @@ import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
 import static io.airlift.json.JsonBinder.jsonBinder;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
 

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/CatalogSystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/CatalogSystemTable.java
@@ -53,6 +53,12 @@ public class CatalogSystemTable
     }
 
     @Override
+    public boolean isCoordinatorOnly()
+    {
+        return true;
+    }
+
+    @Override
     public ConnectorTableMetadata getTableMetadata()
     {
         return CATALOG_TABLE;

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/CatalogSystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/CatalogSystemTable.java
@@ -47,15 +47,9 @@ public class CatalogSystemTable
     }
 
     @Override
-    public boolean isDistributed()
+    public TableDistributionEnum getDistributionMode()
     {
-        return false;
-    }
-
-    @Override
-    public boolean isCoordinatorOnly()
-    {
-        return true;
+        return TableDistributionEnum.SINGLE_COORDINATOR;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/NodeSystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/NodeSystemTable.java
@@ -59,6 +59,12 @@ public class NodeSystemTable
     }
 
     @Override
+    public boolean isCoordinatorOnly()
+    {
+        return true;
+    }
+
+    @Override
     public ConnectorTableMetadata getTableMetadata()
     {
         return NODES_TABLE;

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/NodeSystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/NodeSystemTable.java
@@ -53,15 +53,9 @@ public class NodeSystemTable
     }
 
     @Override
-    public boolean isDistributed()
+    public TableDistributionEnum getDistributionMode()
     {
-        return false;
-    }
-
-    @Override
-    public boolean isCoordinatorOnly()
-    {
-        return true;
+        return TableDistributionEnum.SINGLE_COORDINATOR;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/QuerySystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/QuerySystemTable.java
@@ -69,7 +69,13 @@ public class QuerySystemTable
     @Override
     public boolean isDistributed()
     {
-        return false;
+        return true;
+    }
+
+    @Override
+    public boolean isCoordinatorOnly()
+    {
+        return true;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/QuerySystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/QuerySystemTable.java
@@ -69,7 +69,7 @@ public class QuerySystemTable
     @Override
     public boolean isDistributed()
     {
-        return true;
+        return false;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/QuerySystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/QuerySystemTable.java
@@ -67,15 +67,9 @@ public class QuerySystemTable
     }
 
     @Override
-    public boolean isDistributed()
+    public TableDistributionEnum getDistributionMode()
     {
-        return true;
-    }
-
-    @Override
-    public boolean isCoordinatorOnly()
-    {
-        return true;
+        return TableDistributionEnum.ALL_COORDINATORS;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplitManager.java
@@ -26,8 +26,10 @@ import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SystemTable;
+import com.facebook.presto.spi.SystemTable.TableDistributionEnum;
 import com.facebook.presto.spi.TupleDomain;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 import java.util.List;
@@ -76,24 +78,26 @@ public class SystemSplitManager
         SystemTable systemTable = tables.get(systemPartition.getTableHandle().getSchemaTableName());
         checkArgument(systemTable != null, "Table %s does not exist", systemPartition.getTableHandle().getTableName());
 
-        if (systemTable.isCoordinatorOnly()) {
-            ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
-            for (Node node : nodeManager.getCoordinators()) {
-                splits.add(new SystemSplit(systemPartition.getTableHandle(), node.getHostAndPort()));
-            }
-            return new FixedSplitSource(SystemConnector.NAME, splits.build());
-        }
-        else if (systemTable.isDistributed()) {
-            ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
-            for (Node node : nodeManager.getActiveNodes()) {
-                splits.add(new SystemSplit(systemPartition.getTableHandle(), node.getHostAndPort()));
-            }
-            return new FixedSplitSource(SystemConnector.NAME, splits.build());
+        TableDistributionEnum tableDistributionMode = systemTable.getDistributionMode();
+        if (tableDistributionMode == TableDistributionEnum.SINGLE_COORDINATOR) {
+            HostAddress address = nodeManager.getCurrentNode().getHostAndPort();
+            ConnectorSplit split = new SystemSplit(systemPartition.getTableHandle(), address);
+            return new FixedSplitSource(SystemConnector.NAME, ImmutableList.of(split));
         }
 
-        HostAddress address = nodeManager.getCurrentNode().getHostAndPort();
-        ConnectorSplit split = new SystemSplit(systemPartition.getTableHandle(), address);
-        return new FixedSplitSource(SystemConnector.NAME, ImmutableList.of(split));
+        ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
+        ImmutableSet.Builder<Node> nodes = ImmutableSet.builder();
+        if (tableDistributionMode == TableDistributionEnum.ALL_COORDINATORS) {
+            nodes.addAll(nodeManager.getCoordinators());
+        }
+        else if (tableDistributionMode == TableDistributionEnum.ALL_NODES) {
+            nodes.addAll(nodeManager.getActiveNodes());
+        }
+        Set<Node> nodeSet = nodes.build();
+        for (Node node : nodeSet) {
+            splits.add(new SystemSplit(systemPartition.getTableHandle(), node.getHostAndPort()));
+        }
+        return new FixedSplitSource(SystemConnector.NAME, splits.build());
     }
 
     public static class SystemPartition

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/TaskSystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/TaskSystemTable.java
@@ -83,15 +83,9 @@ public class TaskSystemTable
     }
 
     @Override
-    public boolean isDistributed()
+    public TableDistributionEnum getDistributionMode()
     {
-        return true;
-    }
-
-    @Override
-    public boolean isCoordinatorOnly()
-    {
-        return false;
+        return TableDistributionEnum.ALL_NODES;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/TaskSystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/TaskSystemTable.java
@@ -89,6 +89,12 @@ public class TaskSystemTable
     }
 
     @Override
+    public boolean isCoordinatorOnly()
+    {
+        return false;
+    }
+
+    @Override
     public ConnectorTableMetadata getTableMetadata()
     {
         return TASK_TABLE;

--- a/presto-main/src/main/java/com/facebook/presto/discovery/EmbeddedDiscoveryModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/discovery/EmbeddedDiscoveryModule.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.configuration.ConfigurationModule.bindConfig;
 import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
@@ -57,7 +58,7 @@ public class EmbeddedDiscoveryModule
             return;
         }
 
-        bindConfig(binder).to(DiscoveryConfig.class);
+        configBinder(binder).bindConfig(DiscoveryConfig.class);
         jaxrsBinder(binder).bind(ServiceResource.class);
 
         discoveryBinder(binder).bindHttpAnnouncement("discovery");

--- a/presto-main/src/main/java/com/facebook/presto/discovery/EmbeddedDiscoveryModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/discovery/EmbeddedDiscoveryModule.java
@@ -43,7 +43,6 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
 import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -105,6 +105,12 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
+    public void pruneInfo()
+    {
+        // no-op
+    }
+
+    @Override
     public QueryId getQueryId()
     {
         return stateMachine.getQueryId();

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -81,4 +81,10 @@ public class FailedQueryExecution
     {
         // no-op
     }
+
+    @Override
+    public void pruneInfo()
+    {
+        // no-op
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -35,6 +35,9 @@ public interface QueryExecution
 
     void recordHeartbeat();
 
+    // XXX: This should be removed when the client protocol is improved, so that we don't need to hold onto so much query history
+    void pruneInfo();
+
     void addStateChangeListener(StateChangeListener<QueryState> stateChangeListener);
 
     interface QueryExecutionFactory<T extends QueryExecution>

--- a/presto-main/src/main/java/com/facebook/presto/failureDetector/FailureDetectorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/failureDetector/FailureDetectorModule.java
@@ -18,7 +18,7 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 import org.weakref.jmx.guice.ExportBinder;
 
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
 
 public class FailureDetectorModule
@@ -32,7 +32,7 @@ public class FailureDetectorModule
                 .withPrivateIoThreadPool()
                 .withTracing();
 
-        bindConfig(binder).to(FailureDetectorConfig.class);
+        configBinder(binder).bindConfig(FailureDetectorConfig.class);
 
         binder.bind(HeartbeatFailureDetector.class).in(Scopes.SINGLETON);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TestingRowConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TestingRowConstructor.java
@@ -135,7 +135,7 @@ public final class TestingRowConstructor
     public static Slice testRowBooleanArrayMap(@Nullable @SqlType(StandardTypes.BOOLEAN) Boolean arg1, @Nullable @SqlType("array<bigint>") Slice arg2,
                                                @Nullable @SqlType("map<bigint,double>") Slice arg3)
     {
-        List<Type> parameterTypes = ImmutableList.of(BIGINT, new ArrayType(BIGINT), new MapType(BIGINT, DOUBLE));
+        List<Type> parameterTypes = ImmutableList.of(BOOLEAN, new ArrayType(BIGINT), new MapType(BIGINT, DOUBLE));
         return toStackRepresentation(parameterTypes, arg1, arg2, arg3);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -73,7 +73,7 @@ import static com.facebook.presto.execution.QueryExecution.QueryExecutionFactory
 import static com.facebook.presto.execution.SqlQueryExecution.SqlQueryExecutionFactory;
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static io.airlift.concurrent.Threads.threadsNamed;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
 import static io.airlift.http.server.HttpServerBinder.httpServerBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
@@ -101,10 +101,10 @@ public class CoordinatorModule
         binder.bind(QueryManager.class).to(SqlQueryManager.class).in(Scopes.SINGLETON);
         binder.bind(QueryQueueManager.class).to(SqlQueryQueueManager.class).in(Scopes.SINGLETON);
         newExporter(binder).export(QueryManager.class).withGeneratedName();
-        bindConfig(binder).to(QueryManagerConfig.class);
+        configBinder(binder).bindConfig(QueryManagerConfig.class);
 
         // analyzer
-        bindConfig(binder).to(FeaturesConfig.class);
+        configBinder(binder).bindConfig(FeaturesConfig.class);
 
         // split manager
         binder.bind(SplitManager.class).in(Scopes.SINGLETON);
@@ -112,7 +112,7 @@ public class CoordinatorModule
         // node scheduler
         binder.bind(InternalNodeManager.class).to(DiscoveryNodeManager.class).in(Scopes.SINGLETON);
         binder.bind(NodeManager.class).to(Key.get(InternalNodeManager.class)).in(Scopes.SINGLETON);
-        bindConfig(binder).to(NodeSchedulerConfig.class);
+        configBinder(binder).bindConfig(NodeSchedulerConfig.class);
         binder.bind(NodeScheduler.class).in(Scopes.SINGLETON);
         binder.bind(NodeTaskMap.class).in(Scopes.SINGLETON);
         newExporter(binder).export(NodeScheduler.class).withGeneratedName();

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -104,7 +104,7 @@ import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
 import static io.airlift.event.client.EventBinder.eventBinder;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
@@ -146,8 +146,8 @@ public class ServerMainModule
         // task execution
         jaxrsBinder(binder).bind(TaskResource.class);
         binder.bind(TaskManager.class).to(SqlTaskManager.class).in(Scopes.SINGLETON);
-        bindConfig(binder).to(MemoryManagerConfig.class);
-        bindConfig(binder).to(ReservedSystemMemoryConfig.class);
+        configBinder(binder).bindConfig(MemoryManagerConfig.class);
+        configBinder(binder).bindConfig(ReservedSystemMemoryConfig.class);
         newExporter(binder).export(ClusterMemoryManager.class).withGeneratedName();
         binder.bind(ClusterMemoryManager.class).in(Scopes.SINGLETON);
         binder.bind(LocalMemoryManager.class).in(Scopes.SINGLETON);
@@ -156,10 +156,10 @@ public class ServerMainModule
         binder.bind(TaskExecutor.class).in(Scopes.SINGLETON);
         newExporter(binder).export(TaskExecutor.class).withGeneratedName();
         binder.bind(LocalExecutionPlanner.class).in(Scopes.SINGLETON);
-        bindConfig(binder).to(CompilerConfig.class);
+        configBinder(binder).bindConfig(CompilerConfig.class);
         binder.bind(ExpressionCompiler.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ExpressionCompiler.class).withGeneratedName();
-        bindConfig(binder).to(TaskManagerConfig.class);
+        configBinder(binder).bindConfig(TaskManagerConfig.class);
         binder.bind(IndexJoinLookupStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(IndexJoinLookupStats.class).withGeneratedName();
         binder.bind(AsyncHttpExecutionMBean.class).in(Scopes.SINGLETON);
@@ -171,7 +171,7 @@ public class ServerMainModule
         // exchange client
         binder.bind(new TypeLiteral<Supplier<ExchangeClient>>() {}).to(ExchangeClientFactory.class).in(Scopes.SINGLETON);
         httpClientBinder(binder).bindHttpClient("exchange", ForExchange.class).withTracing();
-        bindConfig(binder).to(ExchangeClientConfig.class);
+        configBinder(binder).bindConfig(ExchangeClientConfig.class);
         binder.bind(ExchangeExecutionMBean.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ExchangeExecutionMBean.class).withGeneratedName();
 
@@ -198,7 +198,7 @@ public class ServerMainModule
 
         // metadata
         binder.bind(CatalogManager.class).in(Scopes.SINGLETON);
-        bindConfig(binder).to(CatalogManagerConfig.class);
+        configBinder(binder).bindConfig(CatalogManagerConfig.class);
         binder.bind(MetadataManager.class).in(Scopes.SINGLETON);
         binder.bind(Metadata.class).to(MetadataManager.class).in(Scopes.SINGLETON);
 
@@ -270,7 +270,7 @@ public class ServerMainModule
 
         // plugin manager
         binder.bind(PluginManager.class).in(Scopes.SINGLETON);
-        bindConfig(binder).to(PluginManagerConfig.class);
+        configBinder(binder).bindConfig(PluginManagerConfig.class);
 
         // optimizers
         binder.bind(new TypeLiteral<List<PlanOptimizer>>() {}).toProvider(PlanOptimizersFactory.class).in(Scopes.SINGLETON);

--- a/presto-main/src/test/java/com/facebook/presto/failureDetector/TestHeartbeatFailureDetector.java
+++ b/presto-main/src/test/java/com/facebook/presto/failureDetector/TestHeartbeatFailureDetector.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
 import static io.airlift.discovery.client.ServiceTypes.serviceType;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
@@ -59,7 +59,7 @@ public class TestHeartbeatFailureDetector
                     @Override
                     public void configure(Binder binder)
                     {
-                        bindConfig(binder).to(QueryManagerConfig.class);
+                        configBinder(binder).bindConfig(QueryManagerConfig.class);
                         discoveryBinder(binder).bindSelector("presto");
                         discoveryBinder(binder).bindHttpAnnouncement("presto");
 

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClientModule.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClientModule.java
@@ -19,7 +19,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class MySqlClientModule
         implements Module
@@ -28,7 +28,7 @@ public class MySqlClientModule
     public void configure(Binder binder)
     {
         binder.bind(JdbcClient.class).to(MySqlClient.class).in(Scopes.SINGLETON);
-        bindConfig(binder).to(BaseJdbcConfig.class);
-        bindConfig(binder).to(MySqlConfig.class);
+        configBinder(binder).bindConfig(BaseJdbcConfig.class);
+        configBinder(binder).bindConfig(MySqlConfig.class);
     }
 }

--- a/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClientModule.java
+++ b/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClientModule.java
@@ -20,7 +20,6 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
 
 public class PostgreSqlClientModule
         implements Module

--- a/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClientModule.java
+++ b/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClientModule.java
@@ -19,6 +19,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.configuration.ConfigurationModule.bindConfig;
 
 public class PostgreSqlClientModule
@@ -28,6 +29,6 @@ public class PostgreSqlClientModule
     public void configure(Binder binder)
     {
         binder.bind(JdbcClient.class).to(PostgreSqlClient.class).in(Scopes.SINGLETON);
-        bindConfig(binder).to(BaseJdbcConfig.class);
+        configBinder(binder).bindConfig(BaseJdbcConfig.class);
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageModule.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageModule.java
@@ -21,7 +21,6 @@ import com.google.inject.Scopes;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
 import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageModule.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageModule.java
@@ -20,6 +20,7 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.configuration.ConfigurationModule.bindConfig;
 import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
@@ -37,7 +38,7 @@ public class StorageModule
     @Override
     public void configure(Binder binder)
     {
-        bindConfig(binder).to(StorageManagerConfig.class);
+        configBinder(binder).bindConfig(StorageManagerConfig.class);
         binder.bind(StorageManager.class).to(OrcStorageManager.class).in(Scopes.SINGLETON);
         binder.bind(StorageService.class).to(FileStorageService.class).in(Scopes.SINGLETON);
         binder.bind(ShardManager.class).to(DatabaseShardManager.class).in(Scopes.SINGLETON);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/SystemTable.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SystemTable.java
@@ -22,16 +22,9 @@ import static java.util.stream.Collectors.toList;
 public interface SystemTable
         extends RecordSet
 {
-    /**
-     * True if table is distributed across all nodes.
-     */
-    boolean isDistributed();
+    public enum TableDistributionEnum { ALL_NODES, ALL_COORDINATORS, SINGLE_COORDINATOR }
 
-    /**
-     * 
-     * True if table is only on coordinators
-     */
-    boolean isCoordinatorOnly();
+    TableDistributionEnum getDistributionMode();
 
     ConnectorTableMetadata getTableMetadata();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/SystemTable.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SystemTable.java
@@ -27,6 +27,12 @@ public interface SystemTable
      */
     boolean isDistributed();
 
+    /**
+     * 
+     * True if table is only on coordinators
+     */
+    boolean isCoordinatorOnly();
+
     ConnectorTableMetadata getTableMetadata();
 
     @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/tpch/ExampleSystemTable.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/tpch/ExampleSystemTable.java
@@ -37,15 +37,9 @@ public class ExampleSystemTable
             .build();
 
     @Override
-    public boolean isDistributed()
+    public TableDistributionEnum getDistributionMode()
     {
-        return false;
-    }
-
-    @Override
-    public boolean isCoordinatorOnly()
-    {
-        return true;
+        return TableDistributionEnum.SINGLE_COORDINATOR;
     }
 
     @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/tpch/ExampleSystemTable.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/tpch/ExampleSystemTable.java
@@ -43,6 +43,12 @@ public class ExampleSystemTable
     }
 
     @Override
+    public boolean isCoordinatorOnly()
+    {
+        return true;
+    }
+
+    @Override
     public ConnectorTableMetadata getTableMetadata()
     {
         return METADATA;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/PrestoVerifierModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/PrestoVerifierModule.java
@@ -24,7 +24,6 @@ import java.util.Set;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.airlift.configuration.ConfigurationModule.bindConfig;
 import static io.airlift.event.client.EventBinder.eventBinder;
 
 public class PrestoVerifierModule

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/PrestoVerifierModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/PrestoVerifierModule.java
@@ -23,6 +23,7 @@ import io.airlift.event.client.EventClient;
 import java.util.Set;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.configuration.ConfigurationModule.bindConfig;
 import static io.airlift.event.client.EventBinder.eventBinder;
 
@@ -32,7 +33,7 @@ public class PrestoVerifierModule
     @Override
     protected void setup(Binder binder)
     {
-        bindConfig(binder).to(VerifierConfig.class);
+        configBinder(binder).bindConfig(VerifierConfig.class);
         eventBinder(binder).bindEventClient(VerifierQueryEvent.class);
 
         Multibinder<String> supportedClients = newSetBinder(binder, String.class, Names.named(PrestoVerifier.SUPPORTED_EVENT_CLIENTS));


### PR DESCRIPTION
When we run query over table system.runtime.queries, it should only be run on coordinator.