### PR TITLE
Refactor BlockBuilderStatus for usability

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SharedBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SharedBuffer.java
@@ -52,7 +52,7 @@ import static com.facebook.presto.execution.SharedBuffer.BufferState.FLUSHING;
 import static com.facebook.presto.execution.SharedBuffer.BufferState.NO_MORE_BUFFERS;
 import static com.facebook.presto.execution.SharedBuffer.BufferState.NO_MORE_PAGES;
 import static com.facebook.presto.execution.SharedBuffer.BufferState.OPEN;
-import static com.facebook.presto.spi.block.BlockBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+import static com.facebook.presto.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/presto-main/src/test/java/com/facebook/presto/BenchmarkHashPagePartitionFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/BenchmarkHashPagePartitionFunction.java
@@ -16,7 +16,7 @@ package com.facebook.presto;
 import com.facebook.presto.block.BlockAssertions;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.PageBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
@@ -57,7 +57,7 @@ public class BenchmarkHashPagePartitionFunction
 
     private static List<Page> createPages(int pageCount, int channelCount)
     {
-        int positionCount = BlockBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES / (channelCount * 8);
+        int positionCount = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES / (channelCount * 8);
         List<Page> pages = new ArrayList<>(pageCount);
         for (int numPage = 0; numPage < pageCount; numPage++) {
             Block[] blocks = new Block[channelCount];

--- a/presto-main/src/test/java/com/facebook/presto/BenchmarkPagesIndexPageSorter.java
+++ b/presto-main/src/test/java/com/facebook/presto/BenchmarkPagesIndexPageSorter.java
@@ -17,7 +17,7 @@ import com.facebook.presto.block.BlockAssertions;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageSorter;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.PageBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
@@ -62,7 +62,7 @@ public class BenchmarkPagesIndexPageSorter
 
     private static List<Page> createPages(int pageCount, int channelCount, Type type)
     {
-        int positionCount = BlockBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES / (channelCount * 8);
+        int positionCount = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES / (channelCount * 8);
 
         List<Page> pages = new ArrayList<>(pageCount);
         for (int numPage = 0; numPage < pageCount; numPage++) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.PageBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
@@ -260,7 +261,7 @@ public class TestHashAggregationOperator
     {
         // estimate the number of entries required to create 1.5 pages of results
         int fixedWidthSize = SIZE_OF_LONG + SIZE_OF_DOUBLE + SIZE_OF_DOUBLE;
-        int multiSlicePositionCount = (int) (1.5 * BlockBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES / fixedWidthSize);
+        int multiSlicePositionCount = (int) (1.5 * PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES / fixedWidthSize);
         multiSlicePositionCount = Math.min((int) (1.5 * DEFAULT_MAX_BLOCK_SIZE_IN_BYTES / SIZE_OF_DOUBLE), multiSlicePositionCount);
 
         List<Integer> hashChannels = Ints.asList(1);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
@@ -67,14 +67,4 @@ public interface BlockBuilder
      * Builds the block. This method can be called multiple times.
      */
     Block build();
-
-    /**
-     * Have any values been added to the block?
-     */
-    boolean isEmpty();
-
-    /**
-     * Is this block full? If true no more values should be added to the block.
-     */
-    boolean isFull();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilderStatus.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilderStatus.java
@@ -13,32 +13,29 @@
  */
 package com.facebook.presto.spi.block;
 
+import static com.facebook.presto.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+import static java.util.Objects.requireNonNull;
+
 public class BlockBuilderStatus
 {
-    public static final int DEFAULT_MAX_PAGE_SIZE_IN_BYTES = 1024 * 1024;
     public static final int DEFAULT_MAX_BLOCK_SIZE_IN_BYTES = 64 * 1024;
 
-    private final int maxPageSizeInBytes;
+    private final PageBuilderStatus pageBuilderStatus;
     private final int maxBlockSizeInBytes;
 
-    private boolean full;
     private int currentSize;
 
     public BlockBuilderStatus()
     {
-        this(DEFAULT_MAX_PAGE_SIZE_IN_BYTES, DEFAULT_MAX_BLOCK_SIZE_IN_BYTES);
+        // When this constructor is used, this class has no observable internal state (except getMaxBlockSizeInBytes).
+        // TODO: this constructor essentially constructs a black hole. This constructor and all its usage should probably be removed.
+        this(new PageBuilderStatus(DEFAULT_MAX_PAGE_SIZE_IN_BYTES, DEFAULT_MAX_BLOCK_SIZE_IN_BYTES), DEFAULT_MAX_BLOCK_SIZE_IN_BYTES);
     }
 
-    public BlockBuilderStatus(int maxPageSizeInBytes, int maxBlockSizeInBytes)
+    BlockBuilderStatus(PageBuilderStatus pageBuilderStatus, int maxBlockSizeInBytes)
     {
-        this.maxPageSizeInBytes = maxPageSizeInBytes;
+        this.pageBuilderStatus = requireNonNull(pageBuilderStatus, "pageBuilderStatus must not be null");
         this.maxBlockSizeInBytes = maxBlockSizeInBytes;
-    }
-
-    public BlockBuilderStatus(BlockBuilderStatus status)
-    {
-        this.maxPageSizeInBytes = status.maxPageSizeInBytes;
-        this.maxBlockSizeInBytes = status.maxBlockSizeInBytes;
     }
 
     public int getMaxBlockSizeInBytes()
@@ -46,42 +43,20 @@ public class BlockBuilderStatus
         return maxBlockSizeInBytes;
     }
 
-    public int getMaxPageSizeInBytes()
-    {
-        return maxPageSizeInBytes;
-    }
-
-    public boolean isEmpty()
-    {
-        return currentSize == 0;
-    }
-
-    public boolean isFull()
-    {
-        return full || currentSize >= maxPageSizeInBytes;
-    }
-
-    public void setFull()
-    {
-        this.full = true;
-    }
-
     public void addBytes(int bytes)
     {
         currentSize += bytes;
-    }
-
-    public int getSizeInBytes()
-    {
-        return currentSize;
+        pageBuilderStatus.addBytes(bytes);
+        if (currentSize >= maxBlockSizeInBytes) {
+            pageBuilderStatus.setFull();
+        }
     }
 
     @Override
     public String toString()
     {
         StringBuilder buffer = new StringBuilder("BlockBuilderStatus{");
-        buffer.append("maxSizeInBytes=").append(maxPageSizeInBytes);
-        buffer.append(", full=").append(full);
+        buffer.append("maxSizeInBytes=").append(maxBlockSizeInBytes);
         buffer.append(", currentSize=").append(currentSize);
         buffer.append('}');
         return buffer.toString();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
@@ -172,7 +172,7 @@ public class FixedWidthBlockBuilder
         valueIsNull.appendByte(isNull ? 1 : 0);
 
         positionCount++;
-        blockBuilderStatus.addBytes(fixedSize);
+        blockBuilderStatus.addBytes(Byte.BYTES + fixedSize);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
@@ -56,7 +56,7 @@ public class FixedWidthBlockBuilder
 
         Slice slice = Slices.allocate(fixedSize * positionCount);
 
-        this.blockBuilderStatus = new BlockBuilderStatus(slice.length(), slice.length());
+        this.blockBuilderStatus = new BlockBuilderStatus();
         this.sliceOutput = slice.getOutput();
 
         this.valueIsNull = Slices.allocate(positionCount).getOutput();
@@ -72,18 +72,6 @@ public class FixedWidthBlockBuilder
     public int getPositionCount()
     {
         return positionCount;
-    }
-
-    @Override
-    public boolean isEmpty()
-    {
-        return positionCount == 0;
-    }
-
-    @Override
-    public boolean isFull()
-    {
-        return blockBuilderStatus.isFull();
     }
 
     @Override
@@ -185,9 +173,6 @@ public class FixedWidthBlockBuilder
 
         positionCount++;
         blockBuilderStatus.addBytes(fixedSize);
-        if (sliceOutput.size() >= blockBuilderStatus.getMaxBlockSizeInBytes()) {
-            blockBuilderStatus.setFull();
-        }
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/PageBuilderStatus.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/PageBuilderStatus.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import static com.facebook.presto.spi.block.BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+
+public class PageBuilderStatus
+{
+    public static final int DEFAULT_MAX_PAGE_SIZE_IN_BYTES = 1024 * 1024;
+
+    private final int maxPageSizeInBytes;
+    private final int maxBlockSizeInBytes;
+
+    private boolean full;
+    private int currentSize;
+
+    public PageBuilderStatus()
+    {
+        this(DEFAULT_MAX_PAGE_SIZE_IN_BYTES, DEFAULT_MAX_BLOCK_SIZE_IN_BYTES);
+    }
+
+    public PageBuilderStatus(int maxPageSizeInBytes, int maxBlockSizeInBytes)
+    {
+        this.maxPageSizeInBytes = maxPageSizeInBytes;
+        this.maxBlockSizeInBytes = maxBlockSizeInBytes;
+    }
+
+    public BlockBuilderStatus createBlockBuilderStatus()
+    {
+        return new BlockBuilderStatus(this, maxBlockSizeInBytes);
+    }
+
+    public int getMaxBlockSizeInBytes()
+    {
+        return maxBlockSizeInBytes;
+    }
+
+    public int getMaxPageSizeInBytes()
+    {
+        return maxPageSizeInBytes;
+    }
+
+    public boolean isEmpty()
+    {
+        return currentSize == 0;
+    }
+
+    public boolean isFull()
+    {
+        return full || currentSize >= maxPageSizeInBytes;
+    }
+
+    void setFull()
+    {
+        this.full = true;
+    }
+
+    void addBytes(int bytes)
+    {
+        currentSize += bytes;
+    }
+
+    public int getSizeInBytes()
+    {
+        return currentSize;
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder buffer = new StringBuilder("BlockBuilderStatus{");
+        buffer.append("maxSizeInBytes=").append(maxPageSizeInBytes);
+        buffer.append(", full=").append(full);
+        buffer.append(", currentSize=").append(currentSize);
+        buffer.append('}');
+        return buffer.toString();
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -84,18 +84,6 @@ public class VariableWidthBlockBuilder
     }
 
     @Override
-    public boolean isEmpty()
-    {
-        return positions == 0;
-    }
-
-    @Override
-    public boolean isFull()
-    {
-        return blockBuilderStatus.isFull();
-    }
-
-    @Override
     public int getSizeInBytes()
     {
         long size = sliceOutput.getUnderlyingSlice().length() + offsets.getUnderlyingSlice().length() + valueIsNull.getUnderlyingSlice().length();
@@ -188,9 +176,6 @@ public class VariableWidthBlockBuilder
         offsets.appendInt(sliceOutput.size());
 
         blockBuilderStatus.addBytes(SIZE_OF_BYTE + SIZE_OF_INT + bytesWritten);
-        if (sliceOutput.size() + valueIsNull.size() + offsets.size() >= blockBuilderStatus.getMaxBlockSizeInBytes()) {
-            blockBuilderStatus.setFull();
-        }
     }
 
     @Override

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestFixedWidthBlockBuilder.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestFixedWidthBlockBuilder.java
@@ -21,7 +21,7 @@ import static org.testng.Assert.assertTrue;
 
 public class TestFixedWidthBlockBuilder
 {
-    private static final int BOOLEAN_ENTRY_SIZE = BOOLEAN.getFixedSize();
+    private static final int BOOLEAN_ENTRY_SIZE = BOOLEAN.getFixedSize() + Byte.BYTES; // value + isNull
     private static final int EXPECTED_ENTRY_COUNT = 3;
 
     @Test
@@ -34,7 +34,7 @@ public class TestFixedWidthBlockBuilder
 
     private static void testIsFull(PageBuilderStatus pageBuilderStatus)
     {
-        FixedWidthBlockBuilder blockBuilder = new FixedWidthBlockBuilder(BOOLEAN_ENTRY_SIZE, pageBuilderStatus.createBlockBuilderStatus());
+        FixedWidthBlockBuilder blockBuilder = new FixedWidthBlockBuilder(BOOLEAN.getFixedSize(), pageBuilderStatus.createBlockBuilderStatus());
         assertTrue(pageBuilderStatus.isEmpty());
         while (!pageBuilderStatus.isFull()) {
             BOOLEAN.writeBoolean(blockBuilder, true);

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestFixedWidthBlockBuilder.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestFixedWidthBlockBuilder.java
@@ -28,18 +28,18 @@ public class TestFixedWidthBlockBuilder
     public void testFixedBlockIsFull()
             throws Exception
     {
-        testIsFull(new FixedWidthBlockBuilder(BOOLEAN.getFixedSize(), EXPECTED_ENTRY_COUNT));
-        testIsFull(new FixedWidthBlockBuilder(BOOLEAN.getFixedSize(), new BlockBuilderStatus(BOOLEAN_ENTRY_SIZE * EXPECTED_ENTRY_COUNT, 1024)));
-        testIsFull(new FixedWidthBlockBuilder(BOOLEAN.getFixedSize(), new BlockBuilderStatus(1024, BOOLEAN_ENTRY_SIZE * EXPECTED_ENTRY_COUNT)));
+        testIsFull(new PageBuilderStatus(BOOLEAN_ENTRY_SIZE * EXPECTED_ENTRY_COUNT, 1024));
+        testIsFull(new PageBuilderStatus(1024, BOOLEAN_ENTRY_SIZE * EXPECTED_ENTRY_COUNT));
     }
 
-    private static void testIsFull(FixedWidthBlockBuilder blockBuilder)
+    private static void testIsFull(PageBuilderStatus pageBuilderStatus)
     {
-        assertTrue(blockBuilder.isEmpty());
-        while (!blockBuilder.isFull()) {
+        FixedWidthBlockBuilder blockBuilder = new FixedWidthBlockBuilder(BOOLEAN_ENTRY_SIZE, pageBuilderStatus.createBlockBuilderStatus());
+        assertTrue(pageBuilderStatus.isEmpty());
+        while (!pageBuilderStatus.isFull()) {
             BOOLEAN.writeBoolean(blockBuilder, true);
         }
         assertEquals(blockBuilder.getPositionCount(), EXPECTED_ENTRY_COUNT);
-        assertEquals(blockBuilder.isFull(), true);
+        assertEquals(pageBuilderStatus.isFull(), true);
     }
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockBuilder.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockBuilder.java
@@ -31,17 +31,18 @@ public class TestVariableWidthBlockBuilder
     public void testFixedBlockIsFull()
             throws Exception
     {
-        testIsFull(new VariableWidthBlockBuilder(new BlockBuilderStatus(VARCHAR_ENTRY_SIZE * EXPECTED_ENTRY_COUNT, 1024)));
-        testIsFull(new VariableWidthBlockBuilder(new BlockBuilderStatus(1024, VARCHAR_ENTRY_SIZE * EXPECTED_ENTRY_COUNT)));
+        testIsFull(new PageBuilderStatus(VARCHAR_ENTRY_SIZE * EXPECTED_ENTRY_COUNT, 1024));
+        testIsFull(new PageBuilderStatus(1024, VARCHAR_ENTRY_SIZE * EXPECTED_ENTRY_COUNT));
     }
 
-    private void testIsFull(VariableWidthBlockBuilder blockBuilder)
+    private void testIsFull(PageBuilderStatus pageBuilderStatus)
     {
-        assertTrue(blockBuilder.isEmpty());
-        while (!blockBuilder.isFull()) {
+        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(pageBuilderStatus.createBlockBuilderStatus());
+        assertTrue(pageBuilderStatus.isEmpty());
+        while (!pageBuilderStatus.isFull()) {
             VARCHAR.writeSlice(blockBuilder, Slices.allocate(VARCHAR_VALUE_SIZE));
         }
         assertEquals(blockBuilder.getPositionCount(), EXPECTED_ENTRY_COUNT);
-        assertEquals(blockBuilder.isFull(), true);
+        assertEquals(pageBuilderStatus.isFull(), true);
     }
 }


### PR DESCRIPTION
BlockBuilderStatus currently contains functionality for both block building and page building tracking. It also requires caller's close interaction to make the block building tracking work.

By splitting it into two, the two tracking functionalities are split, and close interaction is removed.