### PR TITLE
Collect retry statistics from the S3 filesystem

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -147,7 +147,8 @@ public class PrestoS3FileSystem
 
         HiveClientConfig defaults = new HiveClientConfig();
         this.stagingDirectory = new File(conf.get(S3_STAGING_DIRECTORY, defaults.getS3StagingDirectory().toString()));
-        this.maxClientRetries = conf.getInt(S3_MAX_CLIENT_RETRIES, defaults.getS3MaxClientRetries());
+        //add one to account for the first attempt as we set the maxAttempts to this.maxClientRetries
+        this.maxClientRetries = conf.getInt(S3_MAX_CLIENT_RETRIES, defaults.getS3MaxClientRetries()) + 1;
         this.maxBackoffTime = Duration.valueOf(conf.get(S3_MAX_BACKOFF_TIME, defaults.getS3MaxBackoffTime().toString()));
         this.maxRetryTime = Duration.valueOf(conf.get(S3_MAX_RETRY_TIME, defaults.getS3MaxRetryTime().toString()));
         int maxErrorRetries = conf.getInt(S3_MAX_ERROR_RETRIES, defaults.getS3MaxErrorRetries());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -477,6 +477,7 @@ public class PrestoS3FileSystem
                     .maxAttempts(maxClientRetries)
                     .exponentialBackoff(new Duration(1, TimeUnit.SECONDS), maxBackoffTime, maxRetryTime, 2.0)
                     .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class)
