### PR TITLE
Concat string function supports multiple arguments.

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -32,9 +32,9 @@ String Functions
 
     Returns the Unicode code point ``n`` as a single character string.
 
-.. function:: concat(string1, string2) -> varchar
+.. function:: concat(string1, ..., stringN) -> varchar
 
-    Returns the concatenation of ``string1`` and ``string2``.
+    Returns the concatenation of ``string1``, ``string2``, ``...``, ``stringN``.
     This function provides the same functionality as the
     SQL-standard concatenation operator (``||``).
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -166,6 +166,7 @@ import static com.facebook.presto.operator.scalar.ArraySubscriptOperator.ARRAY_S
 import static com.facebook.presto.operator.scalar.ArrayToArrayCast.ARRAY_TO_ARRAY_CAST;
 import static com.facebook.presto.operator.scalar.ArrayToElementConcatFunction.ARRAY_TO_ELEMENT_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayToJsonCast.ARRAY_TO_JSON;
+import static com.facebook.presto.operator.scalar.ConcatFunction.CONCAT;
 import static com.facebook.presto.operator.scalar.ElementToArrayConcatFunction.ELEMENT_TO_ARRAY_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.Greatest.GREATEST;
 import static com.facebook.presto.operator.scalar.IdentityCast.IDENTITY_CAST;
@@ -356,6 +357,7 @@ public class FunctionRegistry
                 .functions(MAX_AGGREGATION, MIN_AGGREGATION)
                 .function(COUNT_COLUMN)
                 .functions(ROW_HASH_CODE, ROW_TO_JSON, ROW_EQUAL, ROW_NOT_EQUAL)
+                .function(CONCAT)
                 .function(TRY_CAST);
 
         if (experimentalSyntaxEnabled) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ConcatFunction.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.byteCode.Block;
+import com.facebook.presto.byteCode.ClassDefinition;
+import com.facebook.presto.byteCode.DynamicClassLoader;
+import com.facebook.presto.byteCode.MethodDefinition;
+import com.facebook.presto.byteCode.Parameter;
+import com.facebook.presto.byteCode.Scope;
+import com.facebook.presto.byteCode.Variable;
+import com.facebook.presto.byteCode.expression.ByteCodeExpression;
+import com.facebook.presto.metadata.FunctionInfo;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.ParametricScalar;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.sql.gen.CompilerUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.byteCode.Access.FINAL;
+import static com.facebook.presto.byteCode.Access.PRIVATE;
+import static com.facebook.presto.byteCode.Access.PUBLIC;
+import static com.facebook.presto.byteCode.Access.STATIC;
+import static com.facebook.presto.byteCode.Access.a;
+import static com.facebook.presto.byteCode.Parameter.arg;
+import static com.facebook.presto.byteCode.ParameterizedType.type;
+import static com.facebook.presto.byteCode.expression.ByteCodeExpressions.add;
+import static com.facebook.presto.byteCode.expression.ByteCodeExpressions.constantInt;
+import static com.facebook.presto.byteCode.expression.ByteCodeExpressions.invokeStatic;
+import static com.facebook.presto.metadata.Signature.internalFunction;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.gen.CompilerUtils.defineClass;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static java.lang.Math.addExact;
+
+public final class ConcatFunction
+        extends ParametricScalar
+{
+    public static final ConcatFunction CONCAT = new ConcatFunction();
+
+    private static final Signature SIGNATURE = new Signature("concat", ImmutableList.of(), StandardTypes.VARCHAR, ImmutableList.of(StandardTypes.VARCHAR), true, false);
+
+    @Override
+    public Signature getSignature()
+    {
+        return SIGNATURE;
+    }
+
+    @Override
+    public boolean isHidden()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "concatenates given strings";
+    }
+
+    @Override
+    public FunctionInfo specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        if (arity < 2) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "There must be two or more concatenation arguments");
+        }
+
+        Class<?> clazz = generateConcat(arity);
+        MethodHandle methodHandle = methodHandle(clazz, "concat", Collections.nCopies(arity, Slice.class).toArray(new Class<?>[arity]));
+        List<Boolean> nullableParameters = ImmutableList.copyOf(Collections.nCopies(arity, false));
+
+        Signature specializedSignature = internalFunction(SIGNATURE.getName(), VARCHAR.getTypeSignature(), Collections.nCopies(arity, VARCHAR.getTypeSignature()));
+        return new FunctionInfo(specializedSignature, getDescription(), isHidden(), methodHandle, isDeterministic(), false, nullableParameters);
+    }
+
+    private static Class<?> generateConcat(int arity)
+    {
+        ClassDefinition definition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                CompilerUtils.makeClassName("Concat" + arity + "ScalarFunction"),
+                type(Object.class));
+
+        // Generate constructor
+        definition.declareDefaultConstructor(a(PRIVATE));
+
+        // Generate concat()
+        List<Parameter> parameters = IntStream.range(0, arity)
+                .mapToObj(i -> arg("arg" + i, Slice.class))
+                .collect(toImmutableList());
+
+        MethodDefinition method = definition.declareMethod(a(PUBLIC, STATIC), "concat", type(Slice.class), parameters);
+        Scope scope = method.getScope();
+        Block body = method.getBody();
+
+        Variable length = scope.declareVariable(int.class, "length");
+        body.append(length.set(constantInt(0)));
+
+        for (int i = 0; i < arity; ++i) {
+            body.append(length.set(generateCheckedAdd(length, parameters.get(i).invoke("length", int.class))));
+        }
+
+        Variable result = scope.declareVariable(Slice.class, "result");
+        body.append(result.set(invokeStatic(Slices.class, "allocate", Slice.class, length)));
+
+        Variable position = scope.declareVariable(int.class, "position");
+        body.append(position.set(constantInt(0)));
+
+        for (int i = 0; i < arity; ++i) {
+            body.append(result.invoke("setBytes", void.class, position, parameters.get(i)));
+            body.append(position.set(add(position, parameters.get(i).invoke("length", int.class))));
+        }
+
+        body.getVariable(result)
+                .retObject();
+
+        return defineClass(definition, Object.class, ImmutableMap.of(), new DynamicClassLoader(ConcatFunction.class.getClassLoader()));
+    }
+
+    private static ByteCodeExpression generateCheckedAdd(ByteCodeExpression x, ByteCodeExpression y)
+    {
+        return invokeStatic(ConcatFunction.class, "checkedAdd", int.class, x, y);
+    }
+
+    public static int checkedAdd(int x, int y)
+    {
+        try {
+            return addExact(x, y);
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Concatenated string is too large");
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -67,17 +67,6 @@ public final class StringFunctions
         }
     }
 
