### PR TITLE
Remove unnecessary check

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/HashPartitionMaskOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashPartitionMaskOperator.java
@@ -125,7 +125,6 @@ public class HashPartitionMaskOperator
         this.types = ImmutableList.copyOf(checkNotNull(types, "types is null"));
         this.maskChannels = maskChannels;
 
-        checkArgument(partitionChannels.length >= 0, "partitionChannels is empty");
         checkNotNull(hashChannel, "hashChannel is null");
 
         ImmutableList.Builder<Type> distinctTypes = ImmutableList.builder();


### PR DESCRIPTION
This PR removes an unnecessary check (which is always true). There are already checks covering this case in the ``HashPartitionMaskOperatorFactory`` constructor.