### PR TITLE
Fix documentation error for comparison operators

### DIFF
--- a/presto-docs/src/main/sphinx/functions/comparison.rst
+++ b/presto-docs/src/main/sphinx/functions/comparison.rst
@@ -89,7 +89,7 @@ The following truth table demonstrate the handling of ``NULL`` in
 ``IS DISTINCT FROM`` and ``IS NOT DISTINCT FROM``:
 
 ======== ======== ========= ========= ============ ================
-a        b        a = a     a <> b    a DISTINCT b a NOT DISTINCT b
+a        b        a = b     a <> b    a DISTINCT b a NOT DISTINCT b
 ======== ======== ========= ========= ============ ================
 ``1``    ``1``    ``TRUE``  ``FALSE`` ``FALSE``       ``TRUE``
 ``1``    ``2``    ``FALSE`` ``TRUE``  ``TRUE``        ``FALSE``


### PR DESCRIPTION
Compare should be `a = b` instead of `a = a`
Fix #3138 