### PR TITLE
Enforce minimum Java version for building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: java
 jdk:
   - oraclejdk8
 
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
 env:
   global:
     - MAVEN_OPTS="-Xmx256M"

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>41</version>
+        <version>42</version>
     </parent>
 
     <groupId>com.facebook.presto</groupId>
@@ -41,6 +41,8 @@
 
         <air.check.fail-checkstyle>true</air.check.fail-checkstyle>
         <air.check.skip-checkstyle>false</air.check.skip-checkstyle>
+
+        <air.java.version>1.8.0-40</air.java.version>
 
         <dep.antlr.version>4.5.1</dep.antlr.version>
         <dep.airlift.version>0.112</dep.airlift.version>


### PR DESCRIPTION
This prints a failure like this (with property changed to `-51` for testing):
```
[INFO] --- maven-enforcer-plugin:1.2:enforce (default) @ presto-root ---
[WARNING] Rule 2: org.apache.maven.plugins.enforcer.RequireJavaVersion failed with message:
Detected JDK Version: 1.8.0-45 is not in the allowed range 1.8.0-51.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3.256 s
[INFO] Finished at: 2015-07-25T22:26:59-07:00
[INFO] Final Memory: 36M/339M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:1.2:enforce (default) on project presto-root: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]
