### PR TITLE
Fix regression for repartition exchange

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -221,7 +221,7 @@ public class UnaliasSymbolReferences
             List<PlanNode> sources = node.getSources().stream()
                     .map(context::rewrite)
                     .collect(toImmutableList());
-            Optional<List<Symbol>> partitionKeys = node.getPartitionKeys().map(this::canonicalizeAndDistinct);
+            Optional<List<Symbol>> partitionKeys = node.getPartitionKeys().map(this::canonicalize);
 
             List<List<Symbol>> inputs = new ArrayList<>();
             for (int i = 0; i < node.getInputs().size(); i++) {
@@ -510,6 +510,13 @@ public class UnaliasSymbolReferences
                 }
             }
             return builder.build();
+        }
+
+        private List<Symbol> canonicalize(List<Symbol> symbols)
+        {
+            return symbols.stream()
+                    .map(this::canonicalize)
+                    .collect(toImmutableList());
         }
 
         private Set<Symbol> canonicalize(Set<Symbol> symbols)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -34,6 +34,7 @@ import org.intellij.lang.annotations.Language;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -108,7 +109,7 @@ public class DistributedQueryRunner
             throws Exception
     {
         long start = System.nanoTime();
-        ImmutableMap.Builder<String, String> properties = ImmutableMap.<String, String>builder()
+        ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.<String, String>builder()
                 .put("query.client.timeout", "10m")
                 .put("exchange.http-client.read-timeout", "1h")
                 .put("compiler.interpreter-enabled", "false")
@@ -116,14 +117,15 @@ public class DistributedQueryRunner
                 .put("datasources", "system")
                 .put("distributed-index-joins-enabled", "true")
                 .put("optimizer.optimize-hash-generation", "true");
-        properties.putAll(extraProperties);
         if (coordinator) {
-            properties.put("node-scheduler.include-coordinator", "false");
-            properties.put("distributed-joins-enabled", "true");
-            properties.put("node-scheduler.multiple-tasks-per-node-enabled", "true");
+            propertiesBuilder.put("node-scheduler.include-coordinator", "false");
+            propertiesBuilder.put("distributed-joins-enabled", "true");
+            propertiesBuilder.put("node-scheduler.multiple-tasks-per-node-enabled", "true");
         }
+        HashMap<String, String> properties = new HashMap<>(propertiesBuilder.build());
+        properties.putAll(extraProperties);
 
-        TestingPrestoServer server = new TestingPrestoServer(coordinator, properties.build(), ENVIRONMENT, discoveryUri, ImmutableList.<Module>of());
+        TestingPrestoServer server = new TestingPrestoServer(coordinator, properties, ENVIRONMENT, discoveryUri, ImmutableList.<Module>of());
 
         log.info("Created TestingPrestoServer in %s", nanosSince(start).convertToMostSuccinctTimeUnit());
 

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedQueriesWithoutHashGeneration.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedQueriesWithoutHashGeneration.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.facebook.presto.tpch.testing.SampledTpchPlugin;
+import com.google.common.collect.ImmutableMap;
+
+import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
+import static java.util.Locale.ENGLISH;
+
+public class TestTpchDistributedQueriesWithoutHashGeneration
+        extends AbstractTestQueries
+{
+    public TestTpchDistributedQueriesWithoutHashGeneration()
+            throws Exception
+    {
+        super(createQueryRunner());
+    }
+
+    private static DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = Session.builder()
+                .setUser("user")
+                .setSource("test")
+                .setCatalog("tpch")
+                .setSchema("tiny")
+                .setTimeZoneKey(UTC_KEY)
+                .setLocale(ENGLISH)
+                .build();
+
+        DistributedQueryRunner queryRunner = new DistributedQueryRunner(session, 4, ImmutableMap.of("optimizer.optimize-hash-generation", "false"));
+
+        try {
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
+
+            queryRunner.installPlugin(new SampledTpchPlugin());
+            queryRunner.createCatalog("tpch_sampled", "tpch_sampled");
+
+            return queryRunner;
+        }
+        catch (Exception e) {
+            queryRunner.close();
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
This pull request blocks release.

This pull request slows down test.

@cberner @martint Can you think of other cases where deduplication might have broken things?

--------

Fixes #3351 

Commits e64daa6 and ba43b9a introduces deduplication to partitionKeys in `UnaliasSymbolReferences.visitExchange`. This breaks the following query

    SELECT COUNT(*) FROM lineitem FULL JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.orderkey = 2

Before deduplication, left partitionKey is `(orderkey, expr=2)`, right partitionKey is `(orderkey_0, orderkey_0)`. After deduplication, right partitionKey becomes `(orderkey_0)`. As a result, left and right partitionKey no longer matches. Incorrect result is produces because matching rows hashes to different partitions.