### PR TITLE
Add year check to Presto server startup

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -46,7 +46,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.facebook.presto.server.PrestoJvmRequirements.verifyJvmRequirements;
+import static com.facebook.presto.server.PrestoSystemRequirements.verifyJvmRequirements;
+import static com.facebook.presto.server.PrestoSystemRequirements.verifySystemTimeIsReasonable;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.nullToEmpty;
 import static io.airlift.discovery.client.ServiceAnnouncement.ServiceAnnouncementBuilder;
@@ -76,6 +77,7 @@ public class PrestoServer
     public void run()
     {
         verifyJvmRequirements();
+        verifySystemTimeIsReasonable();
 
         Logger log = Logger.get(PrestoServer.class);
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
@@ -16,12 +16,13 @@ package com.facebook.presto.server;
 import com.google.common.base.StandardSystemProperty;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import org.joda.time.DateTime;
 
 import java.nio.ByteOrder;
 
-final class PrestoJvmRequirements
+final class PrestoSystemRequirements
 {
-    private PrestoJvmRequirements() {}
+    private PrestoSystemRequirements() {}
 
     public static void verifyJvmRequirements()
     {
@@ -72,6 +73,18 @@ final class PrestoJvmRequirements
         slice.setByte(1, 0xEF);
         if (slice.getInt(1) != 0xDEADBEEF) {
             failRequirement("Slice library produced an unexpected result");
+        }
+    }
+
+    /**
+     * Perform a sanity check to make sure that the year is reasonably current, to guard against
+     * issues in third party libraries.
+     */
+    public static void verifySystemTimeIsReasonable()
+    {
+        int currentYear = DateTime.now().year().get();
+        if (currentYear < 2015) {
+           failRequirement("Presto requires the system time to be current (found year %s)", currentYear);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/server/TestPrestoSystemRequirements.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestPrestoSystemRequirements.java
@@ -15,14 +15,22 @@ package com.facebook.presto.server;
 
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.server.PrestoJvmRequirements.verifyJvmRequirements;
+import static com.facebook.presto.server.PrestoSystemRequirements.verifyJvmRequirements;
+import static com.facebook.presto.server.PrestoSystemRequirements.verifySystemTimeIsReasonable;
 
-public class TestPrestoJvmRequirements
+public class TestPrestoSystemRequirements
 {
     @Test
     public void testVerifyJvmRequirements()
             throws Exception
     {
         verifyJvmRequirements();
+    }
+
+    @Test
+    public void testSystemTimeSanityCheck()
+            throws Exception
+    {
+        verifySystemTimeIsReasonable();
     }
 }


### PR DESCRIPTION
* Rename PrestoJvmRequirements to PrestoSystemRequirements
* Verify that the year is current, to avoid issues in third party
  libraries

Fixes #2639.

Testing: mvn clean install; manually verified on server with incorrect year