### PR TITLE
Prune StageInfo objects from expired queries

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -105,6 +105,12 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
+    public void pruneInfo()
+    {
+        // no-op
+    }
+
+    @Override
     public QueryId getQueryId()
     {
         return stateMachine.getQueryId();

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -81,4 +81,10 @@ public class FailedQueryExecution
     {
         // no-op
     }
+
+    @Override
+    public void pruneInfo()
+    {
+        // no-op
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -35,6 +35,9 @@ public interface QueryExecution
 
     void recordHeartbeat();
 
+    // XXX: This should be removed when the client protocol is improved, so that we don't need to hold onto so much query history
+    void pruneInfo();
+
     void addStateChangeListener(StateChangeListener<QueryState> stateChangeListener);
 
     interface QueryExecutionFactory<T extends QueryExecution>


### PR DESCRIPTION
The StageInfo object graph can be very large, as it contains the entire
plan, all the tasks, and all the buffers involved in the tasks. This
change prunes StageInfo objects for all queries past the max query
history limit