### PR TITLE
Fix limit push in WindowFilterPushDown optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -86,8 +86,8 @@ public class WindowFilterPushDown
                             getOnlyElement(node.getWindowFunctions().keySet()),
                             limit,
                             Optional.empty());
-                    if (limit.isPresent()) {
-                        return new LimitNode(idAllocator.getNextId(), rowNumberNode, limit.get());
+                    if (context.get() != null && context.get().getLimit().isPresent()) {
+                        return new LimitNode(idAllocator.getNextId(), rowNumberNode, context.get().getLimit().get());
                     }
                     else {
                         return rowNumberNode;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -80,12 +80,18 @@ public class WindowFilterPushDown
                 PlanNode rewrittenSource = context.rewrite(node.getSource(), null);
                 Optional<Integer> limit = getLimit(node, context.get());
                 if (node.getOrderBy().isEmpty()) {
-                    return new RowNumberNode(idAllocator.getNextId(),
+                    PlanNode rowNumberNode =  new RowNumberNode(idAllocator.getNextId(),
                             rewrittenSource,
                             node.getPartitionBy(),
                             getOnlyElement(node.getWindowFunctions().keySet()),
                             limit,
                             Optional.empty());
+                    if (limit.isPresent()) {
+                        return new LimitNode(idAllocator.getNextId(), rowNumberNode, limit.get());
+                    }
+                    else {
+                        return rowNumberNode;
+                    }
                 }
                 if (limit.isPresent()) {
                     return new TopNRowNumberNode(idAllocator.getNextId(),


### PR DESCRIPTION
Fix #3304 

Limit is pushed down to each partition of RowNumberNode, but not limited when we
gather all the result from each partition, which is wrong.
Added a LimitNode above RowNumberNode.
With this fix, 

Query plan with this fix:
```
presto:tiny> explain select row_number() over(partition by clerk) row_number, clerk from orders limit 10;
                                                Query Plan
---------------------------------------------------------------------------------------------------------
 - Output[row_number, clerk] => [row_number_1:bigint, clerk:varchar]
         row_number := row_number_1
     - Limit[10] => [clerk:varchar, row_number_1:bigint]
         - Exchange[GATHER] => clerk:varchar, row_number_1:bigint
             - Limit[10] => [clerk:varchar, row_number_1:bigint]
                 - RowNumber[partition by (clerk) , limit (10) ] => [clerk:varchar, row_number_1:bigint]
                         row_number_1 := row_number()
                     - Exchange[REPARTITION] => clerk:varchar
                         - TableScan[tpch:tpch:orders:sf0.01, original constraint=true] => [clerk:varchar
                                 LAYOUT: tpch:orders:sf0.01
                                 clerk := tpch:clerk
```