### PR TITLE
connector: Add a connector for Phoenix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <module>presto-base-jdbc</module>
         <module>presto-mysql</module>
         <module>presto-postgresql</module>
+        <module>presto-phoenix</module>
         <module>presto-client</module>
         <module>presto-parser</module>
         <module>presto-main</module>

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
@@ -49,7 +49,7 @@ public class QueryBuilder
         sql.append("SELECT ");
         Joiner.on(", ").appendTo(sql, transform(columns, column -> quote(column.getColumnName())));
         if (columns.isEmpty()) {
-            sql.append("null");
+            sql.append("1");
         }
 
         sql.append(" FROM ");

--- a/presto-phoenix/pom.xml
+++ b/presto-phoenix/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.113-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-phoenix</artifactId>
+    <description>Presto - Phoenix Connector</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-base-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.phoenix</groupId>
+            <artifactId>phoenix-server-client</artifactId>
+            <version>4.4.0-HBase-0.98</version>
+        </dependency>
+
+        <!-- Presto SPI -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.self="override" />
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/presto-phoenix/src/main/java/com/facebook/presto/plugin/phoenix/PhoenixClient.java
+++ b/presto-phoenix/src/main/java/com/facebook/presto/plugin/phoenix/PhoenixClient.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.phoenix;
+
+import com.facebook.presto.plugin.jdbc.BaseJdbcClient;
+import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
+import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
+import org.apache.phoenix.queryserver.client.Driver;
+
+import javax.inject.Inject;
+import java.sql.SQLException;
+
+public class PhoenixClient extends BaseJdbcClient
+{
+    @Inject
+    public PhoenixClient(JdbcConnectorId connectorId, BaseJdbcConfig config)
+            throws SQLException
+    {
+        super(connectorId, config, "", new Driver());
+    }
+}

--- a/presto-phoenix/src/main/java/com/facebook/presto/plugin/phoenix/PhoenixClientModule.java
+++ b/presto-phoenix/src/main/java/com/facebook/presto/plugin/phoenix/PhoenixClientModule.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.phoenix;
+
+import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
+import com.facebook.presto.plugin.jdbc.JdbcClient;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class PhoenixClientModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(JdbcClient.class).to(PhoenixClient.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(BaseJdbcConfig.class);
+    }
+}

--- a/presto-phoenix/src/main/java/com/facebook/presto/plugin/phoenix/PhoenixPlugin.java
+++ b/presto-phoenix/src/main/java/com/facebook/presto/plugin/phoenix/PhoenixPlugin.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.phoenix;
+
+import com.facebook.presto.plugin.jdbc.JdbcPlugin;
+
+public class PhoenixPlugin extends JdbcPlugin
+{
+    public PhoenixPlugin()
+    {
+        super("phoenix", new PhoenixClientModule());
+    }
+}

--- a/presto-server/src/main/provisio/presto.xml
+++ b/presto-server/src/main/provisio/presto.xml
@@ -92,6 +92,12 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/phoenix">
+        <artifact id="${project.groupId}:presto-phoenix:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/postgresql">
         <artifact id="${project.groupId}:presto-postgresql:zip:${project.version}">
             <unpack />


### PR DESCRIPTION
Phoenix provides a SQL based access to HBase. This implementation
is for HBase version 0.98.13 and pheonix-4.4.0-HBase-0.98.

Minor change was done in QueryBuilder to use constant 1 instead
of null when columns are not present in the query. Current Phoenix
thin client has a bug with SELET null queries. Using 1 instead of
null will not change any functionality for Presto.

Manual testing has been done, product tests will be added later.