### PR TITLE
2934:  "Connection already closed" error in JdbcRecordCursor

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
@@ -219,17 +219,19 @@ public class JdbcRecordCursor
     @Override
     public void close()
     {
-        closed = true;
-
+        if (closed) {
+            return;
+        }
         // use try with resources to close everything properly
-        try (ResultSet resultSet = this.resultSet;
+        try (Connection connection = this.connection;
                 Statement statement = this.statement;
-                Connection connection = this.connection) {
+                ResultSet resultSet = this.resultSet) {
             // do nothing
         }
         catch (SQLException e) {
             throw Throwables.propagate(e);
         }
+        closed = true;
     }
 
     private RuntimeException handleSqlException(SQLException e)


### PR DESCRIPTION
Fix for https://github.com/facebook/presto/issues/2934:
* Fix incorrect sequence of resultset, statement and connection close
* Also ignore duplicate calls to close() method