### PR TITLE
Handle arbitrary object arrays in JmxRecordSetProvider

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/jmx/JmxRecordSetProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/jmx/JmxRecordSetProvider.java
@@ -118,10 +118,7 @@ public class JmxRecordSetProvider
                         else if (javaType == Slice.class) {
                             if (value.getClass().isArray()) {
                                 // return a string representation of the array
-                                if (value.getClass().getComponentType() == String.class) {
-                                    row.add(Arrays.toString((String[]) value));
-                                }
-                                else if (value.getClass().getComponentType() == boolean.class) {
+                                if (value.getClass().getComponentType() == boolean.class) {
                                     row.add(Arrays.toString((boolean[]) value));
                                 }
                                 else if (value.getClass().getComponentType() == byte.class) {
@@ -144,6 +141,9 @@ public class JmxRecordSetProvider
                                 }
                                 else if (value.getClass().getComponentType() == short.class) {
                                     row.add(Arrays.toString((short[]) value));
+                                }
+                                else {
+                                    row.add(Arrays.toString((Object[]) value));
                                 }
                             }
                             else {


### PR DESCRIPTION
This fix prevents some jmx queries from failing:

```Java
presto:jmx> select * from "com.sun.management:type=hotspotdiagnostic";

Query 20150702_201056_01874_wvjsd, FAILED, 227 nodes
http://presto.master.dataeng.netflix.net:8080/v1/query/20150702_201056_01874_wvjsd?pretty
Splits: 223 total, 0 done (0.00%)
CPU Time: 0.0s total,     0 rows/s,     0B/s, 80% active
Per Node: 0.0 parallelism,     0 rows/s,     0B/s
Parallelism: 0.0
0:01 [0 rows, 0B] [0 rows/s, 0B/s]

Query 20150702_201056_01874_wvjsd failed: Index: 2, Size: 2
java.lang.IndexOutOfBoundsException: Index: 2, Size: 2
	at java.util.ArrayList.rangeCheck(ArrayList.java:653)
	at java.util.ArrayList.get(ArrayList.java:429)
	at com.facebook.presto.spi.InMemoryRecordSet$InMemoryRecordCursor.isNull(InMemoryRecordSet.java:163)
	at com.facebook.presto.spi.RecordPageSource.getNextPage(RecordPageSource.java:101)
	at com.facebook.presto.operator.TableScanOperator.getOutput(TableScanOperator.java:230)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:343)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:283)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:563)
	at com.facebook.presto.execution.TaskExecutor$PrioritizedSplitRunner.process(TaskExecutor.java:505)
	at com.facebook.presto.execution.TaskExecutor$Runner.run(TaskExecutor.java:639)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```