### PR TITLE
Fix NullPointerException of EXPLAIN (TYPE DISTRIBUTED)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -61,7 +61,7 @@ public class QueryExplainer
                 return PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata, session);
             case DISTRIBUTED:
                 SubPlan subPlan = getDistributedPlan(statement);
-                return PlanPrinter.textDistributedPlan(subPlan, metadata);
+                return PlanPrinter.textDistributedPlan(subPlan, metadata, session);
         }
         throw new IllegalArgumentException("Unhandled plan type: " + planType);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanPrinter.java
@@ -122,9 +122,9 @@ public class PlanPrinter
         return new PlanPrinter(plan, types, metadata, session).toString();
     }
 
-    public static String textLogicalPlan(PlanNode plan, Map<Symbol, Type> types, Metadata metadata, int indent)
+    public static String textLogicalPlan(PlanNode plan, Map<Symbol, Type> types, Metadata metadata, Session session, int indent)
     {
-        return new PlanPrinter(plan, types, metadata, null, indent).toString();
+        return new PlanPrinter(plan, types, metadata, session, indent).toString();
     }
 
     public static String getJsonPlanSource(PlanNode plan, Metadata metadata, Session session)
@@ -132,7 +132,7 @@ public class PlanPrinter
         return JsonPlanPrinter.getPlan(plan, metadata, session);
     }
 
-    public static String textDistributedPlan(SubPlan plan, Metadata metadata)
+    public static String textDistributedPlan(SubPlan plan, Metadata metadata, Session session)
     {
         StringBuilder builder = new StringBuilder();
         for (PlanFragment fragment : plan.getAllFragments()) {
@@ -157,7 +157,7 @@ public class PlanPrinter
                 }
             }
 
-            builder.append(textLogicalPlan(fragment.getRoot(), fragment.getSymbols(), metadata, 1))
+            builder.append(textLogicalPlan(fragment.getRoot(), fragment.getSymbols(), metadata, session, 1))
                     .append("\n");
         }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3208,6 +3208,10 @@ public abstract class AbstractTestQueries
         MaterializedResult result = computeActual("EXPLAIN (TYPE DISTRIBUTED) " + query);
         String actual = Iterables.getOnlyElement(transform(result.getMaterializedRows(), onlyColumnGetter()));
         assertEquals(actual, getExplainPlan(query, DISTRIBUTED));
+
+        // This query should not throw exception
+        query = "SELECT * FROM orders";
+        computeActual("EXPLAIN (TYPE DISTRIBUTED) " + query);
     }
 
     @Test


### PR DESCRIPTION
Error: When EXPLAIN (TYPE DISTRIBUTED)  of a query, textDistributedPlan passes NULL instead of Seesion into PlanPrinter, which leads to NPE.
Fix: Pass Session into PlanPrinter

Without this fix, got NullPointerException
```
presto:tiny> EXPLAIN (TYPE DISTRIBUTED) select * from orders;
Query 20150726_014323_00012_ft93r failed: null
java.lang.NullPointerException
    at com.facebook.presto.metadata.MetadataManager.getLayout(MetadataManager.java:294)
    at com.facebook.presto.sql.planner.PlanPrinter$Visitor.lambda$visitTableScan$204(PlanPrinter.java:409)
    at com.facebook.presto.sql.planner.PlanPrinter$Visitor$$Lambda$499/1481106520.apply(Unknown Source)
    at java.util.Optional.map(Optional.java:215)
    at com.facebook.presto.sql.planner.PlanPrinter$Visitor.visitTableScan(PlanPrinter.java:409)
    at com.facebook.presto.sql.planner.PlanPrinter$Visitor.visitTableScan(PlanPrinter.java:196)
    at com.facebook.presto.sql.planner.plan.TableScanNode.accept(TableScanNode.java:135)
    at com.facebook.presto.sql.planner.PlanPrinter.<init>(PlanPrinter.java:111)
    at com.facebook.presto.sql.planner.PlanPrinter.textLogicalPlan(PlanPrinter.java:127)
    at com.facebook.presto.sql.planner.PlanPrinter.textDistributedPlan(PlanPrinter.java:160)
    at com.facebook.presto.sql.analyzer.QueryExplainer.getPlan(QueryExplainer.java:64)
    at com.facebook.presto.sql.analyzer.StatementAnalyzer.getQueryPlan(StatementAnalyzer.java:498)
    at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitExplain(StatementAnalyzer.java:479)
    at com.facebook.presto.sql.analyzer.StatementAnalyzer.visitExplain(StatementAnalyzer.java:115)
    at com.facebook.presto.sql.tree.Explain.accept(Explain.java:54)
    at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:22)
    at com.facebook.presto.sql.analyzer.Analyzer.analyze(Analyzer.java:52)
    at com.facebook.presto.execution.SqlQueryExecution.doAnalyzeQuery(SqlQueryExecution.java:251)
    at com.facebook.presto.execution.SqlQueryExecution.analyzeQuery(SqlQueryExecution.java:237)
    at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:201)
    at com.facebook.presto.execution.QueuedExecution.lambda$start$126(QueuedExecution.java:68)
    at com.facebook.presto.execution.QueuedExecution$$Lambda$239/358278439.run(Unknown Source)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```