### PR TITLE
Fix LIMIT for partitioned row_number with order by

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -145,9 +145,6 @@ public class WindowFilterPushDown
             PlanNode rewrittenSource = context.rewrite(node.getSource(), constraint);
 
             if (rewrittenSource != node.getSource()) {
-                if (rewrittenSource instanceof TopNRowNumberNode) {
-                    return rewrittenSource;
-                }
                 return new LimitNode(idAllocator.getNextId(), rewrittenSource, node.getCount());
             }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2246,6 +2246,17 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testRowNumberOrderByPartitionedLimit()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT row_number() OVER (PARTITION BY orderstatus order by orderkey) rn\n" +
+                "FROM orders\n" +
+                "LIMIT 10\n");
+        assertEquals(actual.getMaterializedRows().size(), 10);
+    }
+
+    @Test
     public void testRowNumberPartitionedOrderByLimit()
             throws Exception
     {


### PR DESCRIPTION
The limit was only applied for each order by-ed partition of the window
function and not for the entire query.

Without this fix, following query will only apply limit to each partition instead of the whole query.
```
SELECT row_number() OVER (PARTITION BY orderstatus ORDER BY orderkey) rn, orderkey 
FROM orders
LIMIT 5;
```