### PR TITLE
Fix fetching temporal column id from Raptor metadata

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
@@ -211,8 +211,18 @@ public interface MetadataDao
             @Bind("schemaName") String schemaName,
             @Bind("tableName") String tableName);
 
+    // JDBI returns 0 as the column_id when the temporal_column_id is set to NULL
+    // jdbi issue https://github.com/jdbi/jdbi/issues/154
     @SqlQuery("SELECT temporal_column_id\n" +
             "FROM tables\n" +
-            "WHERE table_id = :tableId")
+            "WHERE table_id = :tableId\n" +
+            "  AND temporal_column_id IS NOT NULL")
     Long getTemporalColumnId(@Bind("tableId") long tableId);
+
+    @SqlUpdate("UPDATE tables SET\n" +
+            "temporal_column_id = :columnId\n" +
+            "WHERE table_id = :tableId")
+    void updateTemporalColumnId(
+            @Bind("columnId") long columnId,
+            @Bind("tableId") long tableId);
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestMetadataDao.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestMetadataDao.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.metadata;
+
+import io.airlift.dbpool.H2EmbeddedDataSource;
+import io.airlift.dbpool.H2EmbeddedDataSourceConfig;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.raptor.metadata.MetadataDaoUtils.createMetadataTablesWithRetry;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+@Test(singleThreaded = true)
+public class TestMetadataDao
+{
+    private MetadataDao dao;
+    private Handle handle;
+
+    @BeforeMethod
+    public void setup()
+            throws Exception
+    {
+        handle = new DBI(new H2EmbeddedDataSource(new H2EmbeddedDataSourceConfig().setFilename("mem:"))).open();
+        dao = handle.attach(MetadataDao.class);
+        createMetadataTablesWithRetry(dao);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+    {
+        handle.close();
+    }
+
+    @Test
+    public void testTemporalColumn()
+            throws Exception
+    {
+        Long columnId = 1L;
+        long tableId = dao.insertTable("default", "default", "table1");
+        dao.insertColumn(tableId, columnId, "col1", 1, "bigint");
+        Long temporalColumnId = dao.getTemporalColumnId(tableId);
+        assertNull(temporalColumnId);
+
+        dao.updateTemporalColumnId(columnId, tableId);
+        temporalColumnId = dao.getTemporalColumnId(tableId);
+        assertNotNull(temporalColumnId);
+        assertEquals(temporalColumnId, columnId);
+
+        long tableId2 = dao.insertTable("default", "default", "table2");
+        Long columnId2 = dao.getTemporalColumnId(tableId2);
+        assertNull(columnId2);
+    }
+}


### PR DESCRIPTION
    Due to the following JDBI issue: https://github.com/jdbi/jdbi/issues/154
    we get a 0 as the column_id when the temporal_column_id is set to NULL.
    This fix works around that issue.