+                    .onRetry(STATS::newGetMetadataRetry)
                     .run("getS3ObjectMetadata", () -> {
                         try {
                             STATS.newMetadataCall();
@@ -635,6 +636,7 @@ public class PrestoS3FileSystem
                         .maxAttempts(maxClientRetry)
                         .exponentialBackoff(new Duration(1, TimeUnit.SECONDS), maxBackoffTime, maxRetryTime, 2.0)
                         .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class)
+                        .onRetry(STATS::newReadRetry)
                         .run("readStream", () -> {
                             seekStream();
                             try {
@@ -718,6 +720,7 @@ public class PrestoS3FileSystem
                         .maxAttempts(maxClientRetry)
                         .exponentialBackoff(new Duration(1, TimeUnit.SECONDS), maxBackoffTime, maxRetryTime, 2.0)
                         .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class)
+                        .onRetry(STATS::newGetObjectRetry)
                         .run("getS3Object", () -> {
                             try {
                                 GetObjectRequest request = new GetObjectRequest(host, keyFromPath(path)).withRange(start, Long.MAX_VALUE);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystemStats.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystemStats.java
@@ -41,6 +41,9 @@ public class PrestoS3FileSystemStats
     private final CounterStat socketTimeoutExceptions = new CounterStat();
     private final CounterStat getObjectErrors = new CounterStat();
     private final CounterStat getMetadataErrors = new CounterStat();
+    private final CounterStat getObjectRetries = new CounterStat();
+    private final CounterStat getMetadataRetries = new CounterStat();
+    private final CounterStat readRetries = new CounterStat();
 
     // see AWSRequestMetrics
     private final CounterStat awsRequestCount = new CounterStat();
@@ -174,6 +177,27 @@ public class PrestoS3FileSystemStats
         return awsRequestTime;
     }
 
+    @Managed
+    @Nested
+    public CounterStat getGetObjectRetries()
+    {
+        return getObjectRetries;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getGetMetadataRetries()
+    {
+        return getMetadataRetries;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getReadRetries()
+    {
+        return readRetries;
+    }
+
     public void connectionOpened()
     {
         activeConnections.update(1);
@@ -263,5 +287,20 @@ public class PrestoS3FileSystemStats
     public void addAwsRequestTime(Duration duration)
     {
         awsRequestTime.add(duration);
+    }
+
+    public void newGetObjectRetry()
+    {
+        getObjectRetries.update(1);
+    }
+
+    public void newGetMetadataRetry()
+    {
+        getMetadataRetries.update(1);
+    }
+
+    public void newReadRetry()
+    {
+        readRetries.update(1);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RetryDriver.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RetryDriver.java
@@ -32,7 +32,7 @@ public class RetryDriver
     private static final Duration DEFAULT_MAX_RETRY_TIME = Duration.valueOf("30s");
     private static final double DEFAULT_SCALE_FACTOR = 2.0;
 
-    private final int maxRetryAttempts;
+    private final int maxAttempts;
     private final Duration minSleepTime;
     private final Duration maxSleepTime;
     private final double scaleFactor;
@@ -40,14 +40,14 @@ public class RetryDriver
     private final List<Class<? extends Exception>> exceptionWhiteList;
 
     private RetryDriver(
-            int maxRetryAttempts,
+            int maxAttempts,
             Duration minSleepTime,
             Duration maxSleepTime,
             double scaleFactor,
             Duration maxRetryTime,
             List<Class<? extends Exception>> exceptionWhiteList)
     {
-        this.maxRetryAttempts = maxRetryAttempts;
+        this.maxAttempts = maxAttempts;
         this.minSleepTime = minSleepTime;
         this.maxSleepTime = maxSleepTime;
         this.scaleFactor = scaleFactor;
@@ -77,7 +77,7 @@ public class RetryDriver
 
     public final RetryDriver exponentialBackoff(Duration minSleepTime, Duration maxSleepTime, Duration maxRetryTime, double scaleFactor)
     {
-        return new RetryDriver(maxRetryAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, exceptionWhiteList);
+        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, exceptionWhiteList);
     }
 
     @SafeVarargs
@@ -89,7 +89,7 @@ public class RetryDriver
                 .addAll(Arrays.asList(classes))
                 .build();
 
-        return new RetryDriver(maxRetryAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, exceptions);
+        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, exceptions);
     }
 
     public RetryDriver stopOnIllegalExceptions()
@@ -116,7 +116,7 @@ public class RetryDriver
                         throw e;
                     }
                 }
-                if (attempt >= maxRetryAttempts || Duration.nanosSince(startTime).compareTo(maxRetryTime) >= 0) {
+                if (attempt >= maxAttempts || Duration.nanosSince(startTime).compareTo(maxRetryTime) >= 0) {
                     throw e;
                 }
                 log.debug("Failed on executing %s with attempt %d, will retry. Exception: %s", callableName, attempt, e.getMessage());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RetryDriver.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RetryDriver.java
@@ -19,6 +19,7 @@ import io.airlift.units.Duration;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -38,6 +39,7 @@ public class RetryDriver
     private final double scaleFactor;
     private final Duration maxRetryTime;
     private final List<Class<? extends Exception>> exceptionWhiteList;
+    private final Optional<Runnable> retryRunnable;
 
     private RetryDriver(
             int maxAttempts,
@@ -45,7 +47,8 @@ public class RetryDriver
             Duration maxSleepTime,
             double scaleFactor,
             Duration maxRetryTime,
-            List<Class<? extends Exception>> exceptionWhiteList)
+            List<Class<? extends Exception>> exceptionWhiteList,
+            Optional<Runnable> retryRunnable)
     {
         this.maxAttempts = maxAttempts;
         this.minSleepTime = minSleepTime;
@@ -53,6 +56,7 @@ public class RetryDriver
         this.scaleFactor = scaleFactor;
         this.maxRetryTime = maxRetryTime;
         this.exceptionWhiteList = exceptionWhiteList;
+        this.retryRunnable = retryRunnable;
     }
 
     private RetryDriver()
@@ -62,7 +66,8 @@ public class RetryDriver
                 DEFAULT_SLEEP_TIME,
                 DEFAULT_SCALE_FACTOR,
                 DEFAULT_MAX_RETRY_TIME,
-                ImmutableList.<Class<? extends Exception>>of());
+                ImmutableList.<Class<? extends Exception>>of(),
+                Optional.empty());
     }
 
     public static RetryDriver retry()
@@ -72,12 +77,17 @@ public class RetryDriver
 
     public final RetryDriver maxAttempts(int maxAttempts)
     {
-        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, exceptionWhiteList);
+        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, exceptionWhiteList, retryRunnable);
     }
 
     public final RetryDriver exponentialBackoff(Duration minSleepTime, Duration maxSleepTime, Duration maxRetryTime, double scaleFactor)
     {
-        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, exceptionWhiteList);
+        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, exceptionWhiteList, retryRunnable);
+    }
+
+    public final RetryDriver onRetry(Runnable retryRunnable)
+    {
+        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, exceptionWhiteList, Optional.ofNullable(retryRunnable));
     }
 
     @SafeVarargs
