### PR TITLE
Update checkstyle version to latest.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -749,7 +749,7 @@
                                     <pluginExecutionFilter>
                                         <groupId>org.apache.maven.plugins</groupId>
                                         <artifactId>maven-checkstyle-plugin</artifactId>
-                                        <versionRange>[2.11,)</versionRange>
+                                        <versionRange>[0,)</versionRange>
                                         <goals>
                                             <goal>check</goal>
                                         </goals>
@@ -816,7 +816,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.11</version>
+                <version>2.15</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -841,14 +841,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>6.1.1</version>
-                        <exclusions>
-                            <!-- MCHECKSTYLE-156 -->
-                            <exclusion>
-                                <groupId>com.sun</groupId>
-                                <artifactId>tools</artifactId>
-                            </exclusion>
-                        </exclusions>
+                        <version>6.6</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
Update checkstyle to use the latest version (6.6) and the latest plugin (2.15). This is required because the 6.1.1 version does not understand some Java 8 language constructs.