### PR TITLE
Finish memory pool implementation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
+import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.sql.tree.Statement;
@@ -50,6 +51,24 @@ public class DataDefinitionExecution<T extends Statement>
         this.session = checkNotNull(session, "session is null");
         this.metadata = checkNotNull(metadata, "metadata is null");
         this.stateMachine = checkNotNull(stateMachine, "stateMachine is null");
+    }
+
+    @Override
+    public VersionedMemoryPoolId getMemoryPool()
+    {
+        return stateMachine.getMemoryPool();
+    }
+
+    @Override
+    public void setMemoryPool(VersionedMemoryPoolId poolId)
+    {
+        stateMachine.setMemoryPool(poolId);
+    }
+
+    @Override
+    public long getTotalMemoryReservation()
+    {
+        return 0;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -15,10 +15,13 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
+import com.facebook.presto.memory.VersionedMemoryPoolId;
 import io.airlift.units.Duration;
 
 import java.net.URI;
 import java.util.concurrent.Executor;
+
+import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
 
 public class FailedQueryExecution
         implements QueryExecution
@@ -43,6 +46,24 @@ public class FailedQueryExecution
     public QueryInfo getQueryInfo()
     {
         return queryInfo;
+    }
+
+    @Override
+    public VersionedMemoryPoolId getMemoryPool()
+    {
+        return new VersionedMemoryPoolId(GENERAL_POOL, 0);
+    }
+
+    @Override
+    public void setMemoryPool(VersionedMemoryPoolId poolId)
+    {
+        // no-op
+    }
+
+    @Override
+    public long getTotalMemoryReservation()
+    {
+        return 0;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
+import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.sql.tree.Statement;
 import io.airlift.units.Duration;
 
@@ -26,6 +27,12 @@ public interface QueryExecution
 
     Duration waitForStateChange(QueryState currentState, Duration maxWait)
             throws InterruptedException;
+
+    VersionedMemoryPoolId getMemoryPool();
+
+    void setMemoryPool(VersionedMemoryPoolId poolId);
+
+    long getTotalMemoryReservation();
 
     void start();
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.client.FailureInfo;
+import com.facebook.presto.memory.MemoryPoolId;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.StandardErrorCode.ErrorType;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -34,6 +35,7 @@ import java.util.Set;
 
 import static com.facebook.presto.spi.StandardErrorCode.toErrorType;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
 
 @Immutable
 public class QueryInfo
@@ -41,6 +43,7 @@ public class QueryInfo
     private final QueryId queryId;
     private final Session session;
     private final QueryState state;
+    private final MemoryPoolId memoryPool;
     private final boolean scheduled;
     private final URI self;
     private final List<String> fieldNames;
@@ -60,6 +63,7 @@ public class QueryInfo
             @JsonProperty("queryId") QueryId queryId,
             @JsonProperty("session") Session session,
             @JsonProperty("state") QueryState state,
+            @JsonProperty("memoryPool") MemoryPoolId memoryPool,
             @JsonProperty("scheduled") boolean scheduled,
             @JsonProperty("self") URI self,
             @JsonProperty("fieldNames") List<String> fieldNames,
@@ -87,6 +91,7 @@ public class QueryInfo
         this.queryId = queryId;
         this.session = session;
         this.state = state;
+        this.memoryPool = requireNonNull(memoryPool, "memoryPool is null");
         this.scheduled = scheduled;
         this.self = self;
         this.fieldNames = ImmutableList.copyOf(fieldNames);
@@ -118,6 +123,12 @@ public class QueryInfo
     public QueryState getState()
     {
         return state;
+    }
+
+    @JsonProperty
+    public MemoryPoolId getMemoryPool()
+    {
+        return memoryPool;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_QUEUE_FULL;
 import static com.facebook.presto.spi.StandardErrorCode.SERVER_SHUTTING_DOWN;
@@ -367,7 +368,7 @@ public class SqlQueryManager
     public void enforceMemoryLimits()
     {
         memoryManager.process(queries.values().stream()
-                .filter(query -> !query.getQueryInfo().getState().isDone())
+                .filter(query -> query.getQueryInfo().getState() == RUNNING)
                 .collect(toImmutableList()));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -276,6 +276,19 @@ public final class SqlStageExecution
     }
 
     @Override
+    public long getTotalMemoryReservation()
+    {
+        long memory = 0;
+        for (RemoteTask task : tasks.values()) {
+            memory += task.getTaskInfo().getStats().getMemoryReservation().toBytes();
+        }
+        for (StageExecutionNode subStage : subStages.values()) {
+            memory += subStage.getTotalMemoryReservation();
+        }
+        return memory;
+    }
+
+    @Override
     public StageInfo getStageInfo()
     {
         try (SetThreadName ignored = new SetThreadName("Stage-%s", stageId)) {
@@ -981,6 +994,8 @@ public final class SqlStageExecution
 interface StageExecutionNode
 {
     StageInfo getStageInfo();
+
+    long getTotalMemoryReservation();
 
     StageState getState();
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution;
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.Session;
 import com.facebook.presto.TaskSource;
+import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
@@ -49,6 +50,8 @@ public interface TaskManager
      * queried.
      */
     ListenableFuture<TaskInfo> getTaskInfo(TaskId taskId, TaskState currentState);
+
+    void updateMemoryPoolAssignments(MemoryPoolAssignmentsRequest assignments);
 
     /**
      * Updates the task plan, sources and output buffers.  If the task does not

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryPool.java
@@ -41,6 +41,9 @@ public class ClusterMemoryPool
     @GuardedBy("this")
     private int blockedNodes;
 
+    @GuardedBy("this")
+    private int queries;
+
     public ClusterMemoryPool(MemoryPoolId id)
     {
         this.id = requireNonNull(id, "id is null");
@@ -75,12 +78,19 @@ public class ClusterMemoryPool
         return blockedNodes;
     }
 
-    public synchronized void update(List<MemoryInfo> memoryInfos)
+    @Managed
+    public synchronized int getQueries()
+    {
+        return queries;
+    }
+
+    public synchronized void update(List<MemoryInfo> memoryInfos, int queries)
     {
         nodes = 0;
         blockedNodes = 0;
         totalDistributedBytes = 0;
         freeDistributedBytes = 0;
+        this.queries = queries;
 
         for (MemoryInfo info : memoryInfos) {
             MemoryPoolInfo poolInfo = info.getPools().get(id);
@@ -123,6 +133,7 @@ public class ClusterMemoryPool
                 .add("freeDistributedBytes", freeDistributedBytes)
                 .add("nodes", nodes)
                 .add("blockedNodes", blockedNodes)
+                .add("queries", queries)
                 .toString();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
@@ -83,6 +83,7 @@ public class MemoryPool
      */
     public synchronized boolean tryReserve(long bytes)
     {
+        checkArgument(bytes >= 0, "bytes is negative");
         if (freeBytes - bytes < 0) {
             return false;
         }
@@ -93,7 +94,7 @@ public class MemoryPool
     public synchronized void free(long bytes)
     {
         checkArgument(bytes >= 0, "bytes is negative");
-        checkArgument(freeBytes <= maxBytes, "tried to free more memory than is reserved");
+        checkArgument(freeBytes + bytes <= maxBytes, "tried to free more memory than is reserved");
         freeBytes += bytes;
         if (freeBytes > 0 && future != null) {
             future.set(null);

--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPoolAssignment.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPoolAssignment.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.facebook.presto.execution.QueryId;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import static java.util.Objects.requireNonNull;
+
+public class MemoryPoolAssignment
+{
+    private final QueryId queryId;
+    private final MemoryPoolId poolId;
+
+    @JsonCreator
+    public MemoryPoolAssignment(@JsonProperty("queryId") QueryId queryId, @JsonProperty("poolId") MemoryPoolId poolId)
+    {
+        this.queryId = requireNonNull(queryId, "queryId is null");
+        this.poolId = requireNonNull(poolId, "poolId is null");
+    }
+
+    @JsonProperty
+    public QueryId getQueryId()
+    {
+        return queryId;
+    }
+
+    @JsonProperty
+    public MemoryPoolId getPoolId()
+    {
+        return poolId;
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("queryId", queryId)
+                .add("poolId", poolId)
+                .toString();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPoolAssignmentsRequest.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPoolAssignmentsRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class MemoryPoolAssignmentsRequest
+{
+    private final long version;
+    private final List<MemoryPoolAssignment> assignments;
+
+    @JsonCreator
+    public MemoryPoolAssignmentsRequest(@JsonProperty("version") long version, @JsonProperty("assignments") List<MemoryPoolAssignment> assignments)
+    {
+        this.version = version;
+        this.assignments = ImmutableList.copyOf(requireNonNull(assignments, "assignments is null"));
+    }
+
+    @JsonProperty
+    public long getVersion()
+    {
+        return version;
+    }
+
+    @JsonProperty
+    public List<MemoryPoolAssignment> getAssignments()
+    {
+        return assignments;
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("version", version)
+                .add("assignments", assignments)
+                .toString();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryResource.java
@@ -13,8 +13,11 @@
  */
 package com.facebook.presto.memory;
 
+import com.facebook.presto.execution.TaskManager;
+
 import javax.inject.Inject;
-import javax.ws.rs.GET;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -28,17 +31,21 @@ import static java.util.Objects.requireNonNull;
 public class MemoryResource
 {
     private final LocalMemoryManager memoryManager;
+    private final TaskManager taskManager;
 
     @Inject
-    public MemoryResource(LocalMemoryManager memoryManager)
+    public MemoryResource(LocalMemoryManager memoryManager, TaskManager taskManager)
     {
         this.memoryManager = requireNonNull(memoryManager, "memoryManager is null");
+        this.taskManager = requireNonNull(taskManager, "taskManager is null");
     }
 
-    @GET
+    @POST
     @Produces(MediaType.APPLICATION_JSON)
-    public MemoryInfo getMemoryInfo()
+    @Consumes(MediaType.APPLICATION_JSON)
+    public MemoryInfo getMemoryInfo(MemoryPoolAssignmentsRequest request)
     {
+        taskManager.updateMemoryPoolAssignments(request);
         return memoryManager.getInfo();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/memory/VersionedMemoryPoolId.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/VersionedMemoryPoolId.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.google.common.base.MoreObjects;
+
+import static java.util.Objects.requireNonNull;
+
+public class VersionedMemoryPoolId
+{
+    private final MemoryPoolId id;
+    private final long version;
+
+    public VersionedMemoryPoolId(MemoryPoolId id, long version)
+    {
+        this.id = requireNonNull(id, "id is null");
+        this.version = version;
+    }
+
+    public MemoryPoolId getId()
+    {
+        return id;
+    }
+
+    public long getVersion()
+    {
+        return version;
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("id", id)
+                .add("version", version)
+                .toString();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/BlockedReason.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BlockedReason.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+public enum BlockedReason
+{
+    WAITING_FOR_MEMORY
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverStats.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.joda.time.DateTime;
@@ -25,9 +26,11 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @Immutable
@@ -46,6 +49,8 @@ public class DriverStats
     private final Duration totalCpuTime;
     private final Duration totalUserTime;
     private final Duration totalBlockedTime;
+    private final boolean fullyBlocked;
+    private final Set<BlockedReason> blockedReasons;
 
     private final DataSize rawInputDataSize;
     private final long rawInputPositions;
@@ -73,6 +78,8 @@ public class DriverStats
         this.totalCpuTime = new Duration(0, MILLISECONDS);
         this.totalUserTime = new Duration(0, MILLISECONDS);
         this.totalBlockedTime = new Duration(0, MILLISECONDS);
+        this.fullyBlocked = false;
+        this.blockedReasons = ImmutableSet.of();
 
         this.rawInputDataSize = new DataSize(0, BYTE);
         this.rawInputPositions = 0;
@@ -101,6 +108,8 @@ public class DriverStats
             @JsonProperty("totalCpuTime") Duration totalCpuTime,
             @JsonProperty("totalUserTime") Duration totalUserTime,
             @JsonProperty("totalBlockedTime") Duration totalBlockedTime,
+            @JsonProperty("fullyBlocked") boolean fullyBlocked,
+            @JsonProperty("blockedReasons") Set<BlockedReason> blockedReasons,
 
             @JsonProperty("rawInputDataSize") DataSize rawInputDataSize,
             @JsonProperty("rawInputPositions") long rawInputPositions,
@@ -126,6 +135,8 @@ public class DriverStats
         this.totalCpuTime = checkNotNull(totalCpuTime, "totalCpuTime is null");
         this.totalUserTime = checkNotNull(totalUserTime, "totalUserTime is null");
         this.totalBlockedTime = checkNotNull(totalBlockedTime, "totalBlockedTime is null");
+        this.fullyBlocked = fullyBlocked;
+        this.blockedReasons = ImmutableSet.copyOf(requireNonNull(blockedReasons, "blockedReasons is null"));
 
         this.rawInputDataSize = checkNotNull(rawInputDataSize, "rawInputDataSize is null");
         Preconditions.checkArgument(rawInputPositions >= 0, "rawInputPositions is negative");
@@ -203,6 +214,18 @@ public class DriverStats
     public Duration getTotalBlockedTime()
     {
         return totalBlockedTime;
+    }
+
+    @JsonProperty
+    public boolean isFullyBlocked()
+    {
+        return fullyBlocked;
+    }
+
+    @JsonProperty
+    public Set<BlockedReason> getBlockedReasons()
+    {
+        return blockedReasons;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -17,7 +17,10 @@ import com.facebook.presto.ExceededMemoryLimitException;
 import com.facebook.presto.Session;
 import com.facebook.presto.spi.Page;
 import com.google.common.base.Supplier;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.stats.CounterStat;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -26,11 +29,12 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
+import static com.facebook.presto.operator.BlockedReason.WAITING_FOR_MEMORY;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.airlift.units.DataSize.Unit.BYTE;
@@ -64,7 +68,7 @@ public class OperatorContext
     private final CounterStat outputDataSize = new CounterStat();
     private final CounterStat outputPositions = new CounterStat();
 
-    private final AtomicReference<ListenableFuture<?>> memoryFuture = new AtomicReference<>(NOT_BLOCKED);
+    private final AtomicReference<SettableFuture<?>> memoryFuture = new AtomicReference<>();
     private final AtomicReference<BlockedMonitor> blockedMonitor = new AtomicReference<>();
     private final AtomicLong blockedWallNanos = new AtomicLong();
 
@@ -87,6 +91,9 @@ public class OperatorContext
         this.operatorType = checkNotNull(operatorType, "operatorType is null");
         this.driverContext = checkNotNull(driverContext, "driverContext is null");
         this.executor = checkNotNull(executor, "executor is null");
+        SettableFuture<Object> future = SettableFuture.create();
+        future.set(null);
+        this.memoryFuture.set(future);
 
         collectTimings = driverContext.isVerboseStats() && driverContext.isCpuTimerEnabled();
     }
@@ -214,7 +221,34 @@ public class OperatorContext
     {
         ListenableFuture<?> future = driverContext.reserveMemory(bytes);
         if (!future.isDone()) {
-            memoryFuture.set(future);
+            SettableFuture<?> currentMemoryFuture = memoryFuture.get();
+            while (currentMemoryFuture.isDone()) {
+                SettableFuture<?> settableFuture = SettableFuture.create();
+                // We can't replace one that's not done, because the task may be blocked on that future
+                if (memoryFuture.compareAndSet(currentMemoryFuture, settableFuture)) {
+                    currentMemoryFuture = settableFuture;
+                }
+                else {
+                    currentMemoryFuture = memoryFuture.get();
+                }
+            }
+
+            SettableFuture<?> finalMemoryFuture = currentMemoryFuture;
+            // Create a new future, so that this operator can un-block before the pool does, if it's moved to a new pool
+            Futures.addCallback(future, new FutureCallback<Object>()
+            {
+                @Override
+                public void onSuccess(Object result)
+                {
+                    finalMemoryFuture.set(null);
+                }
+
+                @Override
+                public void onFailure(Throwable t)
+                {
+                    finalMemoryFuture.set(null);
+                }
+            });
         }
         long newReservation = memoryReservation.getAndAdd(bytes);
         if (newReservation > maxMemoryReservation) {
@@ -243,6 +277,11 @@ public class OperatorContext
         checkArgument(bytes <= memoryReservation.get(), "tried to free more memory than is reserved");
         driverContext.freeMemory(bytes);
         memoryReservation.getAndAdd(-bytes);
+    }
+
+    public void moreMemoryAvailable()
+    {
+        memoryFuture.get().set(null);
     }
 
     public synchronized void setMemoryReservation(long newMemoryReservation)
@@ -334,6 +373,7 @@ public class OperatorContext
                 new Duration(finishUserNanos.get(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
 
                 new DataSize(memoryReservation.get(), BYTE).convertToMostSuccinctDataSize(),
+                memoryFuture.get().isDone() ? Optional.empty() : Optional.of(WAITING_FOR_MEMORY),
                 info);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.util.ImmutableCollectors;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
@@ -223,6 +224,11 @@ public class PipelineContext
         memoryReservation.getAndAdd(-bytes);
     }
 
+    public void moreMemoryAvailable()
+    {
+        drivers.stream().forEach(DriverContext::moreMemoryAvailable);
+    }
+
     public boolean isVerboseStats()
     {
         return taskContext.isVerboseStats();
@@ -377,6 +383,8 @@ public class PipelineContext
                 new Duration(totalCpuTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 new Duration(totalUserTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 new Duration(totalBlockedTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),
+                drivers.stream().allMatch(DriverStats::isFullyBlocked),
+                drivers.stream().flatMap(driver -> driver.getBlockedReasons().stream()).collect(ImmutableCollectors.toImmutableSet()),
 
                 new DataSize(rawInputDataSize, BYTE).convertToMostSuccinctDataSize(),
                 rawInputPositions,

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineStats.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.stats.Distribution.DistributionSnapshot;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -23,9 +24,11 @@ import io.airlift.units.Duration;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 @Immutable
 public class PipelineStats
@@ -49,6 +52,8 @@ public class PipelineStats
     private final Duration totalCpuTime;
     private final Duration totalUserTime;
     private final Duration totalBlockedTime;
+    private final boolean fullyBlocked;
+    private final Set<BlockedReason> blockedReasons;
 
     private final DataSize rawInputDataSize;
     private final long rawInputPositions;
@@ -83,6 +88,8 @@ public class PipelineStats
             @JsonProperty("totalCpuTime") Duration totalCpuTime,
             @JsonProperty("totalUserTime") Duration totalUserTime,
             @JsonProperty("totalBlockedTime") Duration totalBlockedTime,
+            @JsonProperty("fullyBlocked") boolean fullyBlocked,
+            @JsonProperty("blockedReasons") Set<BlockedReason> blockedReasons,
 
             @JsonProperty("rawInputDataSize") DataSize rawInputDataSize,
             @JsonProperty("rawInputPositions") long rawInputPositions,
@@ -121,6 +128,8 @@ public class PipelineStats
         this.totalCpuTime = checkNotNull(totalCpuTime, "totalCpuTime is null");
         this.totalUserTime = checkNotNull(totalUserTime, "totalUserTime is null");
         this.totalBlockedTime = checkNotNull(totalBlockedTime, "totalBlockedTime is null");
+        this.fullyBlocked = fullyBlocked;
+        this.blockedReasons = ImmutableSet.copyOf(requireNonNull(blockedReasons, "blockedReasons is null"));
 
         this.rawInputDataSize = checkNotNull(rawInputDataSize, "rawInputDataSize is null");
         checkArgument(rawInputPositions >= 0, "rawInputPositions is negative");
@@ -229,6 +238,18 @@ public class PipelineStats
     }
 
     @JsonProperty
+    public boolean isFullyBlocked()
+    {
+        return fullyBlocked;
+    }
+
+    @JsonProperty
+    public Set<BlockedReason> getBlockedReasons()
+    {
+        return blockedReasons;
+    }
+
+    @JsonProperty
     public DataSize getRawInputDataSize()
     {
         return rawInputDataSize;
@@ -294,6 +315,8 @@ public class PipelineStats
                 totalCpuTime,
                 totalUserTime,
                 totalBlockedTime,
+                fullyBlocked,
+                blockedReasons,
                 rawInputDataSize,
                 rawInputPositions,
                 processedInputDataSize,

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.joda.time.DateTime;
@@ -23,10 +24,12 @@ import org.joda.time.DateTime;
 import javax.annotation.Nullable;
 
 import java.util.List;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class TaskStats
@@ -52,6 +55,8 @@ public class TaskStats
     private final Duration totalCpuTime;
     private final Duration totalUserTime;
     private final Duration totalBlockedTime;
+    private final boolean fullyBlocked;
+    private final Set<BlockedReason> blockedReasons;
 
     private final DataSize rawInputDataSize;
     private final long rawInputPositions;
@@ -83,6 +88,8 @@ public class TaskStats
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
+                false,
+                ImmutableSet.of(),
                 new DataSize(0, BYTE),
                 0,
                 new DataSize(0, BYTE),
@@ -114,6 +121,8 @@ public class TaskStats
             @JsonProperty("totalCpuTime") Duration totalCpuTime,
             @JsonProperty("totalUserTime") Duration totalUserTime,
             @JsonProperty("totalBlockedTime") Duration totalBlockedTime,
+            @JsonProperty("fullyBlocked") boolean fullyBlocked,
+            @JsonProperty("blockedReasons") Set<BlockedReason> blockedReasons,
 
             @JsonProperty("rawInputDataSize") DataSize rawInputDataSize,
             @JsonProperty("rawInputPositions") long rawInputPositions,
@@ -154,6 +163,8 @@ public class TaskStats
         this.totalCpuTime = checkNotNull(totalCpuTime, "totalCpuTime is null");
         this.totalUserTime = checkNotNull(totalUserTime, "totalUserTime is null");
         this.totalBlockedTime = checkNotNull(totalBlockedTime, "totalBlockedTime is null");
+        this.fullyBlocked = fullyBlocked;
+        this.blockedReasons = ImmutableSet.copyOf(requireNonNull(blockedReasons, "blockedReasons is null"));
 
         this.rawInputDataSize = checkNotNull(rawInputDataSize, "rawInputDataSize is null");
         checkArgument(rawInputPositions >= 0, "rawInputPositions is negative");
@@ -264,6 +275,18 @@ public class TaskStats
     }
 
     @JsonProperty
+    public boolean isFullyBlocked()
+    {
+        return fullyBlocked;
+    }
+
+    @JsonProperty
+    public Set<BlockedReason> getBlockedReasons()
+    {
+        return blockedReasons;
+    }
+
+    @JsonProperty
     public DataSize getRawInputDataSize()
     {
         return rawInputDataSize;
@@ -337,6 +360,8 @@ public class TaskStats
                 totalCpuTime,
                 totalUserTime,
                 totalBlockedTime,
+                fullyBlocked,
+                blockedReasons,
                 rawInputDataSize,
                 rawInputPositions,
                 processedInputDataSize,

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -40,6 +40,7 @@ import com.facebook.presto.memory.ForMemoryManager;
 import com.facebook.presto.memory.LocalMemoryManager;
 import com.facebook.presto.memory.MemoryInfo;
 import com.facebook.presto.memory.MemoryManagerConfig;
+import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
 import com.facebook.presto.memory.MemoryResource;
 import com.facebook.presto.memory.ReservedSystemMemoryConfig;
 import com.facebook.presto.metadata.CatalogManager;
@@ -206,6 +207,7 @@ public class ServerMainModule
                 });
 
         jsonCodecBinder(binder).bindJsonCodec(MemoryInfo.class);
+        jsonCodecBinder(binder).bindJsonCodec(MemoryPoolAssignmentsRequest.class);
 
         // data stream provider
         binder.bind(PageSourceManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -16,6 +16,7 @@ package com.facebook.presto.server.testing;
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.memory.ClusterMemoryManager;
+import com.facebook.presto.memory.LocalMemoryManager;
 import com.facebook.presto.metadata.AllNodes;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.Metadata;
@@ -78,6 +79,7 @@ public class TestingPrestoServer
     private final TestingHttpServer server;
     private final Metadata metadata;
     private final ClusterMemoryManager clusterMemoryManager;
+    private final LocalMemoryManager localMemoryManager;
     private final InternalNodeManager nodeManager;
     private final ServiceSelectorManager serviceSelectorManager;
     private final Announcer announcer;
@@ -161,6 +163,7 @@ public class TestingPrestoServer
         server = injector.getInstance(TestingHttpServer.class);
         metadata = injector.getInstance(Metadata.class);
         clusterMemoryManager = injector.getInstance(ClusterMemoryManager.class);
+        localMemoryManager = injector.getInstance(LocalMemoryManager.class);
         nodeManager = injector.getInstance(InternalNodeManager.class);
         serviceSelectorManager = injector.getInstance(ServiceSelectorManager.class);
         announcer = injector.getInstance(Announcer.class);
@@ -230,6 +233,11 @@ public class TestingPrestoServer
     public Metadata getMetadata()
     {
         return metadata;
+    }
+
+    public LocalMemoryManager getLocalMemoryManager()
+    {
+        return localMemoryManager;
     }
 
     public ClusterMemoryManager getClusterMemoryManager()

--- a/presto-main/src/main/resources/webapp/query.html
+++ b/presto-main/src/main/resources/webapp/query.html
@@ -85,6 +85,9 @@
         <dt>Elapsed</dt>
         <dd id="elapsedTime"></dd>
 
+        <dt>Memory Pool</dt>
+        <dd id="memoryPool"></dd>
+
         <dt>Memory</dt>
         <dd id="memory"></dd>
 
@@ -159,6 +162,7 @@ d3.json('/v1/query/' + window.location.search.substring(1), function (query) {
     d3.select('#sessionCatalog').text(query.session.catalog);
     d3.select('#sessionSchema').text(query.session.schema);
     d3.select('#elapsedTime').text(query.queryStats.elapsedTime);
+    d3.select('#memoryPool').text(query.memoryPool);
     d3.select('#memory').text(query.queryStats.totalMemoryReservation);
     d3.select('#cpuTime').text(query.queryStats.totalCpuTime);
     d3.select('#rows').text(formatCount(query.queryStats.rawInputPositions));

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriverStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriverStats.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -42,6 +43,8 @@ public class TestDriverStats
             new Duration(8, NANOSECONDS),
             new Duration(9, NANOSECONDS),
             new Duration(10, NANOSECONDS),
+            false,
+            ImmutableSet.of(),
 
             new DataSize(11, BYTE),
             12,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -20,6 +20,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.units.DataSize.Unit.BYTE;
@@ -53,6 +54,7 @@ public class TestOperatorStats
             new Duration(17, NANOSECONDS),
 
             new DataSize(18, BYTE),
+            Optional.empty(),
             "19");
 
     public static final OperatorStats MERGEABLE = new OperatorStats(
@@ -81,6 +83,7 @@ public class TestOperatorStats
             new Duration(17, NANOSECONDS),
 
             new DataSize(18, BYTE),
+            Optional.empty(),
             new LongMergeable(19));
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPipelineStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPipelineStats.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodec;
 import io.airlift.stats.Distribution;
 import io.airlift.stats.Distribution.DistributionSnapshot;
@@ -49,6 +50,8 @@ public class TestPipelineStats
             new Duration(9, NANOSECONDS),
             new Duration(10, NANOSECONDS),
             new Duration(11, NANOSECONDS),
+            false,
+            ImmutableSet.of(),
 
             new DataSize(12, BYTE),
             13,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -48,6 +49,8 @@ public class TestTaskStats
             new Duration(13, NANOSECONDS),
             new Duration(14, NANOSECONDS),
             new Duration(15, NANOSECONDS),
+            false,
+            ImmutableSet.of(),
 
             new DataSize(16, BYTE),
             17,

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -163,6 +163,11 @@ public class DistributedQueryRunner
         return coordinator;
     }
 
+    public List<TestingPrestoServer> getServers()
+    {
+        return ImmutableList.copyOf(servers);
+    }
+
     @Override
     public void installPlugin(Plugin plugin)
     {

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -14,24 +14,42 @@
 package com.facebook.presto.memory;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.execution.QueryInfo;
+import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.operator.DriverStats;
+import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
+import static com.facebook.presto.execution.QueryState.FINISHED;
+import static com.facebook.presto.execution.StageInfo.getAllStages;
+import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
 import static com.facebook.presto.memory.LocalMemoryManager.RESERVED_POOL;
+import static com.facebook.presto.operator.BlockedReason.WAITING_FOR_MEMORY;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
 import static java.util.Locale.ENGLISH;
+import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
 public class TestMemoryManager
 {
-    public static final Session SESSION = Session.builder()
+    private static final Session SESSION = Session.builder()
             .setUser("user")
             .setSource("test")
             .setCatalog("tpch")
@@ -41,30 +59,123 @@ public class TestMemoryManager
             .setLocale(ENGLISH)
             .build();
 
+    private static final Session TINY_SESSION = Session.builder()
+            .setUser("user")
+            .setSource("source")
+            .setCatalog("tpch")
+            .setSchema("tiny")
+            .setTimeZoneKey(UTC_KEY)
+            .setLocale(ENGLISH)
+            .setRemoteUserAddress("address")
+            .setUserAgent("agent")
+            .build();
+
+    private final ExecutorService executor = newCachedThreadPool();
+
     @Test(timeOut = 240_000)
     public void testClusterPools()
             throws Exception
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("experimental.cluster-memory-manager-enabled", "true")
+                .put("task.verbose-stats", "true")
+                .put("task.operator-pre-allocated-memory", "0B")
                 .build();
-        try (DistributedQueryRunner queryRunner = createQueryRunner(SESSION, properties)) {
+
+        try (DistributedQueryRunner queryRunner = createQueryRunner(TINY_SESSION, properties)) {
+            // Reserve all the memory
+            for (TestingPrestoServer server : queryRunner.getServers()) {
+                for (MemoryPool pool : server.getLocalMemoryManager().getPools()) {
+                    assertTrue(pool.tryReserve(pool.getMaxBytes()));
+                }
+            }
+
+            List<Future<?>> queryFutures = new ArrayList<>();
+            for (int i = 0; i < 2; i++) {
+                queryFutures.add(executor.submit(() -> queryRunner.execute("SELECT COUNT(*), clerk FROM orders GROUP BY clerk")));
+            }
+
             ClusterMemoryManager memoryManager = queryRunner.getCoordinator().getClusterMemoryManager();
-            ClusterMemoryPool reservedPool = null;
-            while (reservedPool == null) {
-                reservedPool = memoryManager.getPools().get(RESERVED_POOL);
-                MILLISECONDS.sleep(100);
+            ClusterMemoryPool reservedPool;
+            while ((reservedPool = memoryManager.getPools().get(RESERVED_POOL)) == null) {
+                MILLISECONDS.sleep(10);
             }
 
-            while (reservedPool.getNodes() == 0) {
-                MILLISECONDS.sleep(100);
+            ClusterMemoryPool generalPool = memoryManager.getPools().get(GENERAL_POOL);
+            assertNotNull(generalPool);
+
+            // Wait for the queries to start running and get assigned to the expected pools
+            while (generalPool.getQueries() != 1 || reservedPool.getQueries() != 1 || generalPool.getBlockedNodes() != 2 || reservedPool.getBlockedNodes() != 2) {
+                MILLISECONDS.sleep(10);
             }
 
-            assertTrue(reservedPool.getNodes() > 0);
-            assertTrue(reservedPool.getBlockedNodes() == 0);
-            assertTrue(reservedPool.getTotalDistributedBytes() > 0);
-            assertTrue(reservedPool.getFreeDistributedBytes() > 0);
+            // Make sure the queries are blocked
+            List<QueryInfo> currentQueryInfos = queryRunner.getCoordinator().getQueryManager().getAllQueryInfo();
+            for (QueryInfo info : currentQueryInfos) {
+                assertFalse(info.getState().isDone());
+            }
+            assertEquals(currentQueryInfos.size(), 2);
+            // Check that the pool information propagated to the query objects
+            assertNotEquals(currentQueryInfos.get(0).getMemoryPool(), currentQueryInfos.get(1).getMemoryPool());
+
+            while (!allQueriesBlocked(currentQueryInfos)) {
+                MILLISECONDS.sleep(10);
+                currentQueryInfos = queryRunner.getCoordinator().getQueryManager().getAllQueryInfo();
+                for (QueryInfo info : currentQueryInfos) {
+                    assertFalse(info.getState().isDone());
+                }
+            }
+
+            // Release the memory in the reserved pool
+            for (TestingPrestoServer server : queryRunner.getServers()) {
+                MemoryPool reserved = server.getLocalMemoryManager().getPool(RESERVED_POOL);
+                // Free up the entire pool
+                reserved.free(reserved.getMaxBytes());
+                assertTrue(reserved.getFreeBytes() > 0);
+            }
+
+            // Make sure both queries finish now that there's memory free in the reserved pool.
+            // This also checks that the query in the general pool is successfully moved to the reserved pool.
+            for (Future<?> query : queryFutures) {
+                query.get();
+            }
+
+            List<QueryInfo> queryInfos = queryRunner.getCoordinator().getQueryManager().getAllQueryInfo();
+            for (QueryInfo info : queryInfos) {
+                assertEquals(info.getState(), FINISHED);
+            }
+
+            // Make sure we didn't leak any memory on the workers
+            for (TestingPrestoServer worker : queryRunner.getServers()) {
+                MemoryPool reserved = worker.getLocalMemoryManager().getPool(RESERVED_POOL);
+                assertEquals(reserved.getMaxBytes(), reserved.getFreeBytes());
+                MemoryPool general = worker.getLocalMemoryManager().getPool(GENERAL_POOL);
+                // Free up the memory we reserved earlier
+                general.free(general.getMaxBytes());
+                assertEquals(general.getMaxBytes(), general.getFreeBytes());
+            }
         }
+    }
+
+    private static boolean allQueriesBlocked(List<QueryInfo> current)
+    {
+        boolean allDriversBlocked = current.stream()
+                .flatMap(query -> getAllStages(query.getOutputStage()).stream())
+                .flatMap(stage -> stage.getTasks().stream())
+                .flatMap(task -> task.getStats().getPipelines().stream())
+                .flatMap(pipeline -> pipeline.getDrivers().stream())
+                .allMatch(DriverStats::isFullyBlocked);
+        boolean waitingForMemory = current.stream().allMatch(TestMemoryManager::atLeastOneOperatorWaitingForMemory);
+
+        return allDriversBlocked && waitingForMemory;
+    }
+
+    private static boolean atLeastOneOperatorWaitingForMemory(QueryInfo query)
+    {
+        return getAllStages(query.getOutputStage()).stream()
+                .flatMap(stage -> stage.getTasks().stream())
+                .map(TaskInfo::getStats)
+                .anyMatch(task -> task.getBlockedReasons().contains(WAITING_FOR_MEMORY));
     }
 
     @Test(timeOut = 240_000, expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Query exceeded max memory size of 1kB.*")
@@ -93,6 +204,12 @@ public class TestMemoryManager
         try (QueryRunner queryRunner = createQueryRunner(SESSION, properties)) {
             queryRunner.execute(SESSION, "SELECT COUNT(*), clerk FROM orders GROUP BY clerk");
         }
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void shutdown()
+    {
+        executor.shutdownNow();
     }
 
     private static DistributedQueryRunner createQueryRunner(Session session, Map<String, String> properties)


### PR DESCRIPTION
The coordinator now automatically moves queries into the reserved pool
when necessary, and keeps a global view of the cluster's memory pools.