### PR TITLE
PeakMemoryUsage tracking

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryCompletionEvent.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryCompletionEvent.java
@@ -47,6 +47,8 @@ public class QueryCompletionEvent
     private final List<String> fieldNames;
     private final String query;
 
+    private final Long peakMemoryBytes;
+
     private final DateTime createTime;
     private final DateTime executionStartTime;
     private final DateTime endTime;
@@ -85,6 +87,7 @@ public class QueryCompletionEvent
             URI uri,
             List<String> fieldNames,
             String query,
+            Long peakMemoryBytes,
             DateTime createTime,
             DateTime executionStartTime,
             DateTime endTime,
@@ -117,6 +120,7 @@ public class QueryCompletionEvent
         this.uri = uri;
         this.errorCode = errorCode;
         this.fieldNames = ImmutableList.copyOf(fieldNames);
+        this.peakMemoryBytes = peakMemoryBytes;
         this.query = query;
         this.createTime = createTime;
         this.executionStartTime = executionStartTime;
@@ -231,6 +235,12 @@ public class QueryCompletionEvent
     public String getQuery()
     {
         return query;
+    }
+
+    @EventField
+    public Long getPeakMemoryBytes()
+    {
+        return peakMemoryBytes;
     }
 
     @EventField

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
@@ -111,6 +111,7 @@ public class QueryMonitor
                             queryInfo.getSelf(),
                             queryInfo.getFieldNames(),
                             queryInfo.getQuery(),
