### PR TITLE
Fix IndexOutOfBoundsException in NodeScheduler

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/NodeScheduler.java
@@ -182,7 +182,7 @@ public class NodeScheduler
                 }
             }
 
-            if (doubleScheduling) {
+            if (doubleScheduling && !selected.isEmpty()) {
                 // Cycle the nodes until we reach the limit
                 int uniqueNodes = selected.size();
                 int i = 0;


### PR DESCRIPTION
When set node-scheduler.multiple-tasks-per-node-enabled to true, there will be IndexOutOfBoundsException when cluster is staring up.
```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:653)
	at java.util.ArrayList.get(ArrayList.java:429)
	at com.facebook.presto.execution.NodeScheduler$NodeSelector.selectRandomNodes(NodeScheduler.java:193)
	at com.facebook.presto.execution.SqlStageExecution.scheduleFixedNodeCount(SqlStageExecution.java:615)
	at com.facebook.presto.execution.SqlStageExecution.startTasks(SqlStageExecution.java:568)
	at com.facebook.presto.execution.SqlStageExecution$$Lambda$347/1923823155.run(Unknown Source)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```