### PR TITLE
Support multiple metastores for HA Hive

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -54,7 +54,7 @@ HDFS Configuration
 
 Presto configures the HDFS client automatically for most setups and
 does not require any configuration files. In some rare cases, such
-as when using federated HDFS, it may be necessary to specify additional
+as when using federated HDFS or high availability Hive, it may be necessary to specify additional
 HDFS client options in order to access your HDFS cluster. To do so, add
 the ``hive.config.resources`` property to reference your HDFS config files:
 
@@ -72,9 +72,12 @@ Configuration Properties
 ================================================== ============================================================ ==========
 Property Name                                      Description                                                  Default
 ================================================== ============================================================ ==========
-``hive.metastore.uri``                             The URI of the Hive Metastore to connect to using
-                                                   the Thrift protocol. This property is required.
-                                                   Example: ``thrift://192.0.2.3:9083``
+``hive.metastore.uri``                             The URI(s) of the Hive Metastore to connect to using
+                                                   the Thrift protocol. If a comma-separated list of URIs is
+                                                   provided, the first URI is used by default, and the rest of
+                                                   the URIs are fallback Metastores. This property is required.
+                                                   Example: ``thrift://192.0.2.3:9083`` or
+                                                   ``thrift://192.0.2.3:9083,thrift://192.0.2.4:9083``
 
 ``hive.config.resources``                          An optional comma-separated list of HDFS
                                                    configuration files. These files must exist on the

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StaticMetastoreConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StaticMetastoreConfig.java
@@ -13,26 +13,42 @@
  */
 package com.facebook.presto.hive;
 