+                            queryStats.getPeakMemoryReservation().toBytes(),
                             queryStats.getCreateTime(),
                             queryStats.getExecutionStartTime(),
                             queryStats.getEndTime(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.OutputBuffers;
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.StateMachine.StateChangeListener;
+import com.facebook.presto.metadata.Split;
+import com.facebook.presto.spi.Node;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.google.common.collect.Multimap;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.util.Objects.requireNonNull;
+
+public class MemoryTrackingRemoteTaskFactory
+        implements RemoteTaskFactory
+{
+    private final RemoteTaskFactory remoteTaskFactory;
+    private final QueryStateMachine stateMachine;
+
+    public MemoryTrackingRemoteTaskFactory(RemoteTaskFactory remoteTaskFactory, QueryStateMachine stateMachine)
+    {
+        this.remoteTaskFactory = requireNonNull(remoteTaskFactory, "remoteTaskFactory is null");
+        this.stateMachine = requireNonNull(stateMachine, "stateMachine is null");
+    }
+
+    @Override
+    public RemoteTask createRemoteTask(Session session,
+            TaskId taskId,
+            Node node,
+            PlanFragment fragment,
+            Multimap<PlanNodeId, Split> initialSplits,
+            OutputBuffers outputBuffers)
+    {
+        RemoteTask task = remoteTaskFactory.createRemoteTask(session,
+                taskId,
+                node,
+                fragment,
+                initialSplits,
+                outputBuffers);
+
+        task.addStateChangeListener(new UpdatePeakMemory(stateMachine));
+        return task;
+    }
+
+    private static final class UpdatePeakMemory
+            implements StateChangeListener<TaskInfo>
+    {
+        private final QueryStateMachine stateMachine;
+        private final AtomicLong previousMemory;
+
+        public UpdatePeakMemory(QueryStateMachine stateMachine)
+        {
+            this.stateMachine = stateMachine;
+            previousMemory = new AtomicLong();
+        }
+
+        @Override
+        public synchronized void stateChanged(TaskInfo newState)
+        {
+            long currentMemory = newState.getStats().getMemoryReservation().toBytes();
+            long deltaMemoryInBytes = currentMemory - previousMemory.get();
+            previousMemory.getAndSet(currentMemory);
+            stateMachine.updateMemoryUsage(deltaMemoryInBytes);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.facebook.presto.execution.QueryState.FAILED;
@@ -71,6 +72,8 @@ public class QueryStateMachine
 
     private final AtomicReference<VersionedMemoryPoolId> memoryPool = new AtomicReference<>(new VersionedMemoryPoolId(GENERAL_POOL, 0));
 
+    private final AtomicLong peakMemory = new AtomicLong();
+    private final AtomicLong currentMemory = new AtomicLong();
     private final AtomicReference<DateTime> lastHeartbeat = new AtomicReference<>(DateTime.now());
     private final AtomicReference<DateTime> executionStartTime = new AtomicReference<>();
     private final AtomicReference<DateTime> endTime = new AtomicReference<>();
@@ -115,6 +118,19 @@ public class QueryStateMachine
         return session;
     }
 
+    public long getPeakMemoryInBytes()
+    {
+        return peakMemory.get();
+    }
+
+    public void updateMemoryUsage(long deltaMemoryInBytes)
+    {
+        long currentMemoryValue = currentMemory.accumulateAndGet(deltaMemoryInBytes, (x, y) -> x + y);
+        if (currentMemoryValue > peakMemory.get()) {
+            peakMemory.updateAndGet(x -> currentMemoryValue > x ? currentMemoryValue : x);
+        }
+    }
+
     public QueryInfo getQueryInfoWithoutDetails()
     {
         return getQueryInfo(null);
@@ -157,6 +173,7 @@ public class QueryStateMachine
         int completedDrivers = 0;
 
         long totalMemoryReservation = 0;
+        long peakMemoryReservation = 0;
 
         long totalScheduledTime = 0;
         long totalCpuTime = 0;
@@ -188,6 +205,7 @@ public class QueryStateMachine
                 completedDrivers += stageStats.getCompletedDrivers();
 
                 totalMemoryReservation += stageStats.getTotalMemoryReservation().toBytes();
+                peakMemoryReservation = getPeakMemoryInBytes();
 
                 totalScheduledTime += stageStats.getTotalScheduledTime().roundTo(NANOSECONDS);
                 totalCpuTime += stageStats.getTotalCpuTime().roundTo(NANOSECONDS);
@@ -235,6 +253,7 @@ public class QueryStateMachine
                 completedDrivers,
 
                 new DataSize(totalMemoryReservation, BYTE).convertToMostSuccinctDataSize(),
+                new DataSize(peakMemoryReservation, BYTE).convertToMostSuccinctDataSize(),
                 new Duration(totalScheduledTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 new Duration(totalCpuTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 new Duration(totalUserTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
@@ -52,6 +52,7 @@ public class QueryStats
     private final int completedDrivers;
 
     private final DataSize totalMemoryReservation;
+    private final DataSize peakMemoryReservation;
 
     private final Duration totalScheduledTime;
     private final Duration totalCpuTime;
@@ -89,6 +90,7 @@ public class QueryStats
         this.runningDrivers = 0;
         this.completedDrivers = 0;
         this.totalMemoryReservation = null;
+        this.peakMemoryReservation = null;
         this.totalScheduledTime = null;
         this.totalCpuTime = null;
         this.totalUserTime = null;
@@ -126,6 +128,7 @@ public class QueryStats
             @JsonProperty("completedDrivers") int completedDrivers,
 
             @JsonProperty("totalMemoryReservation") DataSize totalMemoryReservation,
+            @JsonProperty("peakMemoryReservation") DataSize peakMemoryReservation,
 
             @JsonProperty("totalScheduledTime") Duration totalScheduledTime,
             @JsonProperty("totalCpuTime") Duration totalCpuTime,
@@ -171,6 +174,7 @@ public class QueryStats
         this.completedDrivers = completedDrivers;
 
         this.totalMemoryReservation = checkNotNull(totalMemoryReservation, "totalMemoryReservation is null");
+        this.peakMemoryReservation = checkNotNull(peakMemoryReservation, "peakMemoryReservation is null");
         this.totalScheduledTime = checkNotNull(totalScheduledTime, "totalScheduledTime is null");
         this.totalCpuTime = checkNotNull(totalCpuTime, "totalCpuTime is null");
         this.totalUserTime = checkNotNull(totalUserTime, "totalUserTime is null");
@@ -291,6 +295,12 @@ public class QueryStats
     public DataSize getTotalMemoryReservation()
     {
         return totalMemoryReservation;
+    }
+
+    @JsonProperty
+    public DataSize getPeakMemoryReservation()
+    {
+        return peakMemoryReservation;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -114,7 +114,6 @@ public final class SqlQueryExecution
             this.splitManager = checkNotNull(splitManager, "splitManager is null");
             this.nodeScheduler = checkNotNull(nodeScheduler, "nodeScheduler is null");
             this.planOptimizers = checkNotNull(planOptimizers, "planOptimizers is null");
-            this.remoteTaskFactory = checkNotNull(remoteTaskFactory, "remoteTaskFactory is null");
             this.locationFactory = checkNotNull(locationFactory, "locationFactory is null");
             this.queryExecutor = checkNotNull(queryExecutor, "queryExecutor is null");
             this.experimentalSyntaxEnabled = experimentalSyntaxEnabled;
@@ -148,6 +147,8 @@ public final class SqlQueryExecution
                 finalQueryInfo.compareAndSet(null, getQueryInfo(stage));
                 outputStage.set(null);
             });
+
+            this.remoteTaskFactory = new MemoryTrackingRemoteTaskFactory(checkNotNull(remoteTaskFactory, "remoteTaskFactory is null"), stateMachine);
 
             this.queryExplainer = new QueryExplainer(session, planOptimizers, metadata, sqlParser, experimentalSyntaxEnabled);
         }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -49,22 +49,23 @@ public class TestQueryStats
             16,
 
             new DataSize(17, BYTE),
+            new DataSize(18, BYTE),
 
-            new Duration(18, NANOSECONDS),
             new Duration(19, NANOSECONDS),
             new Duration(20, NANOSECONDS),
             new Duration(21, NANOSECONDS),
+            new Duration(22, NANOSECONDS),
             false,
             ImmutableSet.of(),
 
-            new DataSize(22, BYTE),
-            23,
+            new DataSize(23, BYTE),
+            24,
 
-            new DataSize(24, BYTE),
-            25,
+            new DataSize(25, BYTE),
+            26,
 
-            new DataSize(26, BYTE),
-            27);
+            new DataSize(27, BYTE),
+            28);
 
     @Test
     public void testJson()
@@ -101,19 +102,20 @@ public class TestQueryStats
         assertEquals(actual.getCompletedDrivers(), 16);
 
         assertEquals(actual.getTotalMemoryReservation(), new DataSize(17, BYTE));
+        assertEquals(actual.getPeakMemoryReservation(), new DataSize(18, BYTE));
 
-        assertEquals(actual.getTotalScheduledTime(), new Duration(18, NANOSECONDS));
-        assertEquals(actual.getTotalCpuTime(), new Duration(19, NANOSECONDS));
-        assertEquals(actual.getTotalUserTime(), new Duration(20, NANOSECONDS));
-        assertEquals(actual.getTotalBlockedTime(), new Duration(21, NANOSECONDS));
+        assertEquals(actual.getTotalScheduledTime(), new Duration(19, NANOSECONDS));
+        assertEquals(actual.getTotalCpuTime(), new Duration(20, NANOSECONDS));
+        assertEquals(actual.getTotalUserTime(), new Duration(21, NANOSECONDS));
+        assertEquals(actual.getTotalBlockedTime(), new Duration(22, NANOSECONDS));
 
-        assertEquals(actual.getRawInputDataSize(), new DataSize(22, BYTE));
-        assertEquals(actual.getRawInputPositions(), 23);
+        assertEquals(actual.getRawInputDataSize(), new DataSize(23, BYTE));
+        assertEquals(actual.getRawInputPositions(), 24);
 
-        assertEquals(actual.getProcessedInputDataSize(), new DataSize(24, BYTE));
-        assertEquals(actual.getProcessedInputPositions(), 25);
+        assertEquals(actual.getProcessedInputDataSize(), new DataSize(25, BYTE));
+        assertEquals(actual.getProcessedInputPositions(), 26);
 
-        assertEquals(actual.getOutputDataSize(), new DataSize(26, BYTE));
-        assertEquals(actual.getOutputPositions(), 27);
+        assertEquals(actual.getOutputDataSize(), new DataSize(27, BYTE));
+        assertEquals(actual.getOutputPositions(), 28);
     }
 }


### PR DESCRIPTION
Tests were done by manually refreshing the summary page of a query and comparing the final PeakMemory (in the raw log) with the highest memory every time the summary was updated to see if they are consistent. 