### PR TITLE
Support composite expressions for TopNRowNumber optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizersFactory.java
@@ -73,7 +73,7 @@ public class PlanOptimizersFactory
                 new UnaliasSymbolReferences(), // Run again because predicate pushdown and projection pushdown might add more projections
                 new IndexJoinOptimizer(metadata, indexManager), // Run this after projections and filters have been fully simplified and pushed down
                 new CountConstantOptimizer(),
-                new WindowFilterPushDown(), // This must run after PredicatePushDown so that it squashes any successive filter nodes
+                new WindowFilterPushDown(metadata), // This must run after PredicatePushDown so that it squashes any successive filter nodes
                 new HashGenerationOptimizer(featuresConfig.isOptimizeHashGeneration()), // This must run after all other optimizers have run to that all the PlanNodes are created
                 new MergeProjections(),
                 new PruneUnreferencedOutputs(), // Make sure to run this at the end to help clean the plan for logging/execution and not remove info that other optimizers might need at an earlier point


### PR DESCRIPTION
Fix #3068 and #3147 

This commit optimize following kinds of queries to use ```TopNRowNumber```:
```
SELECT x FROM (SELECT x, row_number() OVER (ORDER BY x) rn FROM ...) WHERE rn = 5;
```
```
WITH t AS (SELECT x, row_number() OVER (ORDER BY x) rn FROM ...)
SELECT x FROM (SELECT x FROM t WHERE rn <= 10) WHERE rn <= 5;
```
```
WITH t AS (SELECT x, row_number() OVER (ORDER BY x) rn FROM ...)
SELECT x FROM (SELECT x FROM t WHERE rn <= 10) WHERE x IS NOT NULL;
```
```
WITH t AS (SELECT x, row_number() OVER (ORDER BY x) rn FROM ...)
SELECT x FROM t WHERE rn <= 10 OR rn IN (13, 15) OR rn BETWEEN 17 AND 19;
```

If the final range of ```rn``` has an upper bound, then use ```TopNRowNumber```. 
    
Then for the following two cases add a filter on top of ```TopNRowNumber```
    * Filter expression contains ranges other than ```rn```
    * Final range of ```rn``` is not a single range like ```rn < x``` or ```rn <= x```
    
The filter contains the final range of ```rn``` and other filter expressions