### PR TITLE
Add IF NOT EXISTS support for create table

### DIFF
--- a/presto-docs/src/main/sphinx/sql/create-table-as.rst
+++ b/presto-docs/src/main/sphinx/sql/create-table-as.rst
@@ -7,7 +7,7 @@ Synopsis
 
 .. code-block:: none
 
-    CREATE TABLE table_name AS query
+    CREATE TABLE [ IF NOT EXISTS ] table_name AS query
 
 Description
 -----------
@@ -15,12 +15,22 @@ Description
 Create a new table containing the result of a :doc:`select` query.
 Use :doc:`create-table` to create an empty table.
 
+The optional ``IF NOT EXISTS`` clause causes the error to be
+suppressed if the table already exists.
+
 Examples
 --------
 
 Create a new table ``orders_by_date`` that summarizes ``orders``::
 
     CREATE TABLE orders_by_date AS
+    SELECT orderdate, sum(totalprice) AS price
+    FROM orders
+    GROUP BY orderdate
+
+Create the table ``orders_by_date`` if it does not already exist::
+
+    CREATE TABLE IF NOT EXISTS orders_by_date AS
     SELECT orderdate, sum(totalprice) AS price
     FROM orders
     GROUP BY orderdate

--- a/presto-docs/src/main/sphinx/sql/create-table.rst
+++ b/presto-docs/src/main/sphinx/sql/create-table.rst
@@ -7,7 +7,7 @@ Synopsis
 
 .. code-block:: none
 
