### PR TITLE
Revert "Finish inner join if build is empty"

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.109.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.109.rst
@@ -7,6 +7,8 @@ General Changes
 
 * Add :func:`slice`, :func:`md5`, :func:`array_min` and :func:`array_max` functions.
 * Fix bug that could cause queries submitted soon after startup to hang forever.
+* Fix bug that could cause ``JOIN`` queries to hang forever, if the right side of
+  the ``JOIN`` had too little data or skewed data.
 * Improve index join planning heuristics to favor streaming execution.
 * Improve validation of date/time literals.
 * Produce RPM package for Presto server.

--- a/presto-main/src/main/java/com/facebook/presto/operator/InMemoryJoinHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/InMemoryJoinHash.java
@@ -93,12 +93,6 @@ public final class InMemoryJoinHash
     }
 
     @Override
-    public boolean isEmpty()
-    {
-        return addresses.isEmpty();
-    }
-
-    @Override
     public long getInMemorySizeInBytes()
     {
         return size;

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -25,7 +25,6 @@ import java.io.Closeable;
 import java.util.List;
 
 import static com.facebook.presto.operator.LookupJoinOperators.JoinType.FULL_OUTER;
-import static com.facebook.presto.operator.LookupJoinOperators.JoinType.INNER;
 import static com.facebook.presto.operator.LookupJoinOperators.JoinType.LOOKUP_OUTER;
 import static com.facebook.presto.operator.LookupJoinOperators.JoinType.PROBE_OUTER;
 import static com.facebook.presto.util.MoreFutures.tryGetUnchecked;
@@ -46,7 +45,6 @@ public class LookupJoinOperator
 
     private final boolean lookupOnOuterSide;
     private final boolean probeOnOuterSide;
-    private final JoinType joinType;
 
     private LookupSource lookupSource;
     private JoinProbe probe;
@@ -73,7 +71,6 @@ public class LookupJoinOperator
 
         this.lookupSourceFuture = lookupSourceSupplier.getLookupSource(operatorContext);
         this.joinProbeFactory = joinProbeFactory;
-        this.joinType = joinType;
 
         // Cannot use switch case here, because javac will synthesize an inner class and cause IllegalAccessError
         probeOnOuterSide = joinType == PROBE_OUTER || joinType == FULL_OUTER;
@@ -140,10 +137,7 @@ public class LookupJoinOperator
         }
 
         if (lookupSource == null) {
-            tryGetLookupSource();
-            if (finishing) {
-                return false;
-            }
+            lookupSource = tryGetUnchecked(lookupSourceFuture);
         }
         return lookupSource != null && probe == null;
     }
@@ -168,8 +162,8 @@ public class LookupJoinOperator
     {
         // If needsInput was never called, lookupSource has not been initialized so far.
         if (lookupSource == null) {
-            tryGetLookupSource();
-            if (lookupSource == null || finishing) {
+            lookupSource = tryGetUnchecked(lookupSourceFuture);
+            if (lookupSource == null) {
                 return null;
             }
         }
@@ -289,15 +283,6 @@ public class LookupJoinOperator
             if (pageBuilder.isFull()) {
                 return;
             }
-        }
-    }
-
-    private void tryGetLookupSource()
-    {
-        lookupSource = tryGetUnchecked(lookupSourceFuture);
-        // for inner joins, if lookup source does not have any positions, we can finish
-        if (lookupSource != null && joinType == INNER && lookupSource.isEmpty()) {
-            finishing = true;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
@@ -24,8 +24,6 @@ public interface LookupSource
 {
     int getChannelCount();
 
-    boolean isEmpty();
-
     long getInMemorySizeInBytes();
 
     long getJoinPosition(int position, Page page, int rawHash);

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
@@ -52,16 +52,6 @@ public class PartitionedLookupSource
     }
 
     @Override
-    public boolean isEmpty()
-    {
-        boolean empty = true;
-        for (LookupSource lookupSource : lookupSources) {
-            empty = empty && lookupSource.isEmpty();
-        }
-        return empty;
-    }
-
-    @Override
     public long getInMemorySizeInBytes()
     {
         return Arrays.stream(lookupSources).mapToLong(LookupSource::getInMemorySizeInBytes).sum();

--- a/presto-main/src/main/java/com/facebook/presto/operator/SharedLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SharedLookupSource.java
@@ -44,12 +44,6 @@ public final class SharedLookupSource
     }
 
     @Override
-    public boolean isEmpty()
-    {
-        return lookupSource.isEmpty();
-    }
-
-    @Override
     public long getInMemorySizeInBytes()
     {
         return lookupSource.getInMemorySizeInBytes();

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
@@ -376,12 +376,6 @@ public class IndexLoader
         }
 
         @Override
-        public boolean isEmpty()
-        {
-            return true;
-        }
-
-        @Override
         public long getInMemorySizeInBytes()
         {
             return 0;

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSource.java
@@ -45,12 +45,6 @@ public class IndexLookupSource
     }
 
     @Override
-    public boolean isEmpty()
-    {
-        return false;
-    }
-
-    @Override
     public long getInMemorySizeInBytes()
     {
         return 0;

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -483,16 +483,6 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testJoinEmptyBuild()
-            throws Exception
-    {
-        assertQuery("SELECT COUNT(b.quantity) " +
-                "FROM orders a " +
-                "JOIN (SELECT * FROM lineitem WHERE returnflag = 'foo') b " +
-                "ON a.orderkey = b.orderkey");
-    }
-
-    @Test
     public void testArithmeticNegation()
             throws Exception
     {


### PR DESCRIPTION
This change caused queries to hang, because a task could finish its join
before receiving splits for all the remote sources that the probe side
should pull from. Those would then never be closed.