### PR TITLE
Add UnknownOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -102,6 +102,7 @@ import com.facebook.presto.type.TimeOperators;
 import com.facebook.presto.type.TimeWithTimeZoneOperators;
 import com.facebook.presto.type.TimestampOperators;
 import com.facebook.presto.type.TimestampWithTimeZoneOperators;
+import com.facebook.presto.type.UnknownOperators;
 import com.facebook.presto.type.VarbinaryOperators;
 import com.facebook.presto.type.VarcharOperators;
 import com.google.common.annotations.VisibleForTesting;
@@ -321,6 +322,7 @@ public class FunctionRegistry
                 .scalar(JsonFunctions.class)
                 .scalar(ColorFunctions.class)
                 .scalar(HyperLogLogFunctions.class)
+                .scalar(UnknownOperators.class)
                 .scalar(BooleanOperators.class)
                 .scalar(BigintOperators.class)
                 .scalar(DoubleOperators.class)

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/ByteCodeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/ByteCodeUtils.java
@@ -247,7 +247,7 @@ public final class ByteCodeUtils
         else if (type == Void.class) {
             notNull.pushNull()
                     .checkCast(Void.class);
-            expectedCurrentStackType = void.class;
+            return notNull;
         }
         else {
             throw new UnsupportedOperationException("not yet implemented: " + type);

--- a/presto-main/src/main/java/com/facebook/presto/type/UnknownOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/UnknownOperators.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.operator.scalar.ScalarOperator;
+import com.facebook.presto.spi.type.StandardTypes;
+
+import javax.annotation.Nullable;
+
+import static com.facebook.presto.metadata.OperatorType.BETWEEN;
+import static com.facebook.presto.metadata.OperatorType.EQUAL;
+import static com.facebook.presto.metadata.OperatorType.GREATER_THAN;
+import static com.facebook.presto.metadata.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.metadata.OperatorType.HASH_CODE;
+import static com.facebook.presto.metadata.OperatorType.LESS_THAN;
+import static com.facebook.presto.metadata.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.metadata.OperatorType.NOT_EQUAL;
+
+public final class UnknownOperators
+{
+    private UnknownOperators()
+    {
+    }
+
+    @ScalarOperator(EQUAL)
+    @Nullable
+    @SqlType(StandardTypes.BOOLEAN)
+    public static Boolean equal(@SqlType("unknown") @Nullable Void left, @SqlType("unknown") @Nullable Void right)
+    {
+        return null;
+    }
+
+    @ScalarOperator(NOT_EQUAL)
+    @Nullable
+    @SqlType(StandardTypes.BOOLEAN)
+    public static Boolean notEqual(@SqlType("unknown") @Nullable Void left, @SqlType("unknown") @Nullable Void right)
+    {
+        return null;
+    }
+
+    @ScalarOperator(LESS_THAN)
+    @Nullable
+    @SqlType(StandardTypes.BOOLEAN)
+    public static Boolean lessThan(@SqlType("unknown") @Nullable Void left, @SqlType("unknown") @Nullable Void right)
+    {
+        return null;
+    }
+
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
+    @Nullable
+    @SqlType(StandardTypes.BOOLEAN)
+    public static Boolean lessThanOrEqual(@SqlType("unknown") @Nullable Void left, @SqlType("unknown") @Nullable Void right)
+    {
+        return null;
+    }
+
+    @ScalarOperator(GREATER_THAN)
+    @Nullable
+    @SqlType(StandardTypes.BOOLEAN)
+    public static Boolean greaterThan(@SqlType("unknown") @Nullable Void left, @SqlType("unknown") @Nullable Void right)
+    {
+        return null;
+    }
+
+    @ScalarOperator(GREATER_THAN_OR_EQUAL)
+    @Nullable
+    @SqlType(StandardTypes.BOOLEAN)
+    public static Boolean greaterThanOrEqual(@SqlType("unknown") @Nullable Void left, @SqlType("unknown") @Nullable Void right)
+    {
+        return null;
+    }
+
+    @ScalarOperator(BETWEEN)
+    @Nullable
+    @SqlType(StandardTypes.BOOLEAN)
+    public static Boolean between(@SqlType("unknown") @Nullable Void value, @SqlType("unknown") @Nullable Void min, @SqlType("unknown") @Nullable Void max)
+    {
+        return null;
+    }
+
+    @ScalarOperator(HASH_CODE)
+    @Nullable
+    @SqlType(StandardTypes.BIGINT)
+    public static Long hashCode(@SqlType("unknown") @Nullable Void value)
+    {
+        return null;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestUnknownOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestUnknownOperators.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
+
+public class TestUnknownOperators
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testLiteral()
+            throws Exception
+    {
+        assertFunction("NULL", UNKNOWN, null);
+    }
+
+    @Test
+    public void testEqual()
+            throws Exception
+    {
+        assertFunction("NULL = NULL", BOOLEAN, null);
+    }
+
+    @Test
+    public void testNotEqual()
+            throws Exception
+    {
+        assertFunction("NULL <> NULL", BOOLEAN, null);
+    }
+
+    @Test
+    public void testLessThan()
+            throws Exception
+    {
+        assertFunction("NULL < NULL", BOOLEAN, null);
+    }
+
+    @Test
+    public void testLessThanOrEqual()
+            throws Exception
+    {
+        assertFunction("NULL <= NULL", BOOLEAN, null);
+    }
+
+    @Test
+    public void testGreaterThan()
+            throws Exception
+    {
+        assertFunction("NULL > NULL", BOOLEAN, null);
+    }
+
+    @Test
+    public void testGreaterThanOrEqual()
+            throws Exception
+    {
+        assertFunction("NULL >= NULL", BOOLEAN, null);
+    }
+
+    @Test
+    public void testBetween()
+            throws Exception
+    {
+        assertFunction("NULL BETWEEN NULL AND NULL", BOOLEAN, null);
+    }
+
+    @Test
+    public void testCastToBigint()
+            throws Exception
+    {
+        assertFunction("cast(NULL as bigint)", BIGINT, null);
+    }
+
+    @Test
+    public void testCastToVarchar()
+            throws Exception
+    {
+        assertFunction("cast(NULL as varchar)", VARCHAR, null);
+    }
+
+    @Test
+    public void testCastToDouble()
+            throws Exception
+    {
+        assertFunction("cast(NULL as double)", DOUBLE, null);
+    }
+
+    @Test
+    public void testCastToBoolean()
+            throws Exception
+    {
+        assertFunction("cast(NULL as boolean)", BOOLEAN, null);
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3455,6 +3455,7 @@ public abstract class AbstractTestQueries
     {
         assertQuery("SELECT orderkey FROM orders UNION SELECT custkey FROM orders");
         assertQuery("SELECT 123 UNION DISTINCT SELECT 123 UNION ALL SELECT 123");
+        assertQuery("SELECT NULL UNION SELECT NULL");
 
         // mixed single-node vs fixed vs source-distributed
         assertQuery("SELECT orderkey FROM orders UNION ALL SELECT 123 UNION ALL (SELECT custkey FROM orders GROUP BY custkey)");


### PR DESCRIPTION
Fixes #3184 

1. If fixes query SELECT NULL UNION SELECT NULL
2. It avoids future failure when ambiguity check is added to coercion-enabled resolving in FunctionRegistry