### PR TITLE
Support LIMIT ALL.

### DIFF
--- a/presto-docs/src/main/sphinx/sql/select.rst
+++ b/presto-docs/src/main/sphinx/sql/select.rst
@@ -188,7 +188,7 @@ LIMIT Clause
 ------------
 
 The ``LIMIT`` clause restricts the number of rows in the result set.
-``LIMIT ALL`` is the same as omitting the LIMIT clause.
+``LIMIT ALL`` is the same as omitting the ``LIMIT`` clause.
 The following example queries a large table, but the limit clause restricts
 the output to only have five rows (because the query lacks an ``ORDER BY``,
 exactly which rows are returned is arbitrary)::

--- a/presto-docs/src/main/sphinx/sql/select.rst
+++ b/presto-docs/src/main/sphinx/sql/select.rst
@@ -15,7 +15,7 @@ Synopsis
     [ HAVING condition]
     [ UNION [ ALL | DISTINCT ] select ]
     [ ORDER BY expression [ ASC | DESC ] [, ...] ]
-    [ LIMIT count ]
+    [ LIMIT [ count | ALL ] ]
 
 where ``from_item`` is one of
 
@@ -188,6 +188,7 @@ LIMIT Clause
 ------------
 
 The ``LIMIT`` clause restricts the number of rows in the result set.
+``LIMIT ALL`` is the same as omitting the LIMIT clause.
 The following example queries a large table, but the limit clause restricts
 the output to only have five rows (because the query lacks an ``ORDER BY``,
 exactly which rows are returned is arbitrary)::

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -700,7 +700,7 @@ class QueryPlanner
         }
 
         PlanNode planNode;
-        if (limit.isPresent()) {
+        if (limit.isPresent() && !limit.get().equalsIgnoreCase("all")) {
             planNode = new TopNNode(idAllocator.getNextId(), subPlan.getRoot(), Long.parseLong(limit.get()), orderBySymbols.build(), orderings, false);
         }
         else {
@@ -723,8 +723,13 @@ class QueryPlanner
     private PlanBuilder limit(PlanBuilder subPlan, List<SortItem> orderBy, Optional<String> limit)
     {
         if (orderBy.isEmpty() && limit.isPresent()) {
-            long limitValue = Long.parseLong(limit.get());
-            return new PlanBuilder(subPlan.getTranslations(), new LimitNode(idAllocator.getNextId(), subPlan.getRoot(), limitValue), subPlan.getSampleWeight());
+            if (limit.get().equalsIgnoreCase("all")) {
+                return subPlan;
+            }
+            else {
+                long limitValue = Long.parseLong(limit.get());
+                return new PlanBuilder(subPlan.getTranslations(), new LimitNode(idAllocator.getNextId(), subPlan.getRoot(), limitValue), subPlan.getSampleWeight());
+            }
         }
 
         return subPlan;

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -73,7 +73,7 @@ tableElement
 queryNoWith:
       queryTerm
       (ORDER BY sortItem (',' sortItem)*)?
-      (LIMIT limit=INTEGER_VALUE)?
+      (LIMIT limit=(INTEGER_VALUE | ALL))?
       (APPROXIMATE AT confidence=number CONFIDENCE)?
     ;
 

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -55,7 +55,7 @@ statement
     | SHOW PARTITIONS (FROM | IN) qualifiedName
         (WHERE booleanExpression)?
         (ORDER BY sortItem (',' sortItem)*)?
-        (LIMIT limit=INTEGER_VALUE)?                                   #showPartitions
+        (LIMIT limit=(INTEGER_VALUE | ALL))?                           #showPartitions
     ;
 
 query

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -312,6 +312,23 @@ public class TestSqlParser
     }
 
     @Test
+    public void testLimitAll()
+    {
+        Query valuesQuery = query(values(
+                row(new LongLiteral("1"), new StringLiteral("1")),
+                row(new LongLiteral("2"), new StringLiteral("2"))));
+
+        assertStatement("SELECT * FROM (VALUES (1, '1'), (2, '2')) LIMIT ALL",
+                simpleQuery(selectList(new AllColumns()),
+                        subquery(valuesQuery),
+                        Optional.empty(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        ImmutableList.of(),
+                        Optional.of("ALL")));
+    }
+
+    @Test
     public void testValues()
     {
         Query valuesQuery = query(values(

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -677,6 +677,13 @@ public class TestSqlParser
                         Optional.of(new ComparisonExpression(ComparisonExpression.Type.EQUAL, new QualifiedNameReference(QualifiedName.of("x")), new LongLiteral("1"))),
                         ImmutableList.of(new SortItem(new QualifiedNameReference(QualifiedName.of("y")), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
                         Optional.of("10")));
+
+        assertStatement("SHOW PARTITIONS FROM t WHERE x = 1 ORDER BY y LIMIT ALL",
+                new ShowPartitions(
+                        QualifiedName.of("t"),
+                        Optional.of(new ComparisonExpression(ComparisonExpression.Type.EQUAL, new QualifiedNameReference(QualifiedName.of("x")), new LongLiteral("1"))),
+                        ImmutableList.of(new SortItem(new QualifiedNameReference(QualifiedName.of("y")), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED)),
+                        Optional.of("ALL")));
     }
 
     @Test

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
@@ -140,6 +140,9 @@ public class TestStatementBuilder
         printStatement("(table foo) limit 10");
         printStatement("(table foo limit 5) limit 10");
 
+        printStatement("select * from a limit all");
+        printStatement("select * from a order by x limit all");
+
         printStatement("select * from a union select * from b");
         printStatement("table a union all table b");
         printStatement("(table foo) union select * from foo union (table foo order by x)");

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
@@ -103,7 +103,9 @@ public class TestStatementBuilder
         printStatement("show partitions from foo where name = 'foo'");
         printStatement("show partitions from foo order by x");
         printStatement("show partitions from foo limit 10");
+        printStatement("show partitions from foo limit all");
         printStatement("show partitions from foo order by x desc limit 10");
+        printStatement("show partitions from foo order by x desc limit all");
 
         printStatement("show functions");
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -655,10 +655,24 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testLimitAll()
+            throws Exception
+    {
+        assertQuery("SELECT custkey, totalprice FROM orders LIMIT ALL", "SELECT custkey, totalprice FROM orders");
+    }
+
+    @Test
     public void testOrderByLimitZero()
             throws Exception
     {
         assertQuery("SELECT custkey, totalprice FROM orders ORDER BY orderkey LIMIT 0");
+    }
+
+    @Test
+    public void testOrderByLimitAll()
+            throws Exception
+    {
+        assertQuery("SELECT custkey, totalprice FROM orders ORDER BY orderkey LIMIT ALL", "SELECT custkey, totalprice FROM orders ORDER BY orderkey");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3137,6 +3137,18 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testShowPartitionsLimitAll()
+            throws Exception
+    {
+        MaterializedResult result = computeActual("SHOW PARTITIONS FROM orders");
+        MaterializedResult resultWithLimitAll = computeActual("SHOW PARTITIONS FROM orders LIMIT ALL");
+
+        // table is not partitioned
+        // TODO: add a partitioned table for limit all
+        assertEquals(result.getMaterializedRows().size(), resultWithLimitAll.getMaterializedRows().size());
+    }
+
+    @Test
     public void testShowFunctions()
             throws Exception
     {


### PR DESCRIPTION
LIMIT ALL is the same as omitting the LIMIT clause.
Fix #3158 