### PR TITLE
Add launcher for TestingPrestoServer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
         <module>presto-server-rpm</module>
         <module>presto-docs</module>
         <module>presto-verifier</module>
+        <module>presto-testing-server-launcher</module>
     </modules>
 
     <dependencyManagement>

--- a/presto-testing-server-launcher/pom.xml
+++ b/presto-testing-server-launcher/pom.xml
@@ -8,10 +8,12 @@
         <version>0.108-SNAPSHOT</version>
     </parent>
 
+
     <artifactId>presto-testing-server-launcher</artifactId>
     <name>presto-testing-server-launcher</name>
 
     <properties>
+        <main-class>com.facebook.presto.server.testing.TestingPrestoServerLauncher</main-class>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
     </properties>
 
@@ -41,5 +43,50 @@
             <artifactId>guava</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>executable</shadedClassifierName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Main-Class>${main-class}</Main-Class>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.skife.maven</groupId>
+                <artifactId>really-executable-jar-maven-plugin</artifactId>
+                <configuration>
+                    <flags>-Xmx1G</flags>
+                    <classifier>executable</classifier>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>really-executable-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/presto-testing-server-launcher/pom.xml
+++ b/presto-testing-server-launcher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.108-SNAPSHOT</version>
+        <version>0.113-SNAPSHOT</version>
     </parent>
 
 

--- a/presto-testing-server-launcher/pom.xml
+++ b/presto-testing-server-launcher/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.108-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-testing-server-launcher</artifactId>
+    <name>presto-testing-server-launcher</name>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>airline</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncher.java
+++ b/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncher.java
@@ -64,7 +64,7 @@ public class TestingPrestoServerLauncher
             server.createCatalog(catalog.getCatalogName(), catalog.getConnectorName());
         }
 
-        System.out.println(server.getAddress().getHostText() + ":" + server.getAddress().getPort());
+        System.out.println(server.getAddress());
         waitForInterruption();
     }
 

--- a/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncher.java
+++ b/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncher.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.testing;
+
+import com.facebook.presto.server.testing.TestingPrestoServerLauncherOptions.Catalog;
+import com.facebook.presto.spi.Plugin;
+import io.airlift.command.Command;
+import io.airlift.command.HelpOption;
+import io.airlift.command.SingleCommand;
+
+import javax.inject.Inject;
+
+@Command(name = "testing_presto_server", description = "Testing Presto Server Launcher")
+public class TestingPrestoServerLauncher
+{
+    @Inject
+    public HelpOption helpOption;
+
+    @Inject
+    TestingPrestoServerLauncherOptions options = new TestingPrestoServerLauncherOptions();
+
+    private static void registerServerCloseShutdownHook(final TestingPrestoServer server)
+    {
+        Runtime.getRuntime().addShutdownHook(new Thread()
+        {
+            @Override
+            public void run()
+            {
+                server.close();
+            }
+        });
+    }
+
+    private static void waitForInterruption()
+    {
+        try {
+            while (true) {
+                Thread.sleep(1000);
+            }
+        }
+        catch (InterruptedException e) {
+        }
+    }
+
+    public void run()
+            throws Exception
+    {
+        TestingPrestoServer testingPrestoServer = new TestingPrestoServer();
+        for (String pluginClassName : options.getPluginClassNames()) {
+            Plugin plugin = (Plugin) Class.forName(pluginClassName).newInstance();
+            testingPrestoServer.installPlugin(plugin);
+        }
+
+        for (Catalog catalog : options.getCatalogs()) {
+            testingPrestoServer.createCatalog(catalog.getCatalogName(), catalog.getConnectorName());
+        }
+
+        System.out.println(testingPrestoServer.getAddress().getHostText() + ":" + testingPrestoServer.getAddress().getPort());
+        waitForInterruption();
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        TestingPrestoServerLauncher launcher = SingleCommand.singleCommand(TestingPrestoServerLauncher.class).parse(args);
+        if (launcher.helpOption.showHelpIfRequested()) {
+            return;
+        }
+        launcher.validateOptions();
+        launcher.run();
+    }
+
+    private void validateOptions()
+    {
+        options.validate();
+    }
+}

