### PR TITLE
Add rand(seed) function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -90,9 +90,18 @@ Mathematical Functions
 
     Alias for ``random()``.
 
+.. function:: rand(seed) -> double
+
+    Alias for ``random(seed)``.
+
 .. function:: random() -> double
 
     Returns a pseudo-random value in the range 0.0 <= x < 1.0
+
+.. function:: random(seed) -> double
+
+    Returns a pseudo-random value in the range 0.0 <= x < 1.0.
+    The random number generator is initialized with the given seed.
 
 .. function:: round(x) -> [same as input]
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -14,12 +14,14 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.operator.Description;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.type.SqlType;
 import com.google.common.primitives.Doubles;
 import io.airlift.slice.Slice;
 
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -239,6 +241,15 @@ public final class MathFunctions
     public static double random()
     {
         return ThreadLocalRandom.current().nextDouble();
+    }
+
+    @Description("a pseudo-random value")
+    @ScalarFunction(alias = "rand", deterministic = true)
+    @SqlType(StandardTypes.DOUBLE)
+    public static double random(ConnectorSession session, @SqlType(StandardTypes.BIGINT) long seed)
+    {
+        Random rand = RandCache.get(new RandCache.Session(session.getStartTime(), seed));
+        return rand.nextDouble();
     }
 
     @Description("round to nearest integer")

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RandCache.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RandCache.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.StandardErrorCode;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Random object cache
+ */
+public class RandCache
+{
+    private RandCache() {}
+
+    public static class Session
+    {
+        private final long startTime;
+        private final long seed;
+
+        public Session(long startTime, long seed)
+        {
+            this.startTime = startTime;
+            this.seed = seed;
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (obj instanceof Session) {
+                Session other = (Session) obj;
+                return this.startTime == other.startTime && this.seed == other.seed;
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return (int) (startTime * 31 + seed);
+        }
+    }
+
+    private static LoadingCache<Session, Random> randCache =
+            CacheBuilder
+                    .newBuilder()
+                    .expireAfterAccess(10, TimeUnit.MINUTES)
+                    .build(new CacheLoader<Session, Random>()
+                    {
+                        @Override
+                        public Random load(Session session)
+                                throws Exception
+                        {
+                            return new Random(session.seed);
+                        }
+                    });
+
+    public static Random get(Session session)
+    {
+        try {
+            return randCache.get(session);
+        }
+        catch (ExecutionException e) {
+            throw new PrestoException(StandardErrorCode.INTERNAL_ERROR, e);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -25,6 +25,7 @@ public class TestMathFunctions
         extends AbstractTestFunctions
 {
     private static final double[] DOUBLE_VALUES = {123, -123, 123.45, -123.45};
+    private static final long[] LONG_VALUES = {0, 1, 10, 230};
     private static final long[] longLefts = {9, 10, 11, -9, -10, -11};
     private static final long[] longRights = {3, -3};
     private static final double[] doubleLefts = {9, 10, 11, -9, -10, -11, 9.1, 10.1, 11.1, -9.1, -10.1, -11.1};
@@ -295,6 +296,12 @@ public class TestMathFunctions
         // random is non-deterministic
         functionAssertions.tryEvaluateWithAll("rand()", DOUBLE, TEST_SESSION);
         functionAssertions.tryEvaluateWithAll("random()", DOUBLE, TEST_SESSION);
+
+        // seeded random
+        for (long l : LONG_VALUES) {
+            functionAssertions.tryEvaluateWithAll(String.format("rand(%d)", l), DOUBLE, TEST_SESSION);
+            functionAssertions.tryEvaluateWithAll(String.format("random(%d)", l), DOUBLE, TEST_SESSION);
+        }
     }
 
     @Test


### PR DESCRIPTION
Add a random function that accepts the given seed to produce deterministic random values. For reproducibility of the generates random values, RandCache provides a session-local `Random` object, initialized with the seed value.

A question:
This rand(seed) is not 100% deterministic depending on the number of tasks in a query that executes this function. So should I use `deterministic = false` annotation? 