### PR TITLE
Optimize map_agg memory usage.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/BigWriteableBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/BigWriteableBlock.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.BlockEncoding;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.util.array.LongBigArray;
+import io.airlift.slice.Slice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.operator.SyntheticAddress.decodePosition;
+import static com.facebook.presto.operator.SyntheticAddress.decodeSliceIndex;
+import static com.facebook.presto.operator.SyntheticAddress.encodeSyntheticAddress;
+import static java.util.Objects.requireNonNull;
+
+public class BigWriteableBlock
+        implements BlockBuilder
+{
+    private final List<Block> blocks = new ArrayList<>();
+    private final LongBigArray addresses = new LongBigArray();
+    private final Type type;
+    private int completedBlockSize;
+    private int nextPosition;
+    private BlockBuilder currentBuilder;
+
+    public BigWriteableBlock(Type type, int expectedSize)
+    {
+        this.type = requireNonNull(type, "type is null");
+        this.currentBuilder = type.createBlockBuilder(new BlockBuilderStatus(), expectedSize);
+        blocks.add(currentBuilder);
+    }
+
+    @Override
+    public BlockBuilder writeByte(int value)
+    {
+        currentBuilder.writeByte(value);
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeShort(int value)
+    {
+        currentBuilder.writeShort(value);
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeInt(int value)
+    {
+        currentBuilder.writeInt(value);
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeLong(long value)
+    {
+        currentBuilder.writeLong(value);
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeFloat(float v)
+    {
+        currentBuilder.writeFloat(v);
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeDouble(double value)
+    {
+        currentBuilder.writeDouble(value);
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeBytes(Slice source, int sourceIndex, int length)
+    {
+        currentBuilder.writeBytes(source, sourceIndex, length);
+        return this;
+    }
+
+    @Override
+    public BlockBuilder closeEntry()
+    {
+        currentBuilder.closeEntry();
+        recordAddress();
+        return this;
+    }
+
+    @Override
+    public BlockBuilder appendNull()
+    {
+        currentBuilder.appendNull();
+        recordAddress();
+        return this;
+    }
+
+    private void recordAddress()
+    {
+        addresses.ensureCapacity(nextPosition + 1);
+        addresses.set(nextPosition, encodeSyntheticAddress(blocks.size() - 1, currentBuilder.getPositionCount() - 1));
+        nextPosition++;
+
+        // Start a new block is necessary
+        if (currentBuilder.isFull()) {
+            Block block = currentBuilder.build();
+            completedBlockSize += block.getSizeInBytes();
+            // currentBuilder is already at the end of the arrays, so replace it
+            blocks.set(blocks.size() - 1, block);
+            // Assume that the next block will be about the same size
+            currentBuilder = type.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount(), block.getSizeInBytes() / block.getPositionCount());
+        }
+    }
+
+    @Override
+    public Block build()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return blocks.size() == 1 && currentBuilder.isEmpty();
+    }
+
+    @Override
+    public boolean isFull()
+    {
+        // Conceptually this would return "false", but if it's ever called this is probably being used in the wrong context
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getLength(int position)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).getLength(blockPosition);
+    }
+
+    @Override
+    public byte getByte(int position, int offset)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).getByte(blockPosition, offset);
+    }
+
+    @Override
+    public short getShort(int position, int offset)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).getShort(blockPosition, offset);
+    }
+
+    @Override
+    public int getInt(int position, int offset)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).getInt(blockPosition, offset);
+    }
+
+    @Override
+    public long getLong(int position, int offset)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).getLong(blockPosition, offset);
+    }
+
+    @Override
+    public float getFloat(int position, int offset)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).getFloat(blockPosition, offset);
+    }
+
+    @Override
+    public double getDouble(int position, int offset)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).getDouble(blockPosition, offset);
+    }
+
+    @Override
+    public Slice getSlice(int position, int offset, int length)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).getSlice(blockPosition, offset, length);
+    }
+
+    @Override
+    public boolean bytesEqual(int position, int offset, Slice otherSlice, int otherOffset, int length)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).bytesEqual(blockPosition, offset, otherSlice, otherOffset, length);
+    }
+
+    @Override
+    public int bytesCompare(int position, int offset, int length, Slice otherSlice, int otherOffset, int otherLength)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).bytesCompare(blockPosition, offset, length, otherSlice, otherOffset, otherLength);
+    }
+
+    @Override
+    public void writeBytesTo(int position, int offset, int length, BlockBuilder blockBuilder)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        blocks.get(block).writeBytesTo(blockPosition, offset, length, blockBuilder);
+    }
+
+    @Override
+    public boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).equals(blockPosition, offset, otherBlock, otherPosition, otherOffset, length);
+    }
+
+    @Override
+    public int hash(int position, int offset, int length)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).hash(blockPosition, offset, length);
+    }
+
+    @Override
+    public int compareTo(int leftPosition, int leftOffset, int leftLength, Block rightBlock, int rightPosition, int rightOffset, int rightLength)
+    {
+        int block = decodeSliceIndex(addresses.get(leftPosition));
+        int blockPosition = decodePosition(addresses.get(leftPosition));
+        return blocks.get(block).compareTo(blockPosition, leftOffset, leftLength, rightBlock, rightPosition, rightOffset, rightLength);
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).getSingleValueBlock(blockPosition);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return nextPosition;
+    }
+
+    @Override
+    public int getSizeInBytes()
+    {
+        return completedBlockSize + currentBuilder.getSizeInBytes();
+    }
+
+    @Override
+    public BlockEncoding getEncoding()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        int block = decodeSliceIndex(addresses.get(position));
+        int blockPosition = decodePosition(addresses.get(position));
+        return blocks.get(block).isNull(blockPosition);
+    }
+
+    @Override
+    public void assureLoaded()
+    {
+        currentBuilder.assureLoaded();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/KeyValuePairs.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/KeyValuePairs.java
@@ -13,22 +13,15 @@
  */
 package com.facebook.presto.operator.aggregation;
 
-import com.facebook.presto.operator.GroupByHash;
-import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.type.TypeUtils;
-import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.Optional;
-
-import static com.facebook.presto.operator.GroupByHash.createGroupByHash;
-import static com.facebook.presto.spi.block.BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
 import static com.facebook.presto.type.TypeUtils.buildStructuralSlice;
 import static com.facebook.presto.type.TypeUtils.expectedValueSize;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -39,7 +32,7 @@ public class KeyValuePairs
     private static final int EXPECTED_ENTRIES = 10;
     private static final int EXPECTED_ENTRY_SIZE = 16;
 
-    private final GroupByHash keysHash;
+    private final TypedSet keySet;
     private final BlockBuilder keyBlockBuilder;
     private final Type keyType;
 
@@ -53,24 +46,15 @@ public class KeyValuePairs
 
         this.keyType = keyType;
         this.valueType = valueType;
-        keysHash = createGroupByHash(ImmutableList.of(keyType), new int[] {0}, Optional.empty(), Optional.empty(), EXPECTED_ENTRIES);
-        BlockBuilderStatus keyBlockBuilderStatus = new BlockBuilderStatus();
-        keyBlockBuilder = this.keyType.createBlockBuilder(keyBlockBuilderStatus, EXPECTED_ENTRIES, expectedValueSize(keyType, EXPECTED_ENTRY_SIZE));
+        this.keySet = new SimpleTypedSet(keyType, EXPECTED_ENTRIES);
+        keyBlockBuilder = this.keyType.createBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES, expectedValueSize(keyType, EXPECTED_ENTRY_SIZE));
         valueBlockBuilder = this.valueType.createBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES, expectedValueSize(valueType, EXPECTED_ENTRY_SIZE));
     }
 
     public KeyValuePairs(Slice serialized, Type keyType, Type valueType)
     {
+        this(keyType, valueType);
         checkNotNull(serialized, "serialized is null");
-        checkNotNull(keyType, "keyType is null");
-        checkNotNull(valueType, "valueType is null");
-
-        this.keyType = keyType;
-        this.valueType = valueType;
-        keysHash = createGroupByHash(ImmutableList.of(keyType), new int[] {0}, Optional.empty(), Optional.empty(), EXPECTED_ENTRIES);
-        BlockBuilderStatus keyBlockBuilderStatus = new BlockBuilderStatus();
-        keyBlockBuilder = this.keyType.createBlockBuilder(keyBlockBuilderStatus, EXPECTED_ENTRIES, expectedValueSize(keyType, EXPECTED_ENTRY_SIZE));
-        valueBlockBuilder = this.valueType.createBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES, expectedValueSize(valueType, EXPECTED_ENTRY_SIZE));
         deserialize(serialized);
     }
 
