### PR TITLE
Fix bug in property derivations for delete

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -241,7 +241,8 @@ class PropertyDerivations
         @Override
         public ActualProperties visitDelete(DeleteNode node, List<ActualProperties> inputProperties)
         {
-            return Iterables.getOnlyElement(inputProperties);
+            // drop all symbols in property because delete doesn't pass on any of the columns
+            return Iterables.getOnlyElement(inputProperties).translate(symbol -> Optional.empty());
         }
 
         @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -240,6 +240,15 @@ public abstract class AbstractTestDistributedQueries
                 "SELECT * FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE orderstatus <> 'F')");
 
         assertQueryTrue("DROP TABLE test_delete");
+
+        // delete using a constant property
+
+        assertQuery("CREATE TABLE test_delete AS SELECT * FROM orders", "SELECT count(*) FROM orders");
+
+        assertQuery("DELETE FROM test_delete WHERE orderstatus = 'O'", "SELECT count(*) FROM orders WHERE orderstatus = 'O'");
+        assertQuery("SELECT * FROM test_delete", "SELECT * FROM orders WHERE orderstatus <> 'O'");
+
+        assertQueryTrue("DROP TABLE test_delete");
     }
 
     @Test


### PR DESCRIPTION
`visitDelete` in property derivations pass on its child's property unchanged. This is incorrect because none of the columns are passed on in delete operation. Now none of the symbols in the child's property references a valid column after the delete operation. This change removes all symbol from the property.