### PR TITLE
Validate session properties

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnector.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnector.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.ConnectorMetadata;
 import com.facebook.presto.spi.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.ConnectorRecordSinkProvider;
 import com.facebook.presto.spi.ConnectorSplitManager;
+import com.facebook.presto.spi.SessionProperty;
 import com.facebook.presto.spi.SystemTable;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.bootstrap.LifeCycleManager;
@@ -93,6 +94,12 @@ public class HiveConnector
     public Set<SystemTable> getSystemTables()
     {
         return systemTables;
+    }
+
+    @Override
+    public Set<SessionProperty> getAvailableSessionProperties()
+    {
+        return HiveSessionProperties.getAvailableProperties();
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -13,15 +13,22 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hadoop.shaded.com.google.common.collect.ImmutableSet;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SessionProperty;
 import io.airlift.units.DataSize;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 
 public final class HiveSessionProperties
 {
+    private static Set<SessionProperty> sessionProperties = new HashSet<>();
+
     public static final String STORAGE_FORMAT_PROPERTY = "storage_format";
     private static final String FORCE_LOCAL_SCHEDULING = "force_local_scheduling";
     private static final String OPTIMIZED_READER_ENABLED = "optimized_reader_enabled";
@@ -29,8 +36,21 @@ public final class HiveSessionProperties
     private static final String ORC_MAX_BUFFER_SIZE = "orc_max_buffer_size";
     private static final String ORC_STREAM_BUFFER_SIZE = "orc_stream_buffer_size";
 
-    private HiveSessionProperties()
+    static {
+        //TODO provide better descriptions
+        sessionProperties.add(new SessionProperty(STORAGE_FORMAT_PROPERTY, "Sets the storage format to be used with CTAS."));
+        sessionProperties.add(new SessionProperty(FORCE_LOCAL_SCHEDULING, "Forces local scheduling."));
+        sessionProperties.add(new SessionProperty(OPTIMIZED_READER_ENABLED, "Enables optimized reader."));
+        sessionProperties.add(new SessionProperty(ORC_MAX_MERGE_DISTANCE, "Sets ORC file max merge distance."));
+        sessionProperties.add(new SessionProperty(ORC_MAX_BUFFER_SIZE, "Sets ORC file max buffer size."));
+        sessionProperties.add(new SessionProperty(ORC_STREAM_BUFFER_SIZE, "Sets ORC stream buffer size."));
+    }
+
+    private HiveSessionProperties() {}
+
+    public static Set<SessionProperty> getAvailableProperties()
     {
+        return ImmutableSet.copyOf(sessionProperties);
     }
 
     public static HiveStorageFormat getHiveStorageFormat(ConnectorSession session, HiveStorageFormat defaultValue)

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -13,10 +13,17 @@
  */
 package com.facebook.presto;
 
+import com.facebook.presto.spi.SessionProperty;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public final class SystemSessionProperties
 {
+    private static Set<SessionProperty> sessionProperties = new HashSet<>();
+
     private static final String OPTIMIZE_HASH_GENERATION = "optimize_hash_generation";
     private static final String DISTRIBUTED_JOIN = "distributed_join";
     private static final String HASH_PARTITION_COUNT = "hash_partition_count";
@@ -29,7 +36,26 @@ public final class SystemSessionProperties
     private static final String QUERY_MAX_MEMORY = "query_max_memory";
     private static final String REDISTRIBUTE_WRITES = "redistribute_writes";
 
+    static {
+        //TODO provide better descriptions
+        sessionProperties.add(new SessionProperty(OPTIMIZE_HASH_GENERATION, "Enables hash generation optimizer."));
+        sessionProperties.add(new SessionProperty(DISTRIBUTED_JOIN, "Enables distributed join."));
+        sessionProperties.add(new SessionProperty(HASH_PARTITION_COUNT, "Sets number of hash partitions."));
+        sessionProperties.add(new SessionProperty(PREFER_STREAMING_OPERATORS, "Prefer streaming operators."));
+        sessionProperties.add(new SessionProperty(TASK_WRITER_COUNT, "Sets number of table writer tasks."));
+        sessionProperties.add(new SessionProperty(TASK_DEFAULT_CONCURRENCY, "Sets default concurrency."));
+        sessionProperties.add(new SessionProperty(TASK_JOIN_CONCURRENCY, "Sets join concurrency."));
+        sessionProperties.add(new SessionProperty(TASK_HASH_BUILD_CONCURRENCY, "Sets hash build concurrency."));
+        sessionProperties.add(new SessionProperty(TASK_AGGREGATION_CONCURRENCY, "Sets aggregation concurrency."));
+        sessionProperties.add(new SessionProperty(REDISTRIBUTE_WRITES, "Enables the redistribution of write tasks."));
+    }
+
     private SystemSessionProperties() {}
+
+    public static Set<SessionProperty> getAvailableProperties()
+    {
+        return ImmutableSet.copyOf(sessionProperties);
+    }
 
     private static boolean isEnabled(String propertyName, Session session, boolean defaultValue)
     {

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnector.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnector.java
@@ -13,12 +13,14 @@
  */
 package com.facebook.presto.connector.system;
 
+import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.spi.Connector;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.ConnectorMetadata;
 import com.facebook.presto.spi.ConnectorRecordSetProvider;
 import com.facebook.presto.spi.ConnectorSplitManager;
 import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.SessionProperty;
 import com.facebook.presto.spi.SystemTable;
 
 import javax.inject.Inject;
@@ -64,5 +66,11 @@ public class SystemConnector
     public ConnectorRecordSetProvider getRecordSetProvider()
     {
         return recordSetProvider;
+    }
+
+    @Override
+    public Set<SessionProperty> getAvailableSessionProperties()
+    {
+        return SystemSessionProperties.getAvailableProperties();
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Connector.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Connector.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi;
 
+import java.util.Collections;
 import java.util.Set;
 
 import static java.util.Collections.emptySet;
@@ -24,6 +25,11 @@ public interface Connector
     ConnectorMetadata getMetadata();
 
     ConnectorSplitManager getSplitManager();
+
+    default Set<SessionProperty> getAvailableSessionProperties()
+    {
+        return Collections.emptySet();
+    }
 
     /**
      * @throws UnsupportedOperationException if this connector does not support reading tables page at a time

--- a/presto-spi/src/main/java/com/facebook/presto/spi/SessionProperty.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SessionProperty.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class SessionProperty
+{
+    private final String name;
+    private final String description;
+
+    public SessionProperty(String name, String description)
+    {
+        this.name = requireNonNull(name);
+        this.description = requireNonNull(description);
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, description);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final SessionProperty other = (SessionProperty) obj;
+        return Objects.equals(this.name, other.name) &&
+                Objects.equals(this.description, other.description);
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder();
+        return builder.append("SessionProperty: { name = ").
+                append(name).
+                append(", description = ").
+                append(description).
+                append(" }").toString();
+    }
+}


### PR DESCRIPTION
At a high level this PR makes two changes:
- Adds a new class `SessionProperty` to spi and adds a new default method `getAvailableSessionProperties()` to the `Connector` interface. Using this method the `ConnectorManager` now polls the connectors to get all the available session properties.
- Adds logic to check whether a session property specified in a `set session ...` statement is valid.

With this change later on we can also validate the session properties specified in the request headers.