### PR TITLE
Fix leak in SqlStageExecution

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -610,6 +610,11 @@ public final class SqlStageExecution
         localNodeTaskMap.put(node, task.getTaskInfo().getTaskId());
         nodeTaskMap.addTask(node, task);
 
+        // check whether the stage finished while we were scheduling this task
+        if (stateMachine.getState().isDone()) {
+            task.cancel();
+        }
+
         // update in case task finished before listener was registered
         doUpdateState();
 


### PR DESCRIPTION
Task scheduling and stage cancellation race against each other. In
particular, scheduleSourcePartitionedNodes() may take a long time if it
has to wait for free nodes, and a LIMIT query could finish after just
one of those tasks starts running. In this case the stage will be
cancelled while scheduling is still in progress, which will cause tasks
to be leaked, as they're created after the stage already has
transitioned to the CANCELLED state.