### PR TITLE
Convert Hive TimeZone config to a string

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -25,6 +25,7 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDataSize;
 import io.airlift.units.MinDuration;
+import org.joda.time.DateTimeZone;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -44,7 +45,7 @@ public class HiveClientConfig
 {
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
-    private TimeZone timeZone = TimeZone.getDefault();
+    private String timeZone = TimeZone.getDefault().getID();
 
     private DataSize maxSplitSize = new DataSize(64, MEGABYTE);
     private int maxOutstandingSplits = 1_000;
@@ -139,12 +140,6 @@ public class HiveClientConfig
         return this;
     }
 
-    @NotNull
-    public TimeZone getTimeZone()
-    {
-        return timeZone;
-    }
-
     @Config("hive.recursive-directories")
     public HiveClientConfig setRecursiveDirWalkerEnabled(boolean recursiveDirWalkerEnabled)
     {
@@ -157,16 +152,21 @@ public class HiveClientConfig
         return recursiveDirWalkerEnabled;
     }
 
+    public DateTimeZone getDateTimeZone()
+    {
+        return DateTimeZone.forTimeZone(TimeZone.getTimeZone(timeZone));
+    }
+
+    @NotNull
+    public String getTimeZone()
+    {
+        return timeZone;
+    }
+
     @Config("hive.time-zone")
     public HiveClientConfig setTimeZone(String id)
     {
-        this.timeZone = (id == null) ? TimeZone.getDefault() : TimeZone.getTimeZone(id);
-        return this;
-    }
-
-    public HiveClientConfig setTimeZone(TimeZone timeZone)
-    {
-        this.timeZone = (timeZone == null) ? TimeZone.getDefault() : timeZone;
+        this.timeZone = (id != null) ? id : TimeZone.getDefault().getID();
         return this;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -108,7 +108,7 @@ public class HiveMetadata
         this(connectorId,
                 metastore,
                 hdfsEnvironment,
-                DateTimeZone.forTimeZone(hiveClientConfig.getTimeZone()),
+                hiveClientConfig.getDateTimeZone(),
                 hiveClientConfig.getAllowDropTable(),
                 hiveClientConfig.getAllowRenameTable(),
                 hiveClientConfig.getAllowCorruptWritesForTesting(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -58,7 +58,7 @@ public class HivePageSourceProvider
             TypeManager typeManager)
     {
         checkNotNull(hiveClientConfig, "hiveClientConfig is null");
-        this.hiveStorageTimeZone = DateTimeZone.forTimeZone(hiveClientConfig.getTimeZone());
+        this.hiveStorageTimeZone = hiveClientConfig.getDateTimeZone();
         this.hdfsEnvironment = checkNotNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.cursorProviders = ImmutableSet.copyOf(checkNotNull(cursorProviders, "cursorProviders is null"));
         this.pageSourceFactories = ImmutableSet.copyOf(checkNotNull(pageSourceFactories, "pageSourceFactories is null"));

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -126,7 +126,7 @@ public class HiveSplitManager
                 namenodeStats,
                 hdfsEnvironment,
                 directoryLister,
-                DateTimeZone.forTimeZone(hiveClientConfig.getTimeZone()),
+                hiveClientConfig.getDateTimeZone(),
                 new BoundedExecutor(executorService, hiveClientConfig.getMaxSplitIteratorThreads()),
                 hiveClientConfig.getMaxOutstandingSplits(),
                 hiveClientConfig.getMinPartitionBatchSize(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -135,7 +135,7 @@ public class TestHiveClientConfig
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
-                .setTimeZone(nonDefaultTimeZone().toTimeZone())
+                .setTimeZone(nonDefaultTimeZone().toTimeZone().getID())
                 .setMaxSplitSize(new DataSize(256, Unit.MEGABYTE))
                 .setMaxOutstandingSplits(10)
                 .setMaxSplitIteratorThreads(10)


### PR DESCRIPTION
The JDK toString() method for TimeZone is extremely long and
makes the Bootstrap config printing hard to read.