--- a/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncher.java
+++ b/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncher.java
@@ -17,7 +17,6 @@ import com.facebook.presto.server.testing.TestingPrestoServerLauncherOptions.Cat
 import com.facebook.presto.spi.Plugin;
 import io.airlift.command.Command;
 import io.airlift.command.HelpOption;
-import io.airlift.command.SingleCommand;
 
 import javax.inject.Inject;
 

--- a/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncher.java
+++ b/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncher.java
@@ -21,6 +21,9 @@ import io.airlift.command.SingleCommand;
 
 import javax.inject.Inject;
 
+import static io.airlift.command.SingleCommand.singleCommand;
+import static java.lang.Runtime.getRuntime;
+
 @Command(name = "testing_presto_server", description = "Testing Presto Server Launcher")
 public class TestingPrestoServerLauncher
 {
@@ -32,7 +35,7 @@ public class TestingPrestoServerLauncher
 
     private static void registerServerCloseShutdownHook(final TestingPrestoServer server)
     {
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> server.close()));
+        getRuntime().addShutdownHook(new Thread(() -> server.close()));
     }
 
     private static void waitForInterruption()
@@ -68,7 +71,7 @@ public class TestingPrestoServerLauncher
     public static void main(String[] args)
             throws Exception
     {
-        TestingPrestoServerLauncher launcher = SingleCommand.singleCommand(TestingPrestoServerLauncher.class).parse(args);
+        TestingPrestoServerLauncher launcher = singleCommand(TestingPrestoServerLauncher.class).parse(args);
         if (launcher.helpOption.showHelpIfRequested()) {
             return;
         }

--- a/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncherOptions.java
+++ b/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncherOptions.java
@@ -14,16 +14,21 @@
 
 package com.facebook.presto.server.testing;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import io.airlift.command.Option;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.stream.Collectors.toList;
 
 class TestingPrestoServerLauncherOptions
 {
+    private static final Splitter CATALOG_OPTION_SPLITTER = Splitter.on(':').trimResults();
+
     public static class Catalog
     {
         private final String catalogName;
@@ -54,10 +59,10 @@ class TestingPrestoServerLauncherOptions
 
     public List<Catalog> getCatalogs()
     {
-        return catalogOptions.stream().map(o -> {
-            String[] split = o.split(":");
-            checkState(split.length == 2, "bad format of catalog definition '" + o + "'; should be catalog_name:connector_name");
-            return new Catalog(split[0], split[1]);
+        return catalogOptions.stream().map(catalogOption -> {
+            ImmutableList<String> parts = ImmutableList.copyOf(CATALOG_OPTION_SPLITTER.split(catalogOption));
+            checkArgument(parts.size() == 2, "bad format of catalog definition '%s'; should be catalog_name:connector_name", catalogOption);
+            return new Catalog(parts.get(0), parts.get(1));
         }).collect(toList());
     }
 

--- a/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncherOptions.java
+++ b/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncherOptions.java
@@ -52,10 +52,10 @@ class TestingPrestoServerLauncherOptions
         }
     }
 
-    @Option(name = "--catalog", title = "catalog", description = "Default catalog")
+    @Option(name = "--catalog", title = "catalog", description = "Catalog:Connector mapping (can be repeated)")
     private List<String> catalogOptions = new ArrayList<>();
 
-    @Option(name = "--plugin", title = "plugin", description = "Plugin class name")
+    @Option(name = "--plugin", title = "plugin", description = "Fully qualified class name of plugin to be registered (can be repeated)")
     private List<String> pluginClassNames = new ArrayList<>();
 
     public List<Catalog> getCatalogs()

--- a/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncherOptions.java
+++ b/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncherOptions.java
@@ -15,7 +15,6 @@
 package com.facebook.presto.server.testing;
 
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 import io.airlift.command.Option;
 
 import java.util.ArrayList;

--- a/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncherOptions.java
+++ b/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncherOptions.java
@@ -22,7 +22,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.copyOf;
 import static java.util.stream.Collectors.toList;
 
 class TestingPrestoServerLauncherOptions
@@ -36,8 +38,8 @@ class TestingPrestoServerLauncherOptions
 
         public Catalog(String catalogName, String connectorName)
         {
-            this.catalogName = catalogName;
-            this.connectorName = connectorName;
+            this.catalogName = checkNotNull(catalogName, "catalogName is null");
+            this.connectorName = checkNotNull(connectorName, "connectorName is null");
         }
 
         public String getCatalogName()
@@ -60,7 +62,7 @@ class TestingPrestoServerLauncherOptions
     public List<Catalog> getCatalogs()
     {
         return catalogOptions.stream().map(catalogOption -> {
-            ImmutableList<String> parts = ImmutableList.copyOf(CATALOG_OPTION_SPLITTER.split(catalogOption));
+            List<String> parts = copyOf(CATALOG_OPTION_SPLITTER.split(catalogOption));
             checkArgument(parts.size() == 2, "bad format of catalog definition '%s'; should be catalog_name:connector_name", catalogOption);
             return new Catalog(parts.get(0), parts.get(1));
         }).collect(toList());

--- a/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncherOptions.java
+++ b/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncherOptions.java
@@ -20,7 +20,6 @@ import io.airlift.command.Option;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.copyOf;
@@ -62,7 +61,7 @@ class TestingPrestoServerLauncherOptions
     {
         return catalogOptions.stream().map(catalogOption -> {
             List<String> parts = copyOf(CATALOG_OPTION_SPLITTER.split(catalogOption));
-            checkArgument(parts.size() == 2, "bad format of catalog definition '%s'; should be catalog_name:connector_name", catalogOption);
+            checkState(parts.size() == 2, "bad format of catalog definition '%s'; should be catalog_name:connector_name", catalogOption);
             return new Catalog(parts.get(0), parts.get(1));
         }).collect(toList());
     }

--- a/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncherOptions.java
+++ b/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncherOptions.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.server.testing;
+
+import io.airlift.command.Option;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.stream.Collectors.toList;
+
+class TestingPrestoServerLauncherOptions
+{
+    public static class Catalog
+    {
+        private final String catalogName;
+        private final String connectorName;
+
+        public Catalog(String catalogName, String connectorName)
+        {
+            this.catalogName = catalogName;
+            this.connectorName = connectorName;
+        }
+
+        public String getCatalogName()
+        {
+            return catalogName;
+        }
+
+        public String getConnectorName()
+        {
+            return connectorName;
+        }
+    }
+
+    @Option(name = "--catalog", title = "catalog", description = "Default catalog")
+    private List<String> catalogOptions = new ArrayList<>();
+
+    @Option(name = "--plugin", title = "plugin", description = "Plugin class name")
+    private List<String> pluginClassNames = new ArrayList<>();
+
+    public List<Catalog> getCatalogs()
+    {
+        return catalogOptions.stream().map(o -> {
+            String[] split = o.split(":");
+            checkState(split.length == 2, "bad format of catalog definition '" + o + "'; should be catalog_name:connector_name");
+            return new Catalog(split[0], split[1]);
+        }).collect(toList());
+    }
+
+    public List<String> getPluginClassNames()
+    {
+        return pluginClassNames;
+    }
+
+    public void validate()
+    {
+        checkState(!pluginClassNames.isEmpty(), "some plugins must be defined");
+        checkState(!catalogOptions.isEmpty(), "some catalogs must be defined");
+        getCatalogs();
+    }
+}


### PR DESCRIPTION
This commit adds TestingPrestoServerLauncher which allows spawning
instance of TestingPrestoServer as separate java process.
This is needed for integration tests when we cannot spawn
TestingPrestoServer in the same JVM which runs the test code.
Example of such situation is integration testing of Java 6 based JDBC
driver for Presto.