### PR TITLE
Remove skip dependency check for rpm

### DIFF
--- a/presto-server-rpm/pom.xml
+++ b/presto-server-rpm/pom.xml
@@ -18,7 +18,6 @@
 
         <air.check.skip-checkstyle>true</air.check.skip-checkstyle>
         <air.check.skip-duplicate-finder>true</air.check.skip-duplicate-finder>
-        <air.check.skip-dependency>true</air.check.skip-dependency>
         <air.check.skip-dependency-version-check>true</air.check.skip-dependency-version-check>
         <air.check.skip-extended>true</air.check.skip-extended>
 


### PR DESCRIPTION
With air.check.skip-dependency enabled, the
maven-dependency-plugin's unpack goal was being skipped. So mvn install
-P rpmbuild failed since the unpacked presto-server artifacts were
missing.

Testing: mvn clean install and mvn clean install -P rpmbuild