-    CREATE TABLE table_name (
+    CREATE TABLE [ IF NOT EXISTS ] table_name (
       column_name data_type [, ...]
     )
 
@@ -17,12 +17,24 @@ Description
 Create a new, empty table with the specified columns.
 Use :doc:`create-table-as` to create a table with data.
 
+The optional ``IF NOT EXISTS`` clause causes the error to be
+suppressed if the table already exists.
+
 Examples
 --------
 
 Create a new table ``orders``::
 
     CREATE TABLE orders (
+      orderkey bigint,
+      orderstatus varchar,
+      totalprice double,
+      orderdate date
+    )
+
+Create the table ``orders`` if it does not already exist::
+
+    CREATE TABLE IF NOT EXISTS orders (
       orderkey bigint,
       orderstatus varchar,
       totalprice double,

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -53,7 +53,10 @@ public class CreateTableTask
         QualifiedTableName tableName = createQualifiedTableName(session, statement.getName());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
         if (tableHandle.isPresent()) {
-            throw new SemanticException(TABLE_ALREADY_EXISTS, statement, "Table '%s' already exists", tableName);
+            if (!statement.isNotExists()) {
+                throw new SemanticException(TABLE_ALREADY_EXISTS, statement, "Table '%s' already exists", tableName);
+            }
+            return;
         }
 
         List<ColumnMetadata> columns = new ArrayList<>();

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -251,6 +251,10 @@ public final class SqlQueryExecution
         Analyzer analyzer = new Analyzer(stateMachine.getSession(), metadata, sqlParser, Optional.of(queryExplainer), experimentalSyntaxEnabled);
         Analysis analysis = analyzer.analyze(statement);
 
+        if (analysis.isNoOp()) {
+            stateMachine.finished();
+        }
+
         stateMachine.setUpdateType(analysis.getUpdateType());
 
         // plan query

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -251,8 +251,8 @@ public final class SqlQueryExecution
         Analyzer analyzer = new Analyzer(stateMachine.getSession(), metadata, sqlParser, Optional.of(queryExplainer), experimentalSyntaxEnabled);
         Analysis analysis = analyzer.analyze(statement);
 
-        if (analysis.isNoOp()) {
-            stateMachine.finished();
+        if (analysis.isSkipExecution()) {
+            stateMachine.transitionToFinished();
         }
 
         stateMachine.setUpdateType(analysis.getUpdateType());

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -87,8 +87,8 @@ public class Analysis
     // for delete
     private Optional<Delete> delete = Optional.empty();
 
-    // for no-op queries
-    private Boolean noOp = false;
+    // for no-op queries (e.g. create table if not exists)
+    private Boolean skipExecution = false;
 
     public Query getQuery()
     {
@@ -371,14 +371,14 @@ public class Analysis
         return sampleRatios.get(relation);
     }
 
-    public void setNoOp(boolean noOp)
+    public void setSkipExecution(boolean skipExecution)
     {
-        this.noOp = noOp;
+        this.skipExecution = skipExecution;
     }
 
-    public boolean isNoOp()
+    public boolean isSkipExecution()
     {
-        return noOp;
+        return skipExecution;
     }
 
     public static class JoinInPredicates

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -87,6 +87,9 @@ public class Analysis
     // for delete
     private Optional<Delete> delete = Optional.empty();
 
+    // for no-op queries
+    private Boolean noOp = false;
+
     public Query getQuery()
     {
         return query;
@@ -366,6 +369,16 @@ public class Analysis
     {
         Preconditions.checkState(sampleRatios.containsKey(relation), "Sample ratio missing for %s. Broken analysis?", relation);
         return sampleRatios.get(relation);
+    }
+
+    public void setNoOp(boolean noOp)
+    {
+        this.noOp = noOp;
+    }
+
+    public boolean isNoOp()
+    {
+        return noOp;
     }
 
     public static class JoinInPredicates

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -415,7 +415,7 @@ class StatementAnalyzer
             if (!node.isNotExists()) {
                 throw new SemanticException(TABLE_ALREADY_EXISTS, node, "Destination table '%s' already exists", targetTable);
             }
-            analysis.setNoOp(true);
+            analysis.setSkipExecution(true);
         }
 
         // analyze the query that creates the table

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -412,7 +412,10 @@ class StatementAnalyzer
 
         Optional<TableHandle> targetTableHandle = metadata.getTableHandle(session, targetTable);
         if (targetTableHandle.isPresent()) {
-            throw new SemanticException(TABLE_ALREADY_EXISTS, node, "Destination table '%s' already exists", targetTable);
+            if (!node.isNotExists()) {
+                throw new SemanticException(TABLE_ALREADY_EXISTS, node, "Destination table '%s' already exists", targetTable);
+            }
+            analysis.setNoOp(true);
         }
 
         // analyze the query that creates the table

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -30,8 +30,8 @@ statement
     : query                                                            #statementDefault
     | USE schema=identifier                                            #use
     | USE catalog=identifier '.' schema=identifier                     #use
-    | CREATE TABLE qualifiedName AS query                              #createTableAsSelect
-    | CREATE TABLE qualifiedName
+    | CREATE TABLE (IF NOT EXISTS)? qualifiedName AS query             #createTableAsSelect
+    | CREATE TABLE (IF NOT EXISTS)? qualifiedName
         '(' tableElement (',' tableElement)* ')'                       #createTable
     | DROP TABLE (IF EXISTS)? qualifiedName                            #dropTable
     | INSERT INTO qualifiedName query                                  #insertInto

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -595,7 +595,7 @@ public final class SqlFormatter
         {
             builder.append("CREATE TABLE ");
             if (node.isNotExists()) {
-                builder.append("IF NOT EXISTS");
+                builder.append("IF NOT EXISTS ");
             }
             builder.append(node.getName())
                     .append(" AS ");

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -593,8 +593,11 @@ public final class SqlFormatter
         @Override
         protected Void visitCreateTableAsSelect(CreateTableAsSelect node, Integer indent)
         {
-            builder.append("CREATE TABLE ")
-                    .append(node.getName())
+            builder.append("CREATE TABLE ");
+            if (node.isNotExists()) {
+                builder.append("IF NOT EXISTS");
+            }
+            builder.append(node.getName())
                     .append(" AS ");
 
             process(node.getQuery(), indent);
@@ -605,8 +608,11 @@ public final class SqlFormatter
         @Override
         protected Void visitCreateTable(CreateTable node, Integer indent)
         {
-            builder.append("CREATE TABLE ")
-                    .append(node.getName())
+            builder.append("CREATE TABLE ");
+            if (node.isNotExists()) {
+                builder.append("IF NOT EXISTS ");
+            }
+            builder.append(node.getName())
                     .append(" (");
 
             Joiner.on(", ").appendTo(builder, transform(node.getElements(),

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -146,13 +146,13 @@ class AstBuilder
     @Override
     public Node visitCreateTableAsSelect(@NotNull SqlBaseParser.CreateTableAsSelectContext context)
     {
-        return new CreateTableAsSelect(getQualifiedName(context.qualifiedName()), (Query) visit(context.query()));
+        return new CreateTableAsSelect(getQualifiedName(context.qualifiedName()), (Query) visit(context.query()), context.EXISTS() != null);
     }
 
     @Override
     public Node visitCreateTable(@NotNull SqlBaseParser.CreateTableContext context)
     {
-        return new CreateTable(getQualifiedName(context.qualifiedName()), visit(context.tableElement(), TableElement.class));
+        return new CreateTable(getQualifiedName(context.qualifiedName()), visit(context.tableElement(), TableElement.class), context.EXISTS() != null);
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
@@ -26,11 +26,13 @@ public class CreateTable
 {
     private final QualifiedName name;
     private final List<TableElement> elements;
+    private boolean notExists;
 
-    public CreateTable(QualifiedName name, List<TableElement> elements)
+    public CreateTable(QualifiedName name, List<TableElement> elements, boolean notExists)
     {
         this.name = checkNotNull(name, "table is null");
         this.elements = ImmutableList.copyOf(checkNotNull(elements, "elements is null"));
+        this.notExists = notExists;
     }
 
     public QualifiedName getName()
@@ -43,6 +45,11 @@ public class CreateTable
         return elements;
     }
 
+    public boolean isNotExists()
+    {
+        return notExists;
+    }
+
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context)
     {
@@ -52,7 +59,7 @@ public class CreateTable
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, elements);
+        return Objects.hash(name, elements, notExists);
     }
 
     @Override
@@ -66,7 +73,8 @@ public class CreateTable
         }
         CreateTable o = (CreateTable) obj;
         return Objects.equals(name, o.name) &&
-                Objects.equals(elements, o.elements);
+                Objects.equals(elements, o.elements) &&
+                Objects.equals(notExists, o.notExists);
     }
 
     @Override
@@ -75,6 +83,7 @@ public class CreateTable
         return toStringHelper(this)
                 .add("name", name)
                 .add("elements", elements)
+                .add("notExists", notExists)
                 .toString();
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTableAsSelect.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTableAsSelect.java
@@ -23,11 +23,13 @@ public class CreateTableAsSelect
 {
     private final QualifiedName name;
     private final Query query;
+    private final boolean notExists;
 
-    public CreateTableAsSelect(QualifiedName name, Query query)
+    public CreateTableAsSelect(QualifiedName name, Query query, boolean notExists)
     {
         this.name = checkNotNull(name, "name is null");
         this.query = checkNotNull(query, "query is null");
+        this.notExists = notExists;
     }
 
     public QualifiedName getName()
@@ -40,6 +42,11 @@ public class CreateTableAsSelect
         return query;
     }
 
+    public boolean isNotExists()
+    {
+        return notExists;
+    }
+
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context)
     {
@@ -49,7 +56,7 @@ public class CreateTableAsSelect
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, query);
+        return Objects.hash(name, query, notExists);
     }
 
     @Override
@@ -63,7 +70,8 @@ public class CreateTableAsSelect
         }
         CreateTableAsSelect o = (CreateTableAsSelect) obj;
         return Objects.equals(name, o.name)
-                && Objects.equals(query, o.query);
+                && Objects.equals(query, o.query)
+                && Objects.equals(notExists, o.notExists);
     }
 
     @Override
@@ -72,6 +80,7 @@ public class CreateTableAsSelect
         return toStringHelper(this)
                 .add("name", name)
                 .add("query", query)
+                .add("notExists", notExists)
                 .toString();
     }
 }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -21,6 +21,7 @@ import com.facebook.presto.sql.tree.BetweenPredicate;
 import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.CurrentTime;