+import com.google.common.base.Splitter;
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 
 import javax.validation.constraints.NotNull;
 
 import java.net.URI;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 public class StaticMetastoreConfig
 {
-    private URI metastoreUri;
+    private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+
+    private List<URI> metastoreUris;
 
     @NotNull
-    public URI getMetastoreUri()
+    public List<URI> getMetastoreUris()
     {
-        return metastoreUri;
+        return metastoreUris;
     }
 
     @Config("hive.metastore.uri")
-    public StaticMetastoreConfig setMetastoreUri(URI metastoreUri)
+    @ConfigDescription("Hive metastore URIs (comma separated)")
+    public StaticMetastoreConfig setMetastoreUris(String metastoreUris)
     {
-        this.metastoreUri = metastoreUri;
+        if (metastoreUris == null) {
+            this.metastoreUris = null;
+            return this;
+        }
+
+        this.metastoreUris = SPLITTER.splitToList(metastoreUris).stream()
+                .map(URI::create)
+                .collect(toList());
+
         return this;
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/MockHiveMetastoreClientFactory.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/MockHiveMetastoreClientFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.google.common.net.HostAndPort;
+import io.airlift.units.Duration;
+import org.apache.thrift.transport.TTransportException;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+
+public class MockHiveMetastoreClientFactory
+        extends HiveMetastoreClientFactory
+{
+    private final List<HiveMetastoreClient> toReturn;
+
+    public MockHiveMetastoreClientFactory(@Nullable HostAndPort socksProxy, Duration timeout, List<HiveMetastoreClient> toReturn)
+    {
+        super(socksProxy, timeout);
+        this.toReturn = toReturn;
+    }
+
+    public HiveMetastoreClient create(String host, int port)
+            throws TTransportException
+    {
+        if (toReturn.size() == 0) {
+            throw new IllegalArgumentException("Mock not given enough values for the client.");
+        }
+
+        HiveMetastoreClient client = toReturn.remove(0);
+
+        if (client == null) {
+            throw new TTransportException(TTransportException.TIMED_OUT);
+        }
+        else {
+            return client;
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveConnectorFactory.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveConnectorFactory.java
@@ -22,7 +22,9 @@ import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import static io.airlift.testing.Assertions.assertContains;
 import static io.airlift.testing.Assertions.assertInstanceOf;
+import static org.testng.Assert.fail;
 
 public class TestHiveConnectorFactory
 {
@@ -30,6 +32,18 @@ public class TestHiveConnectorFactory
     public void testGetClient()
     {
         assertCreateConnector("thrift://localhost:1234");
+        assertCreateConnector("thrift://localhost:1234,thrift://192.34.10.2:5678");
+    }
+
+    @Test
+    public void testGetClientFailure()
+    {
+        assertCreateConnectorFails("abc", "metastoreUri scheme is missing: abc");
+        assertCreateConnectorFails("thrift://:8090", "metastoreUri host is missing: thrift://:8090");
+        assertCreateConnectorFails("thrift://localhost", "metastoreUri port is missing: thrift://localhost");
+        assertCreateConnectorFails("abc::", "metastoreUri scheme must be thrift: abc::");
+        assertCreateConnectorFails("", "metastoreUri must specify at least one URI");
+        assertCreateConnectorFails("thrift://localhost:1234,thrift://slave-1", "metastoreUri port is missing: thrift://slave-1");
     }
 
     private static void assertCreateConnector(String metastoreUri)
@@ -49,5 +63,17 @@ public class TestHiveConnectorFactory
         assertInstanceOf(connector.getSplitManager(), ClassLoaderSafeConnectorSplitManager.class);
         assertInstanceOf(connector.getPageSourceProvider(), ConnectorPageSourceProvider.class);
         assertInstanceOf(connector.getHandleResolver(), ClassLoaderSafeConnectorHandleResolver.class);
+    }
+
+    private static void assertCreateConnectorFails(String metastoreUri, String exceptionString)
+    {
+        try {
+            assertCreateConnector(metastoreUri);
+        }
+        catch (Exception e) {
+            assertContains(e.getMessage(), exceptionString);
+            return;
+        }
+        fail("Create connector for " + metastoreUri + " did not fail");
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestStaticHiveCluster.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestStaticHiveCluster.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.PrestoException;
+import io.airlift.units.Duration;
+import org.apache.thrift.transport.TTransport;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static io.airlift.testing.Assertions.assertContains;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestStaticHiveCluster
+{
+    private static final HiveMetastoreClient DEFAULT_CLIENT = new HiveMetastoreClient((TTransport) null);
+    private static final HiveMetastoreClient FALLBACK_CLIENT = new HiveMetastoreClient((TTransport) null);
+
+    private static final StaticMetastoreConfig CONFIG_WITH_FALLBACK = new StaticMetastoreConfig().setMetastoreUris("thrift://default:8080,thrift://fallback:8090,thrift://fallback2:8090");
+    private static final StaticMetastoreConfig CONFIG_WITHOUT_FALLBACK = new StaticMetastoreConfig().setMetastoreUris("thrift://default:8080");
+
+    @Test
+    public void testDefaultHiveMetastore()
+    {
+        MockHiveMetastoreClientFactory clientFactory = new MockHiveMetastoreClientFactory(null, new Duration(1, TimeUnit.SECONDS), newArrayList(DEFAULT_CLIENT));
+        StaticHiveCluster hiveCluster = new StaticHiveCluster(CONFIG_WITH_FALLBACK, clientFactory);
+        HiveMetastoreClient metastoreClient = hiveCluster.createMetastoreClient();
+        assertEquals(metastoreClient, DEFAULT_CLIENT);
+    }
+
+    @Test
+    public void testFallbackHiveMetastore()
+    {
+        MockHiveMetastoreClientFactory clientFactory = new MockHiveMetastoreClientFactory(null, new Duration(1, TimeUnit.SECONDS),
+                newArrayList(null, null, FALLBACK_CLIENT));
+        StaticHiveCluster hiveCluster = new StaticHiveCluster(CONFIG_WITH_FALLBACK, clientFactory);
+        HiveMetastoreClient metastoreClient = hiveCluster.createMetastoreClient();
+        assertEquals(metastoreClient, FALLBACK_CLIENT);
+    }
+
+    @Test
+    public void testFallbackHiveMetastoreFails()
+    {
+        int maxMetastoreClients = 1000;
+        ArrayList<HiveMetastoreClient> toReturn = newArrayList();
+        for (int i = 0; i < maxMetastoreClients; i++) {
+            toReturn.add(null);
+        }
+        MockHiveMetastoreClientFactory clientFactory = new MockHiveMetastoreClientFactory(null, new Duration(1, TimeUnit.SECONDS),
+                toReturn);
+        StaticHiveCluster hiveCluster = new StaticHiveCluster(CONFIG_WITH_FALLBACK, clientFactory);
+        try {
+            HiveMetastoreClient metastoreClient = hiveCluster.createMetastoreClient();
+        }
+        catch (PrestoException e) {
+            String errorMessage = e.getMessage();
+            assertTrue(errorMessage.contains("Unable to connect to metastore: [default:8080, fallback:8090, fallback2:8090]"));
+            return;
+        }
+        fail();
+    }
+
+    @Test
+    public void testMetastoreFailedWithoutFallback()
+    {
+        MockHiveMetastoreClientFactory clientFactory = new MockHiveMetastoreClientFactory(null, new Duration(1, TimeUnit.SECONDS),
+                newArrayList((HiveMetastoreClient) null));
+        StaticHiveCluster hiveCluster = new StaticHiveCluster(CONFIG_WITHOUT_FALLBACK, clientFactory);
+        try {
+            HiveMetastoreClient metastoreClient = hiveCluster.createMetastoreClient();
+        }
+        catch (PrestoException e) {
+            assertContains(e.getMessage(), "Unable to connect to metastore: [default:8080]");
+            return;
+        }
+        fail();
+    }
+}


### PR DESCRIPTION
Issue #1434

* Add ability to specifiy a comma-delimited list of metastore URIs in
  hive.metastore.uri
* Connect to metastores in StaticHiveCluster based on HA Hive semantics:
  by default connect to the first metastore, else connect to one of the
  rest of the metastores at random until a connection is made or it
  times out.
* Add tests

Testing: manual, mvn clean install