### PR TITLE
Cassandra: Randomly select host to connect via thrift to spread load on thrift queries.

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraThriftConnectionFactory.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraThriftConnectionFactory.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +60,10 @@ public class CassandraThriftConnectionFactory
     private Cassandra.Client getClientFromAddressList() throws IOException
     {
         List<IOException> exceptions = new ArrayList<IOException>();
-        for (String address : addresses) {
+        // randomly select host to connect to
+        List<String> hostAddresses = new ArrayList<String>(addresses);
+        Collections.shuffle(hostAddresses);
+        for (String address : hostAddresses) {
             try {
                 return createConnection(address, port, factoryClassName);
             }


### PR DESCRIPTION
Currently when Presto calculates the split it calls out to the `describe_splits` thrift function when doing a full table scan. On some cfs this can take a while be resource intensive. Since (I think) the thrift api doesn't take into account multiple hosts or load balancing, presto-cassandra simply selects the first `contactPoint` provided (unless its down, then it selects the second one). This means a single cassandra node can be put under a lot load while  planning (multiple) splits.

Below is a graph of my cassandra cluster (8 dedi nodes, 32gb ram, 1tb ssd, vnodes, 4 core)'s load while evaluating presto.
![screen shot 2015-06-14 at 5 09 23 pm](https://cloud.githubusercontent.com/assets/940094/8151079/2611cee8-12b8-11e5-82c9-724b6bdefe29.png)

The first green spike is caused by a presto query I ran (this node does not have presto installed, all load is from Cassandra), and this node is `cass1`, the first contact point in my `cassandra.properties` file. The second (set) of spikes is completely unrelated to presto and is regular operation for us. After that however, I ran another presto query and you can see `cass1` spike again while presto is planning. (Planning took ~10min on full table scan with a table with ~100B rows).

What this PR does is simply does is copy the addresses into a new array, shuffle them, and iterate over them as normal. The copy here is because I'm not sure if multiple threads can call `create()` so I copied the list to be safe. I don't do much multithreaded Java so let me know if there is a better solution here. Likewise, I opted for randomization over something like round-robin because of ease of implementation (I don't think this case will have great performance differences with random vs. round-robin). (Could have also randomly selected an integer as the start index, but I think this is clearer).

On a separate note, would it be possible for the cassandra-driver to somehow cache the results of `getSplits` somewhere?