@@ -65,6 +66,7 @@ import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.sql.tree.StringLiteral;
 import com.facebook.presto.sql.tree.SubscriptExpression;
 import com.facebook.presto.sql.tree.Table;
+import com.facebook.presto.sql.tree.TableElement;
 import com.facebook.presto.sql.tree.TimeLiteral;
 import com.facebook.presto.sql.tree.TimestampLiteral;
 import com.facebook.presto.sql.tree.Union;
@@ -657,12 +659,31 @@ public class TestSqlParser
     }
 
     @Test
+    public void testCreateTable()
+            throws Exception
+    {
+        assertStatement("CREATE TABLE foo (a VARCHAR, b BIGINT)",
+                new CreateTable(QualifiedName.of("foo"),
+                        ImmutableList.of(new TableElement("a", "VARCHAR"), new TableElement("b", "BIGINT")),
+                        false));
+        assertStatement("CREATE TABLE IF NOT EXISTS bar ( c TIMESTAMP )",
+                new CreateTable(QualifiedName.of("bar"),
+                        ImmutableList.of(new TableElement("c", "TIMESTAMP")),
+                        true));
+    }
+
+    @Test
     public void testCreateTableAsSelect()
             throws Exception
     {
         assertStatement("CREATE TABLE foo AS SELECT * FROM t",
                 new CreateTableAsSelect(QualifiedName.of("foo"),
-                        simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t")))));
+                        simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
+                        false));
+        assertStatement("CREATE TABLE IF NOT EXISTS foo AS SELECT * FROM t",
+                new CreateTableAsSelect(QualifiedName.of("foo"),
+                        simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
+                        true));
     }
 
     @Test

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -666,7 +666,7 @@ public class TestSqlParser
                 new CreateTable(QualifiedName.of("foo"),
                         ImmutableList.of(new TableElement("a", "VARCHAR"), new TableElement("b", "BIGINT")),
                         false));
