### PR TITLE
Cassandra: return cassandra blob types as VARBINARY types

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
@@ -22,6 +22,7 @@ import io.airlift.slice.Slice;
 import java.util.List;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
 
 public class CassandraRecordCursor
         implements RecordCursor
@@ -118,7 +119,14 @@ public class CassandraRecordCursor
     @Override
     public Slice getSlice(int i)
     {
-        return utf8Slice(CassandraType.getColumnValue(currentRow, i, fullCassandraTypes.get(i)).toString());
+        Object value = CassandraType.getColumnValue(currentRow, i, fullCassandraTypes.get(i));
+        switch (getCassandraType(i)) {
+            case BLOB:
+            case CUSTOM:
+                return wrappedBuffer((java.nio.ByteBuffer) value);
+            default:
+                return utf8Slice(value.toString());
+        }
     }
 
     @Override

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.type.DateType;
 import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarbinaryType;
 import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.InetAddresses;
@@ -49,8 +50,8 @@ public enum CassandraType
 {
     ASCII(VarcharType.VARCHAR, String.class),
     BIGINT(BigintType.BIGINT, Long.class),
-    BLOB(VarcharType.VARCHAR, ByteBuffer.class),
-    CUSTOM(VarcharType.VARCHAR, ByteBuffer.class),
+    BLOB(VarbinaryType.VARBINARY, ByteBuffer.class),
+    CUSTOM(VarbinaryType.VARBINARY, ByteBuffer.class),
     BOOLEAN(BooleanType.BOOLEAN, Boolean.class),
     COUNTER(BigintType.BIGINT, Long.class),
     DECIMAL(DoubleType.DOUBLE, BigDecimal.class),
@@ -207,7 +208,7 @@ public enum CassandraType
                     return row.getVarint(i).toString();
                 case BLOB:
                 case CUSTOM:
-                    return Bytes.toHexString(row.getBytesUnsafe(i));
+                    return row.getBytesUnsafe(i);
                 case SET:
                     checkTypeArguments(cassandraType, 1, typeArguments);
                     return buildSetValue(row, i, typeArguments.get(0));
@@ -412,7 +413,7 @@ public enum CassandraType
                 return java.util.UUID.fromString((String) comparable);
             case BLOB:
             case CUSTOM:
-                return Bytes.fromHexString((String) comparable);
+                return comparable;
             case VARINT:
                 return new BigInteger((String) comparable);
             case SET:

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.cassandra;
 
+import com.datastax.driver.core.utils.Bytes;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.Connector;
@@ -55,6 +56,7 @@ import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.testing.Assertions.assertInstanceOf;
@@ -190,9 +192,7 @@ public class TestCassandraConnector
 
                     assertEquals(keyValue, String.format("key %d", rowId));
 
-                    // bytes are encoded as a hex string for some reason
-                    // this check keeps failing for some reason; disabling it for now
-                    assertEquals(cursor.getSlice(columnIndex.get("typebytes")).toStringUtf8(), String.format("0x%08X", rowId));
+                    assertEquals(Bytes.toHexString(cursor.getSlice(columnIndex.get("typebytes")).getBytes()), String.format("0x%08X", rowId));
 
                     // VARINT is returned as a string
                     assertEquals(cursor.getSlice(columnIndex.get("typeinteger")).toStringUtf8(), String.valueOf(rowId));
@@ -230,7 +230,7 @@ public class TestCassandraConnector
                 else if (DOUBLE.equals(type)) {
                     cursor.getDouble(columnIndex);
                 }
-                else if (VARCHAR.equals(type)) {
+                else if (VARCHAR.equals(type) || VARBINARY.equals(type)) {
                     try {
                         cursor.getSlice(columnIndex);
                     }


### PR DESCRIPTION
This PR changes the Cassandra connector to return blob types as the actual binary representations rather than just strings of the hex representation.

Question - `getSlice`  just returns a `wrappedBuffer` around a `ByteBuffer`. Is this kosher, or do I need to copy it first?