### PR TITLE
fix eclipse compiler TypeConversion error

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/ExecuteResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ExecuteResource.java
@@ -124,7 +124,7 @@ public class ExecuteResource
 
     private static <T> Iterator<T> flatten(Iterator<Iterable<T>> iterator)
     {
-        return concat(transform(iterator, Iterable::iterator));
+        return concat(transform(iterator, Iterable<T>::iterator));
     }
 
     private static class ResultsPageIterator


### PR DESCRIPTION
This is a correctness fix; the Sun compiler compiles this statement but the Eclipse compiler requires the generic below.

However, this change must be applied after https://github.com/facebook/presto/pull/2994 because the checkstyle plugin 6.1.1 used in presto does not consider `<T>::` a valid character sequence and flags it as an error.