### PR TITLE
Add url_encode/url_decode function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/url.rst
+++ b/presto-docs/src/main/sphinx/functions/url.rst
@@ -42,3 +42,11 @@ such as ``:`` or ``?``.
 .. function:: url_extract_query(url) -> varchar
 
     Returns the query string from ``url``.
+
+.. function:: url_encode(url) -> varchar
+
+    Returns the encoded ``url``.
+
+.. function:: url_decode(url) -> varchar
+
+    Returns the decoded ``url``.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/UrlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/UrlFunctions.java
@@ -22,8 +22,11 @@ import io.airlift.slice.Slices;
 
 import javax.annotation.Nullable;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.Iterator;
 
 import static com.google.common.base.Strings.nullToEmpty;
@@ -127,6 +130,42 @@ public final class UrlFunctions
 
         // no key matched
         return null;
+    }
+
+    @Nullable
+    @Description("encode url")
+    @ScalarFunction
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice urlEncode(@SqlType(StandardTypes.VARCHAR) Slice url)
+    {
+        if (url == null) {
+            return null;
+        }
+
+        try {
+            return slice(URLEncoder.encode(url.toString(UTF_8), UTF_8.name()));
+        }
+        catch (UnsupportedEncodingException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    @Description("decode url")
+    @ScalarFunction
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice urlDecode(@SqlType(StandardTypes.VARCHAR) Slice url)
+    {
+        if (url == null) {
+            return null;
+        }
+
+        try {
+            return slice(URLDecoder.decode(url.toString(UTF_8), UTF_8.name()));
+        }
+        catch (UnsupportedEncodingException e) {
+            return null;
+        }
     }
 
     private static Slice slice(@Nullable String s)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/UrlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/UrlFunctions.java
@@ -17,6 +17,8 @@ import com.facebook.presto.operator.Description;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.type.SqlType;
 import com.google.common.base.Splitter;
+import com.google.common.escape.Escaper;
+import com.google.common.net.UrlEscapers;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
@@ -26,7 +28,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.util.Iterator;
 
 import static com.google.common.base.Strings.nullToEmpty;
@@ -132,39 +133,25 @@ public final class UrlFunctions
         return null;
     }
 
-    @Nullable
-    @Description("encode url")
+    @Description("encode url, escape value that is included in URL query parameters names and values")
     @ScalarFunction
     @SqlType(StandardTypes.VARCHAR)
-    public static Slice urlEncode(@SqlType(StandardTypes.VARCHAR) Slice url)
+    public static Slice urlEncode(@SqlType(StandardTypes.VARCHAR) Slice value)
     {
-        if (url == null) {
-            return null;
-        }
-
-        try {
-            return slice(URLEncoder.encode(url.toString(UTF_8), UTF_8.name()));
-        }
-        catch (UnsupportedEncodingException e) {
-            return null;
-        }
+        Escaper escaper = UrlEscapers.urlFormParameterEscaper();
+        return slice(escaper.escape(value.toString(UTF_8)));
     }
 
-    @Nullable
     @Description("decode url")
     @ScalarFunction
     @SqlType(StandardTypes.VARCHAR)
-    public static Slice urlDecode(@SqlType(StandardTypes.VARCHAR) Slice url)
+    public static Slice urlDecode(@SqlType(StandardTypes.VARCHAR) Slice value)
     {
-        if (url == null) {
-            return null;
-        }
-
         try {
-            return slice(URLDecoder.decode(url.toString(UTF_8), UTF_8.name()));
+            return slice(URLDecoder.decode(value.toString(UTF_8), UTF_8.name()));
         }
         catch (UnsupportedEncodingException e) {
-            return null;
+            throw new AssertionError(e);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUrlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUrlFunctions.java
@@ -49,6 +49,24 @@ public class TestUrlFunctions
         assertFunction("url_extract_parameter('foo', 'k1')", VARCHAR, null);
     }
 
+    @Test
+    public void testUrlEncode()
+    {
+        assertFunction("url_encode('http://test')", VARCHAR, "http%3A%2F%2Ftest");
+        assertFunction("url_encode('http://テスト')", VARCHAR, "http%3A%2F%2F%E3%83%86%E3%82%B9%E3%83%88");
+        assertFunction("url_encode('test')", VARCHAR, "test");
+        assertFunction("url_encode(null)", VARCHAR, null);
+    }
+
+    @Test
+    public void testUrlDecode()
+    {
+        assertFunction("url_decode('http%3A%2F%2Ftest')", VARCHAR, "http://test");
+        assertFunction("url_decode('http%3A%2F%2F%E3%83%86%E3%82%B9%E3%83%88')", VARCHAR, "http://テスト");
+        assertFunction("url_decode('test')", VARCHAR, "test");
+        assertFunction("url_decode(null)", VARCHAR, null);
+    }
+
     private void validateUrlExtract(String url, String protocol, String host, Long port, String path, String query, String fragment)
     {
         assertFunction("url_extract_protocol('" + url + "')", VARCHAR, protocol);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUrlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUrlFunctions.java
@@ -53,7 +53,8 @@ public class TestUrlFunctions
     public void testUrlEncode()
     {
         assertFunction("url_encode('http://test')", VARCHAR, "http%3A%2F%2Ftest");
-        assertFunction("url_encode('http://テスト')", VARCHAR, "http%3A%2F%2F%E3%83%86%E3%82%B9%E3%83%88");
+        assertFunction("url_encode('http://test?a=b&c=d')", VARCHAR, "http%3A%2F%2Ftest%3Fa%3Db%26c%3Dd");
+        assertFunction("url_encode('http://\u30c6\u30b9\u30c8')", VARCHAR, "http%3A%2F%2F%E3%83%86%E3%82%B9%E3%83%88");
         assertFunction("url_encode('test')", VARCHAR, "test");
         assertFunction("url_encode(null)", VARCHAR, null);
     }
@@ -62,7 +63,8 @@ public class TestUrlFunctions
     public void testUrlDecode()
     {
         assertFunction("url_decode('http%3A%2F%2Ftest')", VARCHAR, "http://test");
-        assertFunction("url_decode('http%3A%2F%2F%E3%83%86%E3%82%B9%E3%83%88')", VARCHAR, "http://テスト");
+        assertFunction("url_decode('http%3A%2F%2Ftest%3Fa%3Db%26c%3Dd')", VARCHAR, "http://test?a=b&c=d");
+        assertFunction("url_decode('http%3A%2F%2F%E3%83%86%E3%82%B9%E3%83%88')", VARCHAR, "http://\u30c6\u30b9\u30c8");
         assertFunction("url_decode('test')", VARCHAR, "test");
         assertFunction("url_decode(null)", VARCHAR, null);
     }


### PR DESCRIPTION
Hi

I want to encode/decode url in Presto.

In Hive, I can encode/decode url in the following example. 

```
reflect("java.net.URLDecoder", "decode","http%3A%2F%2F%E3%83%86%E3%82%B9%E3%83%8", "UTF-8" ) 
```

But now there is no UDF to encode/decode url in Presto, so I want to add UDF.