### PR TITLE
Don't retry when an S3 path is not found

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -729,6 +729,7 @@ public class PrestoS3FileSystem
                                             // ignore request for start past end of object
                                             return new ByteArrayInputStream(new byte[0]);
                                         case SC_FORBIDDEN:
+                                        case SC_NOT_FOUND:
                                             throw new UnrecoverableS3OperationException(e);
                                     }
                                 }


### PR DESCRIPTION
Since S3 provides eventual consistency it's possible that a listing may return a path that doesn't exist. I think PrestoS3FileSystem should fail fast for these paths to release cluster resources as we don't really know when that particular path will be available.