@@ -89,7 +99,7 @@ public class RetryDriver
                 .addAll(Arrays.asList(classes))
                 .build();
 
-        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, exceptions);
+        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, exceptions, retryRunnable);
     }
 
     public RetryDriver stopOnIllegalExceptions()
@@ -107,6 +117,11 @@ public class RetryDriver
         int attempt = 0;
         while (true) {
             attempt++;
+
+            if (attempt > 1) {
+                retryRunnable.ifPresent(runnable -> runnable.run());
+            }
+
             try {
                 return callable.call();
             }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestPrestoS3FileSystem.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.internal.StaticCredentialsProvider;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.google.common.base.Throwables;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -25,9 +26,11 @@ import org.testng.annotations.Test;
 import java.lang.reflect.Field;
 import java.net.URI;
 
+import static com.facebook.presto.hive.PrestoS3FileSystem.S3_MAX_CLIENT_RETRIES;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static org.apache.http.HttpStatus.SC_FORBIDDEN;
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_REQUESTED_RANGE_NOT_SATISFIABLE;
 import static org.testng.Assert.assertEquals;
@@ -71,6 +74,51 @@ public class TestPrestoS3FileSystem
 
         try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
             fs.initialize(new URI("s3n://test-bucket/"), config);
+        }
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    public void testReadRetryCounters()
+            throws Exception
+    {
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            int maxRetries = 2;
+            MockAmazonS3 s3 = new MockAmazonS3();
+            s3.setGetObjectHttpErrorCode(SC_INTERNAL_SERVER_ERROR);
+            Configuration configuration = new Configuration();
+            configuration.setInt(S3_MAX_CLIENT_RETRIES, maxRetries);
+            fs.initialize(new URI("s3n://test-bucket/"), configuration);
+            fs.setS3Client(s3);
+            try (FSDataInputStream inputStream = fs.open(new Path("s3n://test-bucket/test"))) {
+                inputStream.read();
+            }
+            catch (Throwable expected) {
+                assertInstanceOf(expected, AmazonS3Exception.class);
+                assertEquals(((AmazonS3Exception) expected).getStatusCode(), SC_INTERNAL_SERVER_ERROR);
+                assertEquals(PrestoS3FileSystem.getFileSystemStats().getReadRetries().getTotalCount(), maxRetries);
+                assertEquals(PrestoS3FileSystem.getFileSystemStats().getGetObjectRetries().getTotalCount(), (maxRetries + 1) * maxRetries);
+            }
+        }
+    }
+
+    @Test
+    public void testGetMetadataRetryCounter()
+    {
+        int maxRetries = 2;
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            MockAmazonS3 s3 = new MockAmazonS3();
+            s3.setGetObjectMetadataHttpCode(SC_INTERNAL_SERVER_ERROR);
+            Configuration configuration = new Configuration();
+            configuration.setInt(S3_MAX_CLIENT_RETRIES, maxRetries);
+            fs.initialize(new URI("s3n://test-bucket/"), configuration);
+            fs.setS3Client(s3);
+            fs.getS3ObjectMetadata(new Path("s3n://test-bucket/test"));
+        }
+        catch (Throwable expected) {
+            assertInstanceOf(expected, AmazonS3Exception.class);
+            assertEquals(((AmazonS3Exception) expected).getStatusCode(), SC_INTERNAL_SERVER_ERROR);
+            assertEquals(PrestoS3FileSystem.getFileSystemStats().getGetMetadataRetries().getTotalCount(), maxRetries);
         }
     }
 


### PR DESCRIPTION
This PR makes two changes:
- Collect the number of retries made at the s3 file system level for the `read()`, `getMetadata()`, and `getObject()` calls.
- Fix a bug which causes one less retry than the set `hive.s3.max-client-retries` parameter. The reason is this parameter was used by the s3 filesystem to set the number of attempts instead of the number of retries (in other words the very first attempt was considered a retry).

