### PR TITLE
Add time zone GMT at noon (-[+]00:00)

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeZoneKey.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeZoneKey.java
@@ -278,6 +278,8 @@ public final class TimeZoneKey
                 zoneId.equals("ut") ||
                 zoneId.equals("gmt") ||
                 zoneId.equals("gmt0") ||
+                zoneId.equals("gmt+00:00") ||
+                zoneId.equals("gmt-00:00") ||
                 zoneId.equals("greenwich") ||
                 zoneId.equals("universal") ||
                 zoneId.equals("zulu") ||

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTimeZoneKey.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTimeZoneKey.java
@@ -57,6 +57,8 @@ public class TestTimeZoneKey
         assertSame(TimeZoneKey.getTimeZoneKey("GMT0"), UTC_KEY);
         assertSame(TimeZoneKey.getTimeZoneKey("GMT+0"), UTC_KEY);
         assertSame(TimeZoneKey.getTimeZoneKey("GMT-0"), UTC_KEY);
+        assertSame(TimeZoneKey.getTimeZoneKey("GMT+00:00"), UTC_KEY);
+        assertSame(TimeZoneKey.getTimeZoneKey("GMT-00:00"), UTC_KEY);
         assertSame(TimeZoneKey.getTimeZoneKey("+00:00"), UTC_KEY);
         assertSame(TimeZoneKey.getTimeZoneKey("-00:00"), UTC_KEY);
         assertSame(TimeZoneKey.getTimeZoneKey("etc/utc"), UTC_KEY);


### PR DESCRIPTION
ref. issue #2370
As isUtcEquivalentName(...) doesn't accept time zone "gmt-[+]00:00", normalizeZoneId("GMT-00:00") returns "-00:00" which is not a valid TimeZoneKey. By adding conditions "gmt-[+]00:00" to isUtcEquivalentName(), normalizeZoneId("GMT-00:00") returns an expected value "utc". Then, we can support time zone "GMT-[+]00:00". 

P.S.
This is the first time for me to PR. I've already completed the CLA so check my GitHub username please.