### PR TITLE
Add normalize functions for ease of unicode sorting and text search.

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -118,6 +118,24 @@ String Functions
 
     Converts ``string`` to uppercase.
 
+.. function:: normalize(string) -> varchar
+
+    Transforms ``string`` with NFC normalization form.
+
+.. function:: normalize(string, form) -> varchar
+
+    Transforms ``string`` with the specified normalization form. ``form`` must be
+    one of the following:
+
+========= ===========
+Form      Description
+========= ===========
+``NFD``   Canonical Decomposition
+``NFC``   Canonical Decomposition, followed by Canonical Composition
+``NFKD``  Compatibility Decomposition
+``NFKC``  Compatibility Decomposition, followed by Canonical Composition
+========= ===========
+
 .. function:: to_utf8(string) -> varbinary
 
     Encodes ``string`` into a UTF-8 varbinary representation.

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -369,6 +369,19 @@ public class TestStringFunctions
         assertFunction("CAST(UPPER(utf8(from_hex('CE')) || 'hello') AS VARBINARY)", VARBINARY, new SqlVarbinary(new byte[] {(byte) 0xCE, 'H', 'E', 'L', 'L', 'O'}));
     }
 
+    @Test
+    public void testNormalize()
+    {
+        assertFunction("normalize('sch\u00f6n', NFD)", VARCHAR, "scho\u0308n");
+        assertFunction("normalize('sch\u00f6n')", VARCHAR, "sch\u00f6n");
+        assertFunction("normalize('sch\u00f6n', NFC)", VARCHAR, "sch\u00f6n");
+        assertFunction("normalize('sch\u00f6n', NFKD)", VARCHAR, "scho\u0308n");
+
+        assertFunction("normalize('sch\u00f6n', NFKC)", VARCHAR, "sch\u00f6n");
+        assertFunction("normalize('\u3231\u3327\u3326\u2162', NFKC)", VARCHAR, "(\u682a)\u30c8\u30f3\u30c9\u30ebIII");
+        assertFunction("normalize('\uff8a\uff9d\uff76\uff78\uff76\uff85', NFKC)", VARCHAR, "\u30cf\u30f3\u30ab\u30af\u30ab\u30ca");
+    }
+
     // We do not use String toLowerCase or toUpperCase here because they can do multi character transforms
     // and we want to verify our implementation spec which states we perform case transform code point by
     // code point

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -231,6 +231,7 @@ primaryExpression
     | name=LOCALTIME ('(' precision=INTEGER_VALUE ')')?                              #specialDateTimeFunction
     | name=LOCALTIMESTAMP ('(' precision=INTEGER_VALUE ')')?                         #specialDateTimeFunction
     | SUBSTRING '(' valueExpression FROM valueExpression (FOR valueExpression)? ')'  #substring
+    | NORMALIZE '(' valueExpression (',' normalForm)? ')'                            #normalize
     | EXTRACT '(' identifier FROM valueExpression ')'                                #extract
     | POSITION '(' valueExpression IN valueExpression ')'                            #position
     | '(' expression ')'                                                             #parenthesizedExpression
@@ -334,6 +335,11 @@ nonReserved
     | SET | RESET
     | VIEW | REPLACE
     | IF | NULLIF | COALESCE
+    | normalForm
+    ;
+
+normalForm
+    : NFD | NFC | NFKD | NFKC
     ;
 
 SELECT: 'SELECT';
@@ -464,6 +470,12 @@ MAP: 'MAP';
 SET: 'SET';
 RESET: 'RESET';
 SESSION: 'SESSION';
+
+NORMALIZE: 'NORMALIZE';
+NFD : 'NFD';
+NFC : 'NFC';
+NFKD : 'NFKD';
+NFKC : 'NFKC';
 
 IF: 'IF';
 NULLIF: 'NULLIF';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -801,6 +801,13 @@ class AstBuilder
         return new FunctionCall(new QualifiedName("strpos"), arguments);
     }
 
+    public Node visitNormalize(@NotNull SqlBaseParser.NormalizeContext context)
+    {
+        Expression str = (Expression) visit(context.valueExpression());
+        String normalForm = Optional.ofNullable(context.normalForm()).map(ParserRuleContext::getText).orElse("NFC");
+        return new FunctionCall(new QualifiedName("normalize"), ImmutableList.of(str, new StringLiteral(normalForm)));
+    }
+
     @Override
     public Node visitSubscript(@NotNull SqlBaseParser.SubscriptContext context)
     {


### PR DESCRIPTION
When handling unicode characters (e.g., Japanese) we need some normalization that maps different representations of characters to standard ones. For details of unicode normalization, see also:
https://docs.oracle.com/javase/tutorial/i18n/text/normalizerapi.html

This PR adds functionality for unicode normalization.  
