### PR TITLE
Removed HIVE.BINARY from unsupported Parquet types list

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ParquetRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ParquetRecordCursorProvider.java
@@ -98,8 +98,7 @@ public class ParquetRecordCursorProvider
         return columnHandle -> {
             HiveType hiveType = columnHandle.getHiveType();
             return !hiveType.equals(HiveType.HIVE_TIMESTAMP) &&
-                    !hiveType.equals(HiveType.HIVE_DATE) &&
-                    !hiveType.equals(HiveType.HIVE_BINARY);
+                    !hiveType.equals(HiveType.HIVE_DATE);
         };
     }
 }


### PR DESCRIPTION
When running Presto with Parquet binary data (in Hive table), it returns an error that it "Can not read Parquet column:". However, support for this should have been added. Removing HIVE.BINARY from the unsupported Parquet types list in ParquetRecordCursorProvider.java prevents this error and allows proper use of Parquet binary data (tested this with multiple functions and seems to give no problems). 

https://groups.google.com/forum/#!topic/presto-users/JnzI9Z5n3nA

