### PR TITLE
Clean up query and stage state machines

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -19,6 +19,7 @@ import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.sql.tree.Statement;
+import com.google.common.base.Throwables;
 import io.airlift.units.Duration;
 
 import javax.inject.Inject;
@@ -85,8 +86,11 @@ public class DataDefinitionExecution<T extends Statement>
 
             stateMachine.transitionToFinished();
         }
-        catch (RuntimeException e) {
+        catch (Throwable e) {
             fail(e);
+            if (!(e instanceof RuntimeException)) {
+                throw Throwables.propagate(e);
+            }
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -75,17 +75,15 @@ public class DataDefinitionExecution<T extends Statement>
     public void start()
     {
         try {
-            // transition to starting
-            if (!stateMachine.starting()) {
-                // query already started or finished
+            // transition to running
+            if (!stateMachine.transitionToRunning()) {
+                // query already running or finished
                 return;
             }
 
-            stateMachine.recordExecutionStart();
-
             task.execute(statement, session, metadata, stateMachine);
 
-            stateMachine.finished();
+            stateMachine.transitionToFinished();
         }
         catch (RuntimeException e) {
             fail(e);
@@ -108,7 +106,7 @@ public class DataDefinitionExecution<T extends Statement>
     @Override
     public void fail(Throwable cause)
     {
-        stateMachine.fail(cause);
+        stateMachine.transitionToFailed(cause);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.concurrent.Executor;
 
 import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
+import static java.util.Objects.requireNonNull;
 
 public class FailedQueryExecution
         implements QueryExecution
@@ -30,6 +31,7 @@ public class FailedQueryExecution
 
     public FailedQueryExecution(QueryId queryId, String query, Session session, URI self, Executor executor, Throwable cause)
     {
+        requireNonNull(cause, "cause is null");
         QueryStateMachine queryStateMachine = new QueryStateMachine(queryId, query, session, self, executor);
         queryStateMachine.transitionToFailed(cause);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -31,7 +31,7 @@ public class FailedQueryExecution
     public FailedQueryExecution(QueryId queryId, String query, Session session, URI self, Executor executor, Throwable cause)
     {
         QueryStateMachine queryStateMachine = new QueryStateMachine(queryId, query, session, self, executor);
-        queryStateMachine.fail(cause);
+        queryStateMachine.transitionToFailed(cause);
 
         queryInfo = queryStateMachine.getQueryInfo(null);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryState.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryState.java
@@ -13,6 +13,11 @@
  */
 package com.facebook.presto.execution;
 
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
+
 public enum QueryState
 {
     /**
@@ -39,6 +44,8 @@ public enum QueryState
      * Query execution failed.
      */
     FAILED(true);
+
+    public static final Set<QueryState> TERMINAL_QUERY_STATES = Stream.of(QueryState.values()).filter(QueryState::isDone).collect(toImmutableSet());
 
     private final boolean doneState;
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -46,6 +46,7 @@ import static com.facebook.presto.execution.QueryState.PLANNING;
 import static com.facebook.presto.execution.QueryState.QUEUED;
 import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.facebook.presto.execution.QueryState.STARTING;
+import static com.facebook.presto.execution.QueryState.TERMINAL_QUERY_STATES;
 import static com.facebook.presto.execution.StageInfo.getAllStages;
 import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
 import static com.facebook.presto.util.Failures.toFailure;
@@ -100,7 +101,7 @@ public class QueryStateMachine
         this.session = requireNonNull(session, "session is null");
         this.self = requireNonNull(self, "self is null");
 
-        this.queryState = new StateMachine<>("query " + query, executor, QUEUED);
+        this.queryState = new StateMachine<>("query " + query, executor, QUEUED, TERMINAL_QUERY_STATES);
         queryState.addStateChangeListener(currentState -> log.debug("Query %s is %s", QueryStateMachine.this.queryId, currentState));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -200,14 +200,6 @@ public final class SqlStageExecution
                         executor,
                         nodeTaskMap);
 
-                subStage.addStateChangeListener(stageState -> {
-                    // Only abort if sub-stage is failed. All other state transitions are handled elsewhere.
-                    if (stageState == StageState.FAILED) {
-                        abort();
-                    }
-                    doUpdateState();
-                });
-
                 subStages.put(subStageFragmentId, subStage);
             }
             this.subStages = subStages.build();
@@ -259,6 +251,11 @@ public final class SqlStageExecution
                 () -> subStages.values().stream()
                         .map(SqlStageExecution::getStageInfo)
                         .collect(toImmutableList()));
+    }
+
+    public Collection<SqlStageExecution> getSubStages()
+    {
+        return subStages.values();
     }
 
     private synchronized void parentTasksAdded(List<TaskId> parentTasks, boolean noMoreParentNodes)

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -89,9 +89,9 @@ public class SqlTask
         taskStateMachine.addStateChangeListener(new StateChangeListener<TaskState>()
         {
             @Override
-            public void stateChanged(TaskState taskState)
+            public void stateChanged(TaskState newState)
             {
-                if (!taskState.isDone()) {
+                if (!newState.isDone()) {
                     return;
                 }
 
@@ -109,7 +109,7 @@ public class SqlTask
                 }
 
                 // make sure buffers are cleaned up
-                if (taskState == TaskState.FAILED || taskState == TaskState.ABORTED) {
+                if (newState == TaskState.FAILED || newState == TaskState.ABORTED) {
                     // don't close buffers for a failed query
                     // closed buffers signal to upstream tasks that everything finished cleanly
                     sharedBuffer.fail();

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -614,9 +614,9 @@ public class SqlTaskExecution
         }
 
         @Override
-        public void stateChanged(TaskState taskState)
+        public void stateChanged(TaskState newState)
         {
-            if (taskState.isDone()) {
+            if (newState.isDone()) {
                 taskExecutor.removeTask(taskHandle);
             }
         }
@@ -634,9 +634,9 @@ public class SqlTaskExecution
         }
 
         @Override
-        public void stateChanged(BufferState taskState)
+        public void stateChanged(BufferState newState)
         {
-            if (taskState == BufferState.FINISHED) {
+            if (newState == BufferState.FINISHED) {
                 SqlTaskExecution sqlTaskExecution = sqlTaskExecutionReference.get();
                 if (sqlTaskExecution != null) {
                     sqlTaskExecution.checkTaskCompletion();

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageInfo.java
@@ -39,7 +39,7 @@ public class StageInfo
     private final StageStats stageStats;
     private final List<TaskInfo> tasks;
     private final List<StageInfo> subStages;
-    private final List<ExecutionFailureInfo> failures;
+    private final ExecutionFailureInfo failureCause;
 
     @JsonCreator
     public StageInfo(
@@ -51,7 +51,7 @@ public class StageInfo
             @JsonProperty("stageStats") StageStats stageStats,
             @JsonProperty("tasks") List<TaskInfo> tasks,
             @JsonProperty("subStages") List<StageInfo> subStages,
-            @JsonProperty("failures") List<ExecutionFailureInfo> failures)
+            @JsonProperty("failureCause") ExecutionFailureInfo failureCause)
     {
         Preconditions.checkNotNull(stageId, "stageId is null");
         Preconditions.checkNotNull(state, "state is null");
@@ -59,7 +59,6 @@ public class StageInfo
         Preconditions.checkNotNull(stageStats, "stageStats is null");
         Preconditions.checkNotNull(tasks, "tasks is null");
         Preconditions.checkNotNull(subStages, "subStages is null");
-        Preconditions.checkNotNull(failures, "failures is null");
 
         this.stageId = stageId;
         this.state = state;
@@ -69,7 +68,7 @@ public class StageInfo
         this.stageStats = stageStats;
         this.tasks = ImmutableList.copyOf(tasks);
         this.subStages = subStages;
-        this.failures = failures;
+        this.failureCause = failureCause;
     }
 
     @JsonProperty
@@ -122,9 +121,9 @@ public class StageInfo
     }
 
     @JsonProperty
-    public List<ExecutionFailureInfo> getFailures()
+    public ExecutionFailureInfo getFailureCause()
     {
-        return failures;
+        return failureCause;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageState.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageState.java
@@ -13,6 +13,10 @@
  */
 package com.facebook.presto.execution;
 
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public enum StageState
@@ -52,6 +56,8 @@ public enum StageState
      * Stage execution failed.
      */
     FAILED(true, true);
+
+    public static final Set<StageState> TERMINAL_STAGE_STATES = Stream.of(StageState.values()).filter(StageState::isDone).collect(toImmutableSet());
 
     private final boolean doneState;
     private final boolean failureState;

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
@@ -266,7 +266,7 @@ public class StageStateMachine
                 stageStats,
                 taskInfos,
                 subStageInfos,
-                failureInfo == null ? ImmutableList.of() : ImmutableList.of(failureInfo));
+                failureInfo);
     }
 
     public void recordGetSplitTime(long startNanos)

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.StateMachine.StateChangeListener;
+import com.facebook.presto.operator.BlockedReason;
+import com.facebook.presto.operator.TaskStats;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.util.Failures;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import io.airlift.stats.Distribution;
+import org.joda.time.DateTime;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.execution.StageState.ABORTED;
+import static com.facebook.presto.execution.StageState.CANCELED;
+import static com.facebook.presto.execution.StageState.FAILED;
+import static com.facebook.presto.execution.StageState.FINISHED;
+import static com.facebook.presto.execution.StageState.PLANNED;
+import static com.facebook.presto.execution.StageState.RUNNING;
+import static com.facebook.presto.execution.StageState.SCHEDULED;
+import static com.facebook.presto.execution.StageState.SCHEDULING;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.succinctDataSize;
+import static io.airlift.units.Duration.succinctDuration;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+@ThreadSafe
+public class StageStateMachine
+{
+    private static final Logger log = Logger.get(StageStateMachine.class);
+
+    private final StageId stageId;
+    private final URI location;
+    private final PlanFragment fragment;
+    private final Session session;
+
+    private final StateMachine<StageState> stageState;
+    private final AtomicReference<ExecutionFailureInfo> failureCause = new AtomicReference<>();
+
+    private final AtomicReference<DateTime> schedulingComplete = new AtomicReference<>();
+    private final Distribution getSplitDistribution = new Distribution();
+    private final Distribution scheduleTaskDistribution = new Distribution();
+    private final Distribution addSplitDistribution = new Distribution();
+
+    public StageStateMachine(StageId stageId, URI location, Session session, PlanFragment fragment, ExecutorService executor)
+    {
+        this.stageId = requireNonNull(stageId, "stageId is null");
+        this.location = requireNonNull(location, "location is null");
+        this.session = requireNonNull(session, "session is null");
+        this.fragment = requireNonNull(fragment, "fragment is null");
+
+        stageState = new StateMachine<>("stage " + stageId, executor, PLANNED);
+        stageState.addStateChangeListener(state -> log.debug("Stage %s is %s", stageId, state));
+    }
+
+    public StageId getStageId()
+    {
+        return stageId;
+    }
+
+    public URI getLocation()
+    {
+        return location;
+    }
+
+    public Session getSession()
+    {
+        return session;
+    }
+
+    public StageState getState()
+    {
+        return stageState.get();
+    }
+
+    public void addStateChangeListener(StateChangeListener<StageState> stateChangeListener)
+    {
+        stageState.addStateChangeListener(stateChangeListener);
+    }
+
+    public synchronized boolean transitionToScheduling()
+    {
+        return stageState.compareAndSet(PLANNED, SCHEDULING);
+    }
+
+    public synchronized boolean transitionToScheduled()
+    {
+        schedulingComplete.compareAndSet(null, DateTime.now());
+        return stageState.setIf(SCHEDULED, currentState -> currentState == PLANNED || currentState == SCHEDULING);
+    }
+
+    public boolean transitionToRunning()
+    {
+        return stageState.setIf(RUNNING, currentState -> currentState != RUNNING && !currentState.isDone());
+    }
+
+    public boolean transitionToFinished()
+    {
+        return stageState.setIf(FINISHED, currentState -> !currentState.isDone());
+    }
+
+    public boolean transitionToCanceled()
+    {
+        return stageState.setIf(CANCELED, currentState -> !currentState.isDone());
+    }
+
+    public boolean transitionToAborted()
+    {
+        return stageState.setIf(ABORTED, currentState -> !currentState.isDone());
+    }
+
+    public boolean transitionToFailed(Throwable throwable)
+    {
+        requireNonNull(throwable, "throwable is null");
+
+        failureCause.compareAndSet(null, Failures.toFailure(throwable));
+        boolean failed = stageState.setIf(FAILED, currentState -> !currentState.isDone());
+        if (failed) {
+            log.error(throwable, "Stage %s failed", stageId);
+        }
+        else {
+            log.debug(throwable, "Failure after stage %s finished", stageId);
+        }
+        return failed;
+    }
+
+    public StageInfo getStageInfo(Supplier<Iterable<TaskInfo>> taskInfosSupplier, Supplier<Iterable<StageInfo>> subStageInfosSupplier)
+    {
+        // stage state must be captured first in order to provide a
+        // consistent view of the stage. For example, building this
+        // information, the stage could finish, and the task states would
+        // never be visible.
+        StageState state = stageState.get();
+
+        List<TaskInfo> taskInfos = ImmutableList.copyOf(taskInfosSupplier.get());
+        List<StageInfo> subStageInfos = ImmutableList.copyOf(subStageInfosSupplier.get());
+
+        int totalTasks = taskInfos.size();
+        int runningTasks = 0;
+        int completedTasks = 0;
+
+        int totalDrivers = 0;
+        int queuedDrivers = 0;
+        int runningDrivers = 0;
+        int completedDrivers = 0;
+
+        long totalMemoryReservation = 0;
+
+        long totalScheduledTime = 0;
+        long totalCpuTime = 0;
+        long totalUserTime = 0;
+        long totalBlockedTime = 0;
+
+        long rawInputDataSize = 0;
+        long rawInputPositions = 0;
+
+        long processedInputDataSize = 0;
+        long processedInputPositions = 0;
+
+        long outputDataSize = 0;
+        long outputPositions = 0;
+
+        boolean fullyBlocked = true;
+        Set<BlockedReason> blockedReasons = new HashSet<>();
+
+        for (TaskInfo taskInfo : taskInfos) {
+            if (taskInfo.getState().isDone()) {
+                completedTasks++;
+            }
+            else {
+                runningTasks++;
+            }
+
+            TaskStats taskStats = taskInfo.getStats();
+
+            totalDrivers += taskStats.getTotalDrivers();
+            queuedDrivers += taskStats.getQueuedDrivers();
+            runningDrivers += taskStats.getRunningDrivers();
+            completedDrivers += taskStats.getCompletedDrivers();
+
+            totalMemoryReservation += taskStats.getMemoryReservation().toBytes();
+
+            totalScheduledTime += taskStats.getTotalScheduledTime().roundTo(NANOSECONDS);
+            totalCpuTime += taskStats.getTotalCpuTime().roundTo(NANOSECONDS);
+            totalUserTime += taskStats.getTotalUserTime().roundTo(NANOSECONDS);
+            totalBlockedTime += taskStats.getTotalBlockedTime().roundTo(NANOSECONDS);
+            if (!taskInfo.getState().isDone()) {
+                fullyBlocked &= taskStats.isFullyBlocked();
+                blockedReasons.addAll(taskStats.getBlockedReasons());
+            }
+
+            rawInputDataSize += taskStats.getRawInputDataSize().toBytes();
+            rawInputPositions += taskStats.getRawInputPositions();
+
+            processedInputDataSize += taskStats.getProcessedInputDataSize().toBytes();
+            processedInputPositions += taskStats.getProcessedInputPositions();
+
+            outputDataSize += taskStats.getOutputDataSize().toBytes();
+            outputPositions += taskStats.getOutputPositions();
+        }
+
+        StageStats stageStats = new StageStats(
+                schedulingComplete.get(),
+                getSplitDistribution.snapshot(),
+                scheduleTaskDistribution.snapshot(),
+                addSplitDistribution.snapshot(),
+
+                totalTasks,
+                runningTasks,
+                completedTasks,
+
+                totalDrivers,
+                queuedDrivers,
+                runningDrivers,
+                completedDrivers,
+
+                succinctDataSize(totalMemoryReservation, BYTE),
+                succinctDuration(totalScheduledTime, NANOSECONDS),
+                succinctDuration(totalCpuTime, NANOSECONDS),
+                succinctDuration(totalUserTime, NANOSECONDS),
+                succinctDuration(totalBlockedTime, NANOSECONDS),
+                fullyBlocked && runningTasks > 0,
+                blockedReasons,
+
+                succinctDataSize(rawInputDataSize, BYTE),
+                rawInputPositions,
+                succinctDataSize(processedInputDataSize, BYTE),
+                processedInputPositions,
+                succinctDataSize(outputDataSize, BYTE),
+                outputPositions);
+
+        ExecutionFailureInfo failureInfo = null;
+        if (state == FAILED) {
+            failureInfo = failureCause.get();
+        }
+        return new StageInfo(stageId,
+                state,
+                location,
+                fragment,
+                fragment.getTypes(),
+                stageStats,
+                taskInfos,
+                subStageInfos,
+                failureInfo == null ? ImmutableList.of() : ImmutableList.of(failureInfo));
+    }
+
+    public void recordGetSplitTime(long startNanos)
+    {
+        getSplitDistribution.add(System.nanoTime() - startNanos);
+    }
+
+    public void recordScheduleTaskTime(long startNanos)
+    {
+        scheduleTaskDistribution.add(System.nanoTime() - startNanos);
+    }
+
+    public void recordAddSplit(long startNanos)
+    {
+        addSplitDistribution.add(System.nanoTime() - startNanos);
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("stageId", stageId)
+                .add("stageState", stageState)
+                .toString();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.execution.StageState.PLANNED;
 import static com.facebook.presto.execution.StageState.RUNNING;
 import static com.facebook.presto.execution.StageState.SCHEDULED;
 import static com.facebook.presto.execution.StageState.SCHEDULING;
+import static com.facebook.presto.execution.StageState.TERMINAL_STAGE_STATES;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.succinctDataSize;
 import static io.airlift.units.Duration.succinctDuration;
@@ -74,7 +75,7 @@ public class StageStateMachine
         this.session = requireNonNull(session, "session is null");
         this.fragment = requireNonNull(fragment, "fragment is null");
 
-        stageState = new StateMachine<>("stage " + stageId, executor, PLANNED);
+        stageState = new StateMachine<>("stage " + stageId, executor, PLANNED, TERMINAL_STAGE_STATES);
         stageState.addStateChangeListener(state -> log.debug("Stage %s is %s", stageId, state));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskState.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskState.java
@@ -13,6 +13,11 @@
  */
 package com.facebook.presto.execution;
 
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
+
 public enum TaskState
 {
     /**
@@ -42,6 +47,8 @@ public enum TaskState
      * Task execution failed.
      */
     FAILED(true);
+
+    public static final Set<TaskState> TERMINAL_TASK_STATES = Stream.of(TaskState.values()).filter(TaskState::isDone).collect(toImmutableSet());
 
     private final boolean doneState;
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskStateMachine.java
@@ -25,6 +25,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import static com.facebook.presto.execution.TaskState.TERMINAL_TASK_STATES;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -43,7 +44,7 @@ public class TaskStateMachine
     public TaskStateMachine(TaskId taskId, Executor executor)
     {
         this.taskId = checkNotNull(taskId, "taskId is null");
-        taskState = new StateMachine<>("task " + taskId, executor, TaskState.RUNNING);
+        taskState = new StateMachine<>("task " + taskId, executor, TaskState.RUNNING, TERMINAL_TASK_STATES);
         taskState.addStateChangeListener(new StateChangeListener<TaskState>()
         {
             @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskStateMachine.java
@@ -47,9 +47,9 @@ public class TaskStateMachine
         taskState.addStateChangeListener(new StateChangeListener<TaskState>()
         {
             @Override
-            public void stateChanged(TaskState newValue)
+            public void stateChanged(TaskState newState)
             {
-                log.debug("Task %s is %s", TaskStateMachine.this.taskId, newValue);
+                log.debug("Task %s is %s", TaskStateMachine.this.taskId, newState);
             }
         });
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -90,9 +90,9 @@ public class TaskContext
         taskStateMachine.addStateChangeListener(new StateChangeListener<TaskState>()
         {
             @Override
-            public void stateChanged(TaskState newValue)
+            public void stateChanged(TaskState newState)
             {
-                if (newValue.isDone()) {
+                if (newState.isDone()) {
                     executionEndTime.set(DateTime.now());
                     endNanos.set(System.nanoTime());
                 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.client.FailureInfo;
+import com.facebook.presto.memory.MemoryPoolId;
+import com.facebook.presto.memory.VersionedMemoryPoolId;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.jetbrains.annotations.NotNull;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.execution.QueryState.FAILED;
+import static com.facebook.presto.execution.QueryState.FINISHED;
+import static com.facebook.presto.execution.QueryState.PLANNING;
+import static com.facebook.presto.execution.QueryState.QUEUED;
+import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.facebook.presto.execution.QueryState.STARTING;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+public class TestQueryStateMachine
+{
+    private static final QueryId QUERY_ID = new QueryId("query_id");
+    private static final String QUERY = "sql";
+    private static final URI LOCATION = URI.create("fake://fake-query");
+    private static final SQLException FAILED_CAUSE = new SQLException("FAILED");
+    private static final List<Input> INPUTS = ImmutableList.of(new Input("connector", "schema", "table", ImmutableList.of(new Column("a", "varchar", Optional.empty()))));
+    private static final List<String> OUTPUT_FIELD_NAMES = ImmutableList.of("a", "b", "c");
+    private static final String UPDATE_TYPE = "update type";
+    private static final VersionedMemoryPoolId MEMORY_POOL = new VersionedMemoryPoolId(new MemoryPoolId("pool"), 42);
+    private static final Map<String, String> SET_SESSION_PROPERTIES = ImmutableMap.<String, String>builder()
+            .put("fruit", "apple")
+            .put("drink", "coffee")
+            .build();
+    private static final List<String> RESET_SESSION_PROPERTIES = ImmutableList.of("candy");
+
+    private final ExecutorService executor = newCachedThreadPool();
+
+    @AfterClass
+    public void tearDown()
+    {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testBasicStateChanges()
+    {
+        QueryStateMachine stateMachine = createQueryStateMachine();
+        assertState(stateMachine, QUEUED);
+
+        assertTrue(stateMachine.transitionToPlanning());
+        assertState(stateMachine, PLANNING);
+
+        assertTrue(stateMachine.transitionToStarting());
+        assertState(stateMachine, STARTING);
+
+        assertTrue(stateMachine.transitionToRunning());
+        assertState(stateMachine, RUNNING);
+
+        assertTrue(stateMachine.transitionToFinished());
+        assertState(stateMachine, FINISHED);
+    }
+
+    @Test
+    public void testQueued()
+    {
+        QueryStateMachine stateMachine = createQueryStateMachine();
+        assertState(stateMachine, QUEUED);
+
+        assertTrue(stateMachine.transitionToPlanning());
+        assertState(stateMachine, PLANNING);
+
+        stateMachine = createQueryStateMachine();
+        assertTrue(stateMachine.transitionToStarting());
+        assertState(stateMachine, STARTING);
+
+        stateMachine = createQueryStateMachine();
+        assertTrue(stateMachine.transitionToRunning());
+        assertState(stateMachine, RUNNING);
+
+        stateMachine = createQueryStateMachine();
+        assertTrue(stateMachine.transitionToFinished());
+        assertState(stateMachine, FINISHED);
+
+        stateMachine = createQueryStateMachine();
+        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertState(stateMachine, FAILED);
+    }
+
+    @Test
+    public void testPlanning()
+    {
+        QueryStateMachine stateMachine = createQueryStateMachine();
+        assertTrue(stateMachine.transitionToPlanning());
+        assertState(stateMachine, PLANNING);
+
+        assertFalse(stateMachine.transitionToPlanning());
+        assertState(stateMachine, PLANNING);
+
+        assertTrue(stateMachine.transitionToStarting());
+        assertState(stateMachine, STARTING);
+
+        stateMachine = createQueryStateMachine();
+        stateMachine.transitionToPlanning();
+        assertTrue(stateMachine.transitionToRunning());
+        assertState(stateMachine, RUNNING);
+
+        stateMachine = createQueryStateMachine();
+        stateMachine.transitionToPlanning();
+        assertTrue(stateMachine.transitionToFinished());
+        assertState(stateMachine, FINISHED);
+
+        stateMachine = createQueryStateMachine();
+        stateMachine.transitionToPlanning();
+        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertState(stateMachine, FAILED);
+    }
+
+    @Test
+    public void testStarting()
+    {
+        QueryStateMachine stateMachine = createQueryStateMachine();
+        assertTrue(stateMachine.transitionToStarting());
+        assertState(stateMachine, STARTING);
+
+        assertFalse(stateMachine.transitionToPlanning());
+        assertState(stateMachine, STARTING);
+
+        assertFalse(stateMachine.transitionToStarting());
+        assertState(stateMachine, STARTING);
+
+        assertTrue(stateMachine.transitionToRunning());
+        assertState(stateMachine, RUNNING);
+
+        stateMachine = createQueryStateMachine();
+        stateMachine.transitionToStarting();
+        assertTrue(stateMachine.transitionToFinished());
+        assertState(stateMachine, FINISHED);
+
+        stateMachine = createQueryStateMachine();
+        stateMachine.transitionToStarting();
+        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertState(stateMachine, FAILED);
+    }
+
+    @Test
+    public void testRunning()
+    {
+        QueryStateMachine stateMachine = createQueryStateMachine();
+        assertTrue(stateMachine.transitionToRunning());
+        assertState(stateMachine, RUNNING);
+
+        assertFalse(stateMachine.transitionToPlanning());
+        assertState(stateMachine, RUNNING);
+
+        assertFalse(stateMachine.transitionToStarting());
+        assertState(stateMachine, RUNNING);
+
+        assertFalse(stateMachine.transitionToRunning());
+        assertState(stateMachine, RUNNING);
+
+        assertTrue(stateMachine.transitionToFinished());
+        assertState(stateMachine, FINISHED);
+
+        stateMachine = createQueryStateMachine();
+        stateMachine.transitionToRunning();
+        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertState(stateMachine, FAILED);
+    }
+
+    @Test
+    public void testFinished()
+    {
+        QueryStateMachine stateMachine = createQueryStateMachine();
+        assertTrue(stateMachine.transitionToFinished());
+        assertFinalState(stateMachine, FINISHED);
+    }
+
+    @Test
+    public void testFailed()
+    {
+        QueryStateMachine stateMachine = createQueryStateMachine();
+        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertFinalState(stateMachine, FAILED);
+    }
+
+    private static void assertFinalState(QueryStateMachine stateMachine, QueryState expectedState)
+    {
+        assertTrue(expectedState.isDone());
+        assertState(stateMachine, expectedState);
+
+        assertFalse(stateMachine.transitionToPlanning());
+        assertState(stateMachine, expectedState);
+
+        assertFalse(stateMachine.transitionToStarting());
+        assertState(stateMachine, expectedState);
+
+        assertFalse(stateMachine.transitionToRunning());
+        assertState(stateMachine, expectedState);
+
+        assertFalse(stateMachine.transitionToFinished());
+        assertState(stateMachine, expectedState);
+
+        assertFalse(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertState(stateMachine, expectedState);
+    }
+
+    private static void assertState(QueryStateMachine stateMachine, QueryState expectedState)
+    {
+        assertEquals(stateMachine.getQueryId(), QUERY_ID);
+        assertSame(stateMachine.getSession(), TEST_SESSION);
+        assertSame(stateMachine.getMemoryPool(), MEMORY_POOL);
+        assertEquals(stateMachine.getSetSessionProperties(), SET_SESSION_PROPERTIES);
+        assertEquals(stateMachine.getResetSessionProperties(), RESET_SESSION_PROPERTIES);
+
+        QueryInfo queryInfo = stateMachine.getQueryInfo(null);
+        assertEquals(queryInfo.getQueryId(), QUERY_ID);
+        assertEquals(queryInfo.getSelf(), LOCATION);
+        assertNull(queryInfo.getOutputStage());
+        assertEquals(queryInfo.getQuery(), QUERY);
+        assertEquals(queryInfo.getInputs(), INPUTS);
+        assertEquals(queryInfo.getFieldNames(), OUTPUT_FIELD_NAMES);
+        assertEquals(queryInfo.getUpdateType(), UPDATE_TYPE);
+        assertEquals(queryInfo.getMemoryPool(), MEMORY_POOL.getId());
+
+        QueryStats queryStats = queryInfo.getQueryStats();
+        if (queryInfo.getState() == QUEUED) {
+            assertNull(queryStats.getQueuedTime());
+            assertNull(queryStats.getTotalPlanningTime());
+            assertNull(queryStats.getExecutionStartTime());
+            assertNull(queryStats.getEndTime());
+        }
+        else if (queryInfo.getState() == PLANNING) {
+            assertNotNull(queryStats.getQueuedTime());
+            assertNull(queryStats.getTotalPlanningTime());
+            assertNull(queryStats.getExecutionStartTime());
+            assertNull(queryStats.getEndTime());
+        }
+        else if (queryInfo.getState() == STARTING) {
+            assertNotNull(queryStats.getQueuedTime());
+            assertNotNull(queryStats.getTotalPlanningTime());
+            assertNull(queryStats.getExecutionStartTime());
+            assertNull(queryStats.getEndTime());
+        }
+        else if (queryInfo.getState() == RUNNING) {
+            assertNotNull(queryStats.getQueuedTime());
+            assertNotNull(queryStats.getTotalPlanningTime());
+            assertNotNull(queryStats.getExecutionStartTime());
+            assertNull(queryStats.getEndTime());
+        }
+        else {
+            assertNotNull(queryStats.getQueuedTime());
+            assertNotNull(queryStats.getTotalPlanningTime());
+            assertNotNull(queryStats.getExecutionStartTime());
+            assertNotNull(queryStats.getEndTime());
+        }
+
+        assertEquals(stateMachine.getQueryState(), expectedState);
+        assertEquals(queryInfo.getState(), expectedState);
+        assertEquals(stateMachine.isDone(), expectedState.isDone());
+
+        if (expectedState == FAILED) {
+            FailureInfo failure = queryInfo.getFailureInfo();
+            assertNotNull(failure);
+            assertEquals(failure.getMessage(), FAILED_CAUSE.getMessage());
+            assertEquals(failure.getType(), FAILED_CAUSE.getClass().getName());
+        }
+        else {
+            assertNull(queryInfo.getFailureInfo());
+        }
+    }
+
+    @NotNull
+    private QueryStateMachine createQueryStateMachine()
+    {
+        QueryStateMachine stateMachine = new QueryStateMachine(QUERY_ID, QUERY, TEST_SESSION, LOCATION, executor);
+        stateMachine.setInputs(INPUTS);
+        stateMachine.setOutputFieldNames(OUTPUT_FIELD_NAMES);
+        stateMachine.setUpdateType(UPDATE_TYPE);
+        stateMachine.setMemoryPool(MEMORY_POOL);
+        for (Entry<String, String> entry : SET_SESSION_PROPERTIES.entrySet()) {
+            stateMachine.addSetSessionProperties(entry.getKey(), entry.getValue());
+        }
+        RESET_SESSION_PROPERTIES.forEach(stateMachine::addResetSessionProperties);
+        return stateMachine;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.List;
@@ -229,6 +230,10 @@ public class TestQueryStateMachine
         assertState(stateMachine, expectedState);
 
         assertFalse(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertState(stateMachine, expectedState);
+
+        // attempt to fail with another exception, which will fail
+        assertFalse(stateMachine.transitionToFailed(new IOException("failure after finish")));
         assertState(stateMachine, expectedState);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStageStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStageStateMachine.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.sql.planner.PlanFragment.OutputPartitioning;
+import com.facebook.presto.sql.planner.PlanFragment.PlanDistribution;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.PlanFragmentId;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.sql.tree.StringLiteral;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+public class TestStageStateMachine
+{
+    private static final StageId STAGE_ID = new StageId("query", "stage");
+    private static final URI LOCATION = URI.create("fake://fake-stage");
+    private static final PlanFragment PLAN_FRAGMENT = createValuesPlan();
+    private static final SQLException FAILED_CAUSE = new SQLException("FAILED");
+
+    private final ExecutorService executor = newCachedThreadPool();
+
+    @AfterClass
+    public void tearDown()
+    {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testBasicStateChanges()
+    {
+        StageStateMachine stateMachine = createStageStateMachine();
+        assertState(stateMachine, StageState.PLANNED);
+
+        assertTrue(stateMachine.transitionToScheduling());
+        assertState(stateMachine, StageState.SCHEDULING);
+
+        assertTrue(stateMachine.transitionToScheduled());
+        assertState(stateMachine, StageState.SCHEDULED);
+
+        assertTrue(stateMachine.transitionToRunning());
+        assertState(stateMachine, StageState.RUNNING);
+
+        assertTrue(stateMachine.transitionToFinished());
+        assertState(stateMachine, StageState.FINISHED);
+    }
+
+    @Test
+    public void testPlanned()
+    {
+        StageStateMachine stateMachine = createStageStateMachine();
+        assertState(stateMachine, StageState.PLANNED);
+
+        stateMachine = createStageStateMachine();
+        assertTrue(stateMachine.transitionToScheduling());
+        assertState(stateMachine, StageState.SCHEDULING);
+
+        stateMachine = createStageStateMachine();
+        assertTrue(stateMachine.transitionToRunning());
+        assertState(stateMachine, StageState.RUNNING);
+
+        stateMachine = createStageStateMachine();
+        assertTrue(stateMachine.transitionToFinished());
+        assertState(stateMachine, StageState.FINISHED);
+
+        stateMachine = createStageStateMachine();
+        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertState(stateMachine, StageState.FAILED);
+
+        stateMachine = createStageStateMachine();
+        assertTrue(stateMachine.transitionToAborted());
+        assertState(stateMachine, StageState.ABORTED);
+
+        stateMachine = createStageStateMachine();
+        assertTrue(stateMachine.transitionToCanceled());
+        assertState(stateMachine, StageState.CANCELED);
+    }
+
+    @Test
+    public void testScheduling()
+    {
+        StageStateMachine stateMachine = createStageStateMachine();
+        assertTrue(stateMachine.transitionToScheduling());
+        assertState(stateMachine, StageState.SCHEDULING);
+
+        assertFalse(stateMachine.transitionToScheduling());
+        assertState(stateMachine, StageState.SCHEDULING);
+
+        assertTrue(stateMachine.transitionToScheduled());
+        assertState(stateMachine, StageState.SCHEDULED);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToScheduling();
+        assertTrue(stateMachine.transitionToRunning());
+        assertState(stateMachine, StageState.RUNNING);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToScheduling();
+        assertTrue(stateMachine.transitionToFinished());
+        assertState(stateMachine, StageState.FINISHED);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToScheduling();
+        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertState(stateMachine, StageState.FAILED);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToScheduling();
+        assertTrue(stateMachine.transitionToAborted());
+        assertState(stateMachine, StageState.ABORTED);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToScheduling();
+        assertTrue(stateMachine.transitionToCanceled());
+        assertState(stateMachine, StageState.CANCELED);
+    }
+
+    @Test
+    public void testScheduled()
+    {
+        StageStateMachine stateMachine = createStageStateMachine();
+        assertTrue(stateMachine.transitionToScheduled());
+        assertState(stateMachine, StageState.SCHEDULED);
+
+        assertFalse(stateMachine.transitionToScheduling());
+        assertState(stateMachine, StageState.SCHEDULED);
+
+        assertFalse(stateMachine.transitionToScheduled());
+        assertState(stateMachine, StageState.SCHEDULED);
+
+        assertTrue(stateMachine.transitionToRunning());
+        assertState(stateMachine, StageState.RUNNING);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToScheduled();
+        assertTrue(stateMachine.transitionToFinished());
+        assertState(stateMachine, StageState.FINISHED);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToScheduled();
+        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertState(stateMachine, StageState.FAILED);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToScheduled();
+        assertTrue(stateMachine.transitionToAborted());
+        assertState(stateMachine, StageState.ABORTED);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToScheduled();
+        assertTrue(stateMachine.transitionToCanceled());
+        assertState(stateMachine, StageState.CANCELED);
+    }
+
+    @Test
+    public void testRunning()
+    {
+        StageStateMachine stateMachine = createStageStateMachine();
+        assertTrue(stateMachine.transitionToRunning());
+        assertState(stateMachine, StageState.RUNNING);
+
+        assertFalse(stateMachine.transitionToScheduling());
+        assertState(stateMachine, StageState.RUNNING);
+
+        assertFalse(stateMachine.transitionToScheduled());
+        assertState(stateMachine, StageState.RUNNING);
+
+        assertFalse(stateMachine.transitionToRunning());
+        assertState(stateMachine, StageState.RUNNING);
+
+        assertTrue(stateMachine.transitionToFinished());
+        assertState(stateMachine, StageState.FINISHED);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToRunning();
+        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertState(stateMachine, StageState.FAILED);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToRunning();
+        assertTrue(stateMachine.transitionToAborted());
+        assertState(stateMachine, StageState.ABORTED);
+
+        stateMachine = createStageStateMachine();
+        stateMachine.transitionToRunning();
+        assertTrue(stateMachine.transitionToCanceled());
+        assertState(stateMachine, StageState.CANCELED);
+    }
+
+    @Test
+    public void testFinished()
+    {
+        StageStateMachine stateMachine = createStageStateMachine();
+
+        assertTrue(stateMachine.transitionToFinished());
+        assertFinalState(stateMachine, StageState.FINISHED);
+    }
+
+    @Test
+    public void testFailed()
+    {
+        StageStateMachine stateMachine = createStageStateMachine();
+
+        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertFinalState(stateMachine, StageState.FAILED);
+    }
+
+    @Test
+    public void testAborted()
+    {
+        StageStateMachine stateMachine = createStageStateMachine();
+
+        assertTrue(stateMachine.transitionToAborted());
+        assertFinalState(stateMachine, StageState.ABORTED);
+    }
+
+    @Test
+    public void testCanceled()
+    {
+        StageStateMachine stateMachine = createStageStateMachine();
+
+        assertTrue(stateMachine.transitionToCanceled());
+        assertFinalState(stateMachine, StageState.CANCELED);
+    }
+
+    private static void assertFinalState(StageStateMachine stateMachine, StageState expectedState)
+    {
+        assertTrue(expectedState.isDone());
+
+        assertState(stateMachine, expectedState);
+
+        assertFalse(stateMachine.transitionToScheduling());
+        assertState(stateMachine, expectedState);
+
+        assertFalse(stateMachine.transitionToScheduled());
+        assertState(stateMachine, expectedState);
+
+        assertFalse(stateMachine.transitionToRunning());
+        assertState(stateMachine, expectedState);
+
+        assertFalse(stateMachine.transitionToFinished());
+        assertState(stateMachine, expectedState);
+
+        assertFalse(stateMachine.transitionToFailed(FAILED_CAUSE));
+        assertState(stateMachine, expectedState);
+
+        assertFalse(stateMachine.transitionToAborted());
+        assertState(stateMachine, expectedState);
+    }
+
+    private static void assertState(StageStateMachine stateMachine, StageState expectedState)
+    {
+        assertEquals(stateMachine.getStageId(), STAGE_ID);
+        assertEquals(stateMachine.getLocation(), LOCATION);
+        assertSame(stateMachine.getSession(), TEST_SESSION);
+
+        StageInfo stageInfo = stateMachine.getStageInfo(ImmutableList::of, ImmutableList::of);
+        assertEquals(stageInfo.getStageId(), STAGE_ID);
+        assertEquals(stageInfo.getSelf(), LOCATION);
+        assertEquals(stageInfo.getSubStages(), ImmutableList.of());
+        assertEquals(stageInfo.getTasks(), ImmutableList.of());
+        assertEquals(stageInfo.getTypes(), ImmutableList.of(VARCHAR));
+        assertSame(stageInfo.getPlan(), PLAN_FRAGMENT);
+
+        assertEquals(stateMachine.getState(), expectedState);
+        assertEquals(stageInfo.getState(), expectedState);
+
+        if (expectedState == StageState.FAILED) {
+            assertEquals(stageInfo.getFailures().size(), 1);
+            ExecutionFailureInfo failure = stageInfo.getFailures().get(0);
+            assertEquals(failure.getMessage(), FAILED_CAUSE.getMessage());
+            assertEquals(failure.getType(), FAILED_CAUSE.getClass().getName());
+        }
+        else {
+            assertTrue(stageInfo.getFailures().isEmpty());
+        }
+    }
+
+    private StageStateMachine createStageStateMachine()
+    {
+        return new StageStateMachine(STAGE_ID, LOCATION, TEST_SESSION, PLAN_FRAGMENT, executor);
+    }
+
+    private static PlanFragment createValuesPlan()
+    {
+        Symbol symbol = new Symbol("column");
+        PlanNodeId valuesNodeId = new PlanNodeId("plan");
+        PlanFragment planFragment = new PlanFragment(
+                new PlanFragmentId("plan"),
+                new ValuesNode(valuesNodeId,
+                        ImmutableList.of(symbol),
+                        ImmutableList.of(ImmutableList.of(new StringLiteral("foo")))),
+                ImmutableMap.<Symbol, Type>of(symbol, VARCHAR),
+                ImmutableList.of(symbol),
+                PlanDistribution.SINGLE,
+                valuesNodeId,
+                OutputPartitioning.NONE,
+                ImmutableList.<Symbol>of(),
+                Optional.empty());
+
+        return planFragment;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStateMachine.java
@@ -30,6 +30,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 public class TestStateMachine
 {
@@ -45,6 +46,65 @@ public class TestStateMachine
             throws Exception
     {
         executor.shutdownNow();
+    }
+
+    @Test
+    public void testNullState()
+            throws Exception
+    {
+        try {
+            new StateMachine<>("test", executor, null);
+            fail("expected a NullPointerException");
+        }
+        catch (NullPointerException exception) {
+        }
+
+        StateMachine<State> stateMachine = new StateMachine<>("test", executor, State.BREAKFAST);
+
+        assertNoStateChange(stateMachine, () -> {
+            try {
+                stateMachine.set(null);
+                fail("expected a NullPointerException");
+            }
+            catch (NullPointerException exception) {
+            }
+        });
+
+        assertNoStateChange(stateMachine, () -> {
+            try {
+                stateMachine.compareAndSet(State.BREAKFAST, null);
+                fail("expected a NullPointerException");
+            }
+            catch (NullPointerException exception) {
+            }
+        });
+
+        assertNoStateChange(stateMachine, () -> {
+            try {
+                stateMachine.compareAndSet(State.LUNCH, null);
+                fail("expected a NullPointerException");
+            }
+            catch (NullPointerException exception) {
+            }
+        });
+
+        assertNoStateChange(stateMachine, () -> {
+            try {
+                stateMachine.setIf(null, currentState -> true);
+                fail("expected a NullPointerException");
+            }
+            catch (NullPointerException exception) {
+            }
+        });
+
+        assertNoStateChange(stateMachine, () -> {
+            try {
+                stateMachine.setIf(null, currentState -> false);
+                fail("expected a NullPointerException");
+            }
+            catch (NullPointerException exception) {
+            }
+        });
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStateMachine.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import io.airlift.units.Duration;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestStateMachine
+{
+    private enum State
+    {
+        BREAKFAST, LUNCH, DINNER
+    }
+
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+
+    @AfterClass
+    public void tearDown()
+            throws Exception
+    {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testSet()
+            throws Exception
+    {
+        StateMachine<State> stateMachine = new StateMachine<>("test", executor, State.BREAKFAST);
+        assertEquals(stateMachine.get(), State.BREAKFAST);
+
+        assertNoStateChange(stateMachine, () -> assertEquals(stateMachine.set(State.BREAKFAST), State.BREAKFAST));
+
+        assertStateChange(stateMachine, () -> assertEquals(stateMachine.set(State.LUNCH), State.BREAKFAST), State.LUNCH);
+
+        assertStateChange(stateMachine, () -> assertEquals(stateMachine.set(State.BREAKFAST), State.LUNCH), State.BREAKFAST);
+    }
+
+    @Test
+    public void testCompareAndSet()
+            throws Exception
+    {
+        StateMachine<State> stateMachine = new StateMachine<>("test", executor, State.BREAKFAST);
+        assertEquals(stateMachine.get(), State.BREAKFAST);
+
+        // no match with new state
+        assertNoStateChange(stateMachine, () -> stateMachine.compareAndSet(State.DINNER, State.LUNCH));
+
+        // match with new state
+        assertStateChange(stateMachine,
+                () -> stateMachine.compareAndSet(State.BREAKFAST, State.LUNCH),
+                State.LUNCH);
+
+        // no match with same state
+        assertNoStateChange(stateMachine, () -> stateMachine.compareAndSet(State.BREAKFAST, State.LUNCH));
+
+        // match with same state
+        assertNoStateChange(stateMachine, () -> stateMachine.compareAndSet(State.LUNCH, State.LUNCH));
+    }
+
+    @Test
+    public void testSetIf()
+            throws Exception
+    {
+        StateMachine<State> stateMachine = new StateMachine<>("test", executor, State.BREAKFAST);
+        assertEquals(stateMachine.get(), State.BREAKFAST);
+
+        // false predicate with new state
+        assertNoStateChange(stateMachine,
+                () -> assertFalse(stateMachine.setIf(State.LUNCH, currentState -> {
+                    assertEquals(currentState, State.BREAKFAST);
+                    return false;
+                })));
+
+        // true predicate with new state
+        assertStateChange(stateMachine,
+                () -> assertTrue(stateMachine.setIf(State.LUNCH, currentState -> {
+                    assertEquals(currentState, State.BREAKFAST);
+                    return true;
+                })),
+                State.LUNCH);
+
+        // false predicate with same state
+        assertNoStateChange(stateMachine,
+                () -> assertFalse(stateMachine.setIf(State.LUNCH, currentState -> {
+                    assertEquals(currentState, State.LUNCH);
+                    return false;
+                })));
+
+        // true predicate with same state
+        assertNoStateChange(stateMachine,
+                () -> assertFalse(stateMachine.setIf(State.LUNCH, currentState -> {
+                    assertEquals(currentState, State.LUNCH);
+                    return true;
+                })));
+    }
+
+    private void assertStateChange(StateMachine<State> stateMachine, StateChanger stateChange, State expectedState)
+            throws Exception
+    {
+        State initialState = stateMachine.get();
+        ListenableFuture<State> futureChange = stateMachine.getStateChange(initialState);
+
+        SettableFuture<State> listenerChange = SettableFuture.create();
+        stateMachine.addStateChangeListener(listenerChange::set);
+
+        Future<State> waitChange = executor.submit(() -> {
+            try {
+                stateMachine.waitForStateChange(initialState, new Duration(10, SECONDS));
+                return stateMachine.get();
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw Throwables.propagate(e);
+            }
+            catch (Exception e) {
+                throw Throwables.propagate(e);
+            }
+        });
+
+        stateChange.run();
+
+        assertEquals(stateMachine.get(), expectedState);
+
+        assertEquals(futureChange.get(1, SECONDS), expectedState);
+        assertEquals(listenerChange.get(1, SECONDS), expectedState);
+        assertEquals(waitChange.get(1, SECONDS), expectedState);
+    }
+
+    private void assertNoStateChange(StateMachine<State> stateMachine, StateChanger stateChange)
+            throws Exception
+    {
+        State initialState = stateMachine.get();
+        ListenableFuture<State> futureChange = stateMachine.getStateChange(initialState);
+
+        SettableFuture<State> listenerChange = SettableFuture.create();
+        stateMachine.addStateChangeListener(listenerChange::set);
+
+        Future<State> waitChange = executor.submit(() -> {
+            try {
+                stateMachine.waitForStateChange(initialState, new Duration(10, SECONDS));
+                return stateMachine.get();
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw Throwables.propagate(e);
+            }
+        });
+
+        stateChange.run();
+
+        assertEquals(stateMachine.get(), initialState);
+
+        try {
+            // none of the futures should finish, but there is no way to prove that
+            // the state change is not happening (the changes happen in another thread),
+            // so we wait a short time for nothing to happen.
+            futureChange.get(50, MILLISECONDS);
+        }
+        catch (InterruptedException e) {
+            throw e;
+        }
+        catch (Exception ignored) {
+        }
+
+        assertFalse(futureChange.isDone());
+        futureChange.cancel(true);
+        assertFalse(listenerChange.isDone());
+        listenerChange.cancel(true);
+        assertFalse(waitChange.isDone());
+        waitChange.cancel(true);
+    }
+
+    private interface StateChanger
+    {
+        void run()
+                throws Exception;
+    }
+}


### PR DESCRIPTION
This adds a StateStateMachine and updates the QueryStateMachine to match the style.  Additionally, I added tests for the state transitions.

I also fixed the failure tracking between these two state machines, and cleaned up race conditions in the the query completion code.