@@ -109,16 +93,14 @@ public class KeyValuePairs
         long size = INSTANCE_SIZE;
         size += Math.max(EXPECTED_ENTRIES * expectedValueSize(keyType, EXPECTED_ENTRY_SIZE), keyBlockBuilder.getSizeInBytes());
         size += Math.max(EXPECTED_ENTRIES * expectedValueSize(valueType, EXPECTED_ENTRY_SIZE), valueBlockBuilder.getSizeInBytes());
-        // TODO: We need an optimized version of GroupByHash that doesn't allocate a full PageBuilder
-        size += Math.max(DEFAULT_MAX_BLOCK_SIZE_IN_BYTES, keysHash.getEstimatedSize());
+        size += keySet.getEstimatedSize();
         return size;
     }
 
     public void add(Block key, Block value, int keyPosition, int valuePosition)
     {
-        Page page = new Page(key);
-        if (!keysHash.contains(keyPosition, page)) {
-            keysHash.putIfAbsent(keyPosition, page);
+        if (!keySet.contains(key, keyPosition)) {
+            keySet.add(key, keyPosition);
             keyType.appendTo(key, keyPosition, keyBlockBuilder);
             if (value.isNull(valuePosition)) {
                 valueBlockBuilder.appendNull();

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/SimpleTypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/SimpleTypedSet.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.util.array.IntBigArray;
+
+import static com.facebook.presto.type.TypeUtils.hashPosition;
+import static com.facebook.presto.type.TypeUtils.positionEqualsPosition;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static it.unimi.dsi.fastutil.HashCommon.arraySize;
+
+public class SimpleTypedSet
+        implements TypedSet
+{
+    private static final float FILL_RATIO = 0.75f;
+
+    private final Type elementType;
+    private final IntBigArray blockPositionByHash = new IntBigArray();
+    private final BigWriteableBlock elementBlock;
+
+    private int maxFill;
+    private int hashMask;
+    private static final int EMPTY_SLOT = -1;
+
+    private boolean containsNullElement;
+
+    public SimpleTypedSet(Type elementType, int expectedSize)
+    {
+        checkArgument(expectedSize > 0, "expectedSize must be > 0");
+        this.elementType = checkNotNull(elementType, "elementType must not be null");
+        this.elementBlock = new BigWriteableBlock(elementType, expectedSize);
+
+        int hashSize = arraySize(expectedSize, FILL_RATIO);
+        this.maxFill = calculateMaxFill(hashSize);
+        this.hashMask = hashSize - 1;
+
+        blockPositionByHash.ensureCapacity(hashSize);
+        for (int i = 0; i < hashSize; i++) {
+            blockPositionByHash.set(i, EMPTY_SLOT);
+        }
+
+        this.containsNullElement = false;
+    }
+
+    @Override
+    public long getEstimatedSize()
+    {
+        return elementBlock.getSizeInBytes() + blockPositionByHash.sizeOf();
+    }
+
+    @Override
+    public boolean contains(Block block, int position)
+    {
+        checkNotNull(block, "block must not be null");
+        checkArgument(position >= 0, "position must be >= 0");
+
+        if (block.isNull(position)) {
+            return containsNullElement;
+        }
+        else {
+            return blockPositionByHash.get(getHashPositionOfElement(block, position)) != EMPTY_SLOT;
+        }
+    }
+
+    @Override
+    public void add(Block block, int position)
+    {
+        checkNotNull(block, "block must not be null");
+        checkArgument(position >= 0, "position must be >= 0");
+
+        if (block.isNull(position)) {
+            containsNullElement = true;
+        }
+        else {
+            int hashPosition = getHashPositionOfElement(block, position);
+            if (blockPositionByHash.get(hashPosition) == EMPTY_SLOT) {
+                addNewElement(hashPosition, block, position);
+            }
+        }
+    }
+
+    @Override
+    public int size()
+    {
+        return elementBlock.getPositionCount() + (containsNullElement ? 1 : 0);
+    }
+
+    /**
+     * Get slot position of element at {@code position} of {@code block}
+     */
+    private int getHashPositionOfElement(Block block, int position)
+    {
+        int hashPosition = getMaskedHash(hashPosition(elementType, block, position));
+        while (true) {
+            int blockPosition = blockPositionByHash.get(hashPosition);
+            // Doesn't have this element
+            if (blockPosition == EMPTY_SLOT) {
+                return hashPosition;
+            }
+            // Already has this element
+            else if (positionEqualsPosition(elementType, elementBlock, blockPosition, block, position)) {
+                return hashPosition;
+            }
+
+            hashPosition = getMaskedHash(hashPosition + 1);
+        }
+    }
+
+    private void addNewElement(int hashPosition, Block block, int position)
+    {
+        elementType.appendTo(block, position, elementBlock);
+        blockPositionByHash.set(hashPosition, elementBlock.getPositionCount() - 1);
+
+        // increase capacity, if necessary
+        if (elementBlock.getPositionCount() >= maxFill) {
+            rehash(maxFill * 2);
+        }
+    }
+
+    private void rehash(int size)
+    {
+        int newHashSize = arraySize(size + 1, FILL_RATIO);
+        hashMask = newHashSize - 1;
+        maxFill = calculateMaxFill(newHashSize);
+        blockPositionByHash.ensureCapacity(newHashSize);
+        for (int i = 0; i < newHashSize; i++) {
+            blockPositionByHash.set(i, EMPTY_SLOT);
+        }
+
+        rehashBlock(elementBlock);
+    }
+
+    private void rehashBlock(Block block)
+    {
+        for (int blockPosition = 0; blockPosition < block.getPositionCount(); blockPosition++) {
+            blockPositionByHash.set(getHashPositionOfElement(block, blockPosition), blockPosition);
+        }
+    }
+
+    private static int calculateMaxFill(int hashSize)
+    {
+        int maxFill = (int) Math.ceil(hashSize * FILL_RATIO);
+        if (maxFill == hashSize) {
+            maxFill--;
+        }
+        return maxFill;
+    }
+
+    private int getMaskedHash(int rawHash)
+    {
+        return rawHash & hashMask;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+
+/**
+ * Set of {@code Type} elements
+ */
+public interface TypedSet
+{
+    // Check if contains element at {@code position} of {@code block}
+    boolean contains(Block block, int position);
+
+    // Add element at {@code position} of {@code block}
+    void add(Block block, int position);
+
+    // Number of elements
+    int size();
+
+    // Estimated memory size in bytes
+    long getEstimatedSize();
+}

--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -136,6 +136,11 @@ public final class BlockAssertions
         return builder.build();
     }
 
+    public static Block createEmptyLongsBlock()
+    {
+        return BIGINT.createFixedSizeBlockBuilder(0).build();
+    }
+
     // This method makes it easy to create blocks without having to add an L to every value
     public static Block createLongsBlock(int... values)
     {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestSimpleTypedSet.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestSimpleTypedSet.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.block.BlockAssertions.createEmptyLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongSequenceBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestSimpleTypedSet
+{
+    @Test
+    public void testConstructor()
+            throws Exception
+    {
+        for (int i = -2; i <= 0; i++) {
+            try {
+                //noinspection ResultOfObjectAllocationIgnored
+                new SimpleTypedSet(BIGINT, i);
+                fail("Should throw exception if expectedSize <= 0");
+            }
+            catch (IllegalArgumentException e) {
+                // ignored
+            }
+        }
+
+        try {
+            //noinspection ResultOfObjectAllocationIgnored
+            new SimpleTypedSet(null, 1);
+            fail("Should throw exception if type is null");
+        }
+        catch (NullPointerException | IllegalArgumentException e) {
+            // ignored
+        }
+    }
+
+    @Test
+    public void testBigintSimpleTypedSet()
+            throws Exception
+    {
+        List<Integer> expectedSetSizes = ImmutableList.of(1, 10, 100, 1000);
+        List<Block> longBlocks =
+                ImmutableList.of(
+                        createEmptyLongsBlock(),
+                        createLongsBlock(1L),
+                        createLongsBlock(1L, 2L, 3L),
+                        createLongsBlock(1L, 2L, 3L, 1L, 2L, 3L),
+                        createLongsBlock(1L, null, 3L),
+                        createLongsBlock(null, null, null),
+                        createLongSequenceBlock(0, 100),
+                        createLongSequenceBlock(-100, 100),
+                        createLongsBlock(Collections.nCopies(1, null)),
+                        createLongsBlock(Collections.nCopies(100, null)),
+                        createLongsBlock(Collections.nCopies(expectedSetSizes.get(expectedSetSizes.size() - 1) * 2, null)),
+                        createLongsBlock(Collections.nCopies(expectedSetSizes.get(expectedSetSizes.size() - 1) * 2, 0L))
+                );
+
+        for (int expectedSetSize : expectedSetSizes) {
+            for (Block block : longBlocks) {
+                testBigint(block, expectedSetSize);
+            }
+        }
+    }
+
+    private static void testBigint(Block longBlock, int expectedSetSize)
+    {
+        SimpleTypedSet simpleTypedSet = new SimpleTypedSet(BIGINT, expectedSetSize);
+        Set<Long> set = new HashSet<>();
+        for (int blockPosition = 0; blockPosition < longBlock.getPositionCount(); blockPosition++) {
+            long number = BIGINT.getLong(longBlock, blockPosition);
+            assertEquals(simpleTypedSet.contains(longBlock, blockPosition), set.contains(number));
+            assertEquals(simpleTypedSet.size(), set.size());
+
+            set.add(number);
+            simpleTypedSet.add(longBlock, blockPosition);
+
+            assertEquals(simpleTypedSet.contains(longBlock, blockPosition), set.contains(number));
+            assertEquals(simpleTypedSet.size(), set.size());
+        }
+    }
+}


### PR DESCRIPTION
Use TypedSet instead of GroupByHash to reduce memory useage.