### PR TITLE
Add basic IF NOT EXISTS support for create table

### DIFF
--- a/presto-docs/src/main/sphinx/sql/create-table.rst
+++ b/presto-docs/src/main/sphinx/sql/create-table.rst
@@ -7,7 +7,7 @@ Synopsis
 
 .. code-block:: none
 
-    CREATE TABLE table_name (
+    CREATE TABLE [ IF NOT EXISTS ] table_name (
       column_name data_type [, ...]
     )
 
@@ -17,12 +17,24 @@ Description
 Create a new, empty table with the specified columns.
 Use :doc:`create-table-as` to create a table with data.
 
+The optional ``IF NOT EXISTS`` clause causes the error to be
+suppressed if the table already exists.
+
 Examples
 --------
 
 Create a new table ``orders``::
 
     CREATE TABLE orders (
+      orderkey bigint,
+      orderstatus varchar,
+      totalprice double,
+      orderdate date
+    )
+
+Create the table ``orders`` if it does not already exist::
+
+    CREATE TABLE IF NOT EXISTS orders (
       orderkey bigint,
       orderstatus varchar,
       totalprice double,

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -53,7 +53,10 @@ public class CreateTableTask
         QualifiedTableName tableName = createQualifiedTableName(session, statement.getName());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
         if (tableHandle.isPresent()) {
-            throw new SemanticException(TABLE_ALREADY_EXISTS, statement, "Table '%s' already exists", tableName);
+            if (!statement.isNotExists()) {
+                throw new SemanticException(TABLE_ALREADY_EXISTS, statement, "Table '%s' already exists", tableName);
+            }
+            return;
         }
 
         List<ColumnMetadata> columns = new ArrayList<>();

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -30,8 +30,8 @@ statement
     : query                                                            #statementDefault
     | USE schema=identifier                                            #use
     | USE catalog=identifier '.' schema=identifier                     #use
-    | CREATE TABLE qualifiedName AS query                              #createTableAsSelect
-    | CREATE TABLE qualifiedName
+    | CREATE TABLE qualifiedName AS query			       #createTableAsSelect
+    | CREATE TABLE (IF NOT EXISTS)? qualifiedName
         '(' tableElement (',' tableElement)* ')'                       #createTable
     | DROP TABLE (IF EXISTS)? qualifiedName                            #dropTable
     | INSERT INTO qualifiedName query                                  #insertInto

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -605,8 +605,11 @@ public final class SqlFormatter
         @Override
         protected Void visitCreateTable(CreateTable node, Integer indent)
         {
-            builder.append("CREATE TABLE ")
-                    .append(node.getName())
+            builder.append("CREATE TABLE ");
+            if (node.isNotExists()) {
+                builder.append("IF NOT EXISTS ");
+            }
+            builder.append(node.getName())
                     .append(" (");
 
             Joiner.on(", ").appendTo(builder, transform(node.getElements(),

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -153,7 +153,7 @@ class AstBuilder
     @Override
     public Node visitCreateTable(@NotNull SqlBaseParser.CreateTableContext context)
     {
-        return new CreateTable(getQualifiedName(context.qualifiedName()), visit(context.tableElement(), TableElement.class));
+        return new CreateTable(getQualifiedName(context.qualifiedName()), visit(context.tableElement(), TableElement.class), context.EXISTS() != null);
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
@@ -26,11 +26,13 @@ public class CreateTable
 {
     private final QualifiedName name;
     private final List<TableElement> elements;
+    private boolean notExists;
 
-    public CreateTable(QualifiedName name, List<TableElement> elements)
+    public CreateTable(QualifiedName name, List<TableElement> elements, boolean notExists)
     {
         this.name = checkNotNull(name, "table is null");
         this.elements = ImmutableList.copyOf(checkNotNull(elements, "elements is null"));
+        this.notExists = notExists;
     }
 
     public QualifiedName getName()
@@ -43,6 +45,11 @@ public class CreateTable
         return elements;
     }
 
+    public boolean isNotExists()
+    {
+        return notExists;
+    }
+
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context)
     {
@@ -52,7 +59,7 @@ public class CreateTable
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, elements);
+        return Objects.hash(name, elements, notExists);
     }
 
     @Override
@@ -66,7 +73,8 @@ public class CreateTable
         }
         CreateTable o = (CreateTable) obj;
         return Objects.equals(name, o.name) &&
-                Objects.equals(elements, o.elements);
+                Objects.equals(elements, o.elements) &&
+                Objects.equals(notExists, o.notExists);
     }
 
     @Override
@@ -75,6 +83,7 @@ public class CreateTable
         return toStringHelper(this)
                 .add("name", name)
                 .add("elements", elements)
+                .add("notExists", notExists)
                 .toString();
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
@@ -26,7 +26,7 @@ public class CreateTable
 {
     private final QualifiedName name;
     private final List<TableElement> elements;
-    private boolean notExists;
+    private final boolean notExists;
 
     public CreateTable(QualifiedName name, List<TableElement> elements, boolean notExists)
     {

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -21,6 +21,7 @@ import com.facebook.presto.sql.tree.BetweenPredicate;
 import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.CurrentTime;
@@ -65,6 +66,7 @@ import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.sql.tree.StringLiteral;
 import com.facebook.presto.sql.tree.SubscriptExpression;
 import com.facebook.presto.sql.tree.Table;
+import com.facebook.presto.sql.tree.TableElement;
 import com.facebook.presto.sql.tree.TimeLiteral;
 import com.facebook.presto.sql.tree.TimestampLiteral;
 import com.facebook.presto.sql.tree.Union;
@@ -660,6 +662,20 @@ public class TestSqlParser
                         Optional.of(new ComparisonExpression(ComparisonExpression.Type.EQUAL, new QualifiedNameReference(QualifiedName.of("x")), new LongLiteral("1"))),
                         ImmutableList.of(new SortItem(new QualifiedNameReference(QualifiedName.of("y")), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
                         Optional.of("10")));
+    }
+
+    @Test
+    public void testCreateTable()
+            throws Exception
+    {
+        assertStatement("CREATE TABLE foo (a VARCHAR, b BIGINT)",
+                new CreateTable(QualifiedName.of("foo"),
+                        ImmutableList.of(new TableElement("a", "VARCHAR"), new TableElement("b", "BIGINT")),
+                        false));
+        assertStatement("CREATE TABLE IF NOT EXISTS bar (c TIMESTAMP)",
+                new CreateTable(QualifiedName.of("bar"),
+                        ImmutableList.of(new TableElement("c", "TIMESTAMP")),
+                        true));
     }
 
     @Test

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
@@ -159,6 +159,7 @@ public class TestStatementBuilder
         printStatement("alter table a.b.c rename column x to y");
 
         printStatement("create table test (a boolean, b bigint, c double, d varchar, e timestamp)");
+        printStatement("create table if not exists baz (a timestamp, b varchar)");
         printStatement("drop table test");
 
         printStatement("create view foo as with a as (select 123) select * from a");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -116,6 +116,25 @@ public abstract class AbstractTestDistributedQueries
     }
 
     @Test
+    public void testCreateTableIfNotExists()
+            throws Exception
+    {
+        assertQueryTrue("CREATE TABLE test_create_table_if_not_exists (a bigint, b varchar, c double)");
+        assertTrue(queryRunner.tableExists(getSession(), "test_create_table_if_not_exists"));
+        MaterializedResult expected = computeActual(
+                "SELECT column_name FROM information_schema.columns WHERE table_name = 'test_create_table_if_not_exists'");
+
+        assertQueryTrue("CREATE TABLE IF NOT EXISTS test_create_table_if_not_exists (d bigint, e varchar)");
+        assertTrue(queryRunner.tableExists(getSession(), "test_create_table_if_not_exists"));
+        MaterializedResult actual = computeActual(
+                "SELECT column_name FROM information_schema.columns WHERE table_name = 'test_create_table_if_not_exists'");
+        assertEquals(expected, actual);
+
+        assertQueryTrue("DROP TABLE test_create_table_if_not_exists");
+        assertFalse(queryRunner.tableExists(getSession(), "test_create_table_if_not_exists"));
+    }
+
+    @Test
     public void testCreateTableAsSelect()
             throws Exception
     {


### PR DESCRIPTION
Resolves #2108.  This is a subset of the changes in #2941, but only contains the changes to CREATE TABLE, not CREATE TABLE AS.  This is more straightforward, and does not require any "skip execution" hacks.