### PR TITLE
Fix constant subscript analysis

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.ArithmeticUnaryExpression;
@@ -801,7 +802,7 @@ public class ExpressionInterpreter
             if (index == null) {
                 return null;
             }
-            if (index instanceof Long) {
+            if ((index instanceof Long) && isArray(expressionTypes.get(node.getBase()))) {
                 ArraySubscriptOperator.checkArrayIndex((Long) index);
             }
 
@@ -887,5 +888,10 @@ public class ExpressionInterpreter
     private static boolean isNullLiteral(Expression entry)
     {
         return entry instanceof Literal && !(entry instanceof NullLiteral);
+    }
+
+    private static boolean isArray(Type type)
+    {
+        return type.getTypeSignature().getBase().equals(StandardTypes.ARRAY);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -844,15 +844,23 @@ public class TestExpressionInterpreter
     }
 
     @Test(expectedExceptions = PrestoException.class)
-    public void testSubscriptConstantNegativeIndex()
+    public void testArraySubscriptConstantNegativeIndex()
     {
         optimize("ARRAY [1, 2, 3][-1]");
     }
 
     @Test(expectedExceptions = PrestoException.class)
-    public void testSubscriptConstantZeroIndex()
+    public void testArraySubscriptConstantZeroIndex()
     {
         optimize("ARRAY [1, 2, 3][0]");
+    }
+
+    @Test
+    public void testMapSubscriptConstantIndexes()
+    {
+        optimize("MAP(ARRAY [1, 2], ARRAY [3, 4])[-1]");
+        optimize("MAP(ARRAY [1, 2], ARRAY [3, 4])[0]");
+        optimize("MAP(ARRAY [1, 2], ARRAY [3, 4])[5]");
     }
 
     @Test(timeOut = 60000)


### PR DESCRIPTION
The index check should only occur for arrays, not maps.