### PR TITLE
Use separate config class for Hive metastore URI

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -30,7 +30,6 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import java.io.File;
-import java.net.URI;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -61,7 +60,6 @@ public class HiveClientConfig
 
     private boolean allowCorruptWritesForTesting;
 
-    private URI metastoreUri;
     private Duration metastoreCacheTtl = new Duration(1, TimeUnit.HOURS);
     private Duration metastoreRefreshInterval = new Duration(1, TimeUnit.SECONDS);
     private int maxMetastoreRefreshThreads = 100;
@@ -249,19 +247,6 @@ public class HiveClientConfig
     public HiveClientConfig setAllowDropTable(boolean allowDropTable)
     {
         this.allowDropTable = allowDropTable;
-        return this;
-    }
-
-    @NotNull
-    public URI getMetastoreUri()
-    {
-        return metastoreUri;
-    }
-
-    @Config("hive.metastore.uri")
-    public HiveClientConfig setMetastoreUri(URI metastoreUri)
-    {
-        this.metastoreUri = metastoreUri;
         return this;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -82,6 +82,7 @@ public class HiveClientModule
 
         binder.bind(HiveMetastoreClientFactory.class).in(Scopes.SINGLETON);
         binder.bind(HiveCluster.class).to(StaticHiveCluster.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(StaticMetastoreConfig.class);
 
         binder.bind(TypeManager.class).toInstance(typeManager);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StaticHiveCluster.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StaticHiveCluster.java
@@ -31,7 +31,7 @@ public class StaticHiveCluster
     private final HiveMetastoreClientFactory clientFactory;
 
     @Inject
-    public StaticHiveCluster(HiveClientConfig config, HiveMetastoreClientFactory clientFactory)
+    public StaticHiveCluster(StaticMetastoreConfig config, HiveMetastoreClientFactory clientFactory)
     {
         URI uri = checkMetastoreUri(config.getMetastoreUri());
         this.address = HostAndPort.fromParts(uri.getHost(), uri.getPort());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StaticMetastoreConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StaticMetastoreConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import io.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+import java.net.URI;
+
+public class StaticMetastoreConfig
+{
+    private URI metastoreUri;
+
+    @NotNull
+    public URI getMetastoreUri()
+    {
+        return metastoreUri;
+    }
+
+    @Config("hive.metastore.uri")
+    public StaticMetastoreConfig setMetastoreUri(URI metastoreUri)
+    {
+        this.metastoreUri = metastoreUri;
+        return this;
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -24,7 +24,6 @@ import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.net.URI;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -44,7 +43,6 @@ public class TestHiveClientConfig
                 .setAllowDropTable(false)
                 .setAllowRenameTable(false)
                 .setAllowCorruptWritesForTesting(false)
-                .setMetastoreUri(null)
                 .setMetastoreCacheTtl(new Duration(1, TimeUnit.HOURS))
                 .setMetastoreRefreshInterval(new Duration(1, TimeUnit.SECONDS))
                 .setMaxMetastoreRefreshThreads(100)
@@ -96,7 +94,6 @@ public class TestHiveClientConfig
                 .put("hive.allow-drop-table", "true")
                 .put("hive.allow-rename-table", "true")
                 .put("hive.allow-corrupt-writes-for-testing", "true")
-                .put("hive.metastore.uri", "thrift://localhost:9083")
                 .put("hive.metastore-cache-ttl", "2h")
                 .put("hive.metastore-refresh-interval", "30m")
                 .put("hive.metastore-refresh-max-threads", "2500")
@@ -145,7 +142,6 @@ public class TestHiveClientConfig
                 .setAllowDropTable(true)
                 .setAllowRenameTable(true)
                 .setAllowCorruptWritesForTesting(true)
-                .setMetastoreUri(URI.create("thrift://localhost:9083"))
                 .setMetastoreCacheTtl(new Duration(2, TimeUnit.HOURS))
                 .setMetastoreRefreshInterval(new Duration(30, TimeUnit.MINUTES))
                 .setMaxMetastoreRefreshThreads(2500)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestStaticMetastoreConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestStaticMetastoreConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestStaticMetastoreConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(StaticMetastoreConfig.class)
+                .setMetastoreUri(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("hive.metastore.uri", "thrift://localhost:9083")
+                .build();
+
+        StaticMetastoreConfig expected = new StaticMetastoreConfig()
+                .setMetastoreUri(URI.create("thrift://localhost:9083"));
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
This is required for connector extensions that use a different
method to locate the metastore.