### PR TITLE
Optimize CASE expressions on a constant

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -577,6 +577,21 @@ public class TestExpressionInterpreter
     public void testSimpleCase()
             throws Exception
     {
+        assertOptimizedEquals("case null " +
+                "when true then 33 " +
+                "end",
+                "null");
+        assertOptimizedEquals("case null " +
+                "when true then 33 " +
+                "else 33 " +
+                "end",
+                "33");
+        assertOptimizedEquals("case 33 " +
+                "when null then 1 " +
+                "else 33 " +
+                "end",
+                "33");
+
         assertOptimizedEquals("case true " +
                 "when true then 33 " +
                 "end",
@@ -628,6 +643,47 @@ public class TestExpressionInterpreter
                         "case unbound_long " +
                         "when 1234 then 33 " +
                         "else 1 " +
+                        "end");
+
+        assertOptimizedEquals("case 33 " +
+                        "when 0 then 0 " +
+                        "when 33 then unbound_long " +
+                        "else 1 " +
+                        "end",
+                        "unbound_long");
+        assertOptimizedEquals("case 33 " +
+                        "when 0 then 0 " +
+                        "when 33 then 1 " +
+                        "when unbound_long then 2 " +
+                        "else 1 " +
+                        "end",
+                        "1");
+        assertOptimizedEquals("case 33 " +
+                        "when unbound_long then 0 " +
+                        "when 1 then 1 " +
+                        "when 33 then 2 " +
+                        "else 0 " +
+                        "end",
+                        "case 33 " +
+                        "when unbound_long then 0 " +
+                        "else 2 " +
+                        "end");
+        assertOptimizedEquals("case 33 " +
+                        "when 0 then 0 " +
+                        "when 1 then 1 " +
+                        "else unbound_long " +
+                        "end",
+                        "unbound_long");
+        assertOptimizedEquals("case 33 " +
+                        "when unbound_long then 0 " +
+                        "when 1 then 1 " +
+                        "when unbound_long2 then 2 " +
+                        "else 3 " +
+                        "end",
+                        "case 33 " +
+                        "when unbound_long then 0 " +
+                        "when unbound_long2 then 2 " +
+                        "else 3 " +
                         "end");
     }
 


### PR DESCRIPTION
Fix #3230  Optimize CASE expressions on a constant

If operand is a constant
* Remove the WhenClauses whose operand is constant and not equal to case operand
* If we can find a WhenClause, whose constant operand equals to CASE constant operand, remove all the WhenClauses on its right and the default value.