-        assertStatement("CREATE TABLE IF NOT EXISTS bar ( c TIMESTAMP )",
+        assertStatement("CREATE TABLE IF NOT EXISTS bar (c TIMESTAMP)",
                 new CreateTable(QualifiedName.of("bar"),
                         ImmutableList.of(new TableElement("c", "TIMESTAMP")),
                         true));

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
@@ -125,6 +125,7 @@ public class TestStatementBuilder
         printStatement("select * from foo approximate at 90 confidence");
 
         printStatement("create table foo as select * from abc");
+        printStatement("create table if not exists foo as select * from bar");
         printStatement("drop table foo");
 
         printStatement("insert into foo select * from abc");
@@ -159,6 +160,7 @@ public class TestStatementBuilder
         printStatement("alter table a.b.c rename column x to y");
 
         printStatement("create table test (a boolean, b bigint, c double, d varchar, e timestamp)");
+        printStatement("create table if not exists baz (a timestamp, b varchar)");
         printStatement("drop table test");
 
         printStatement("create view foo as with a as (select 123) select * from a");


### PR DESCRIPTION
This resolves #2108.  Note unfortunately in this implementation running "EXPLAIN CREATE TABLE IF NOT EXISTS foo AS ..." will still raise a table already exists error, since I could not think of a simple way to generate the query plan for this no-op query.

An alternative approach would be to create an entire set of no-op Plan, PlanNode, Ast Node, etc... objects, but this felt too heavy for the task here.