-    @Description("concatenates given strings")
-    @ScalarFunction
-    @SqlType(StandardTypes.VARCHAR)
-    public static Slice concat(@SqlType(StandardTypes.VARCHAR) Slice str1, @SqlType(StandardTypes.VARCHAR) Slice str2)
-    {
-        Slice concat = Slices.allocate(str1.length() + str2.length());
-        concat.setBytes(0, str1);
-        concat.setBytes(str1.length(), str2);
-        return concat;
-    }
-
     @Description("count of code points of the given string")
     @ScalarFunction
     @SqlType(StandardTypes.BIGINT)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -57,16 +57,20 @@ public class TestStringFunctions
     @Test
     public void testConcat()
     {
+        assertInvalidFunction("CONCAT()", "There must be two or more concatenation arguments");
+        assertInvalidFunction("CONCAT('')", "There must be two or more concatenation arguments");
         assertFunction("CONCAT('hello', ' world')", VARCHAR, "hello world");
         assertFunction("CONCAT('', '')", VARCHAR, "");
         assertFunction("CONCAT('what', '')", VARCHAR, "what");
         assertFunction("CONCAT('', 'what')", VARCHAR, "what");
         assertFunction("CONCAT(CONCAT('this', ' is'), ' cool')", VARCHAR, "this is cool");
         assertFunction("CONCAT('this', CONCAT(' is', ' cool'))", VARCHAR, "this is cool");
+        assertFunction("CONCAT('this ', 'is ', 'cool ', 'foo ', 'bar')", VARCHAR, "this is cool foo bar");
         //
         // Test concat for non-ASCII
         assertFunction("CONCAT('hello na\u00EFve', ' world')", VARCHAR, "hello na\u00EFve world");
         assertFunction("CONCAT('\uD801\uDC2D', 'end')", VARCHAR, "\uD801\uDC2Dend");
+        assertFunction("CONCAT('\uD801\uDC2D', 'end', '\uD801\uDC2D')", VARCHAR, "\uD801\uDC2Dend\uD801\uDC2D");
         assertFunction("CONCAT(CONCAT('\u4FE1\u5FF5', ',\u7231'), ',\u5E0C\u671B')", VARCHAR, "\u4FE1\u5FF5,\u7231,\u5E0C\u671B");
     }
 


### PR DESCRIPTION
Previously concat() accepted only two VARCHAR arguments.
Now it is possible to pass arbitrary number of VARCHAR arguments.
This ensures compatibility with ODBC standard.