### PR TITLE
Update presto-hive-apache, with Parquet 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
             <dependency>
                 <groupId>com.facebook.presto.hive</groupId>
                 <artifactId>hive-apache</artifactId>
-                <version>0.10</version>
+                <version>0.11</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
@electrum is it OK to update to newer version of presto-hive-apache?