### PR TITLE
Add function to_unixtime_second

### DIFF
--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -91,6 +91,10 @@ Date and Time Functions
 
     Returns ``timestamp`` as a UNIX timestamp.
 
+.. function:: to_unixtime_second(timestamp) -> bigint
+
+    Returns ``timestamp`` as a UNIX Epoch time in seconds.
+
 .. note:: The following SQL-standard functions do not use parenthesis:
 
     - ``current_date``

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -162,6 +162,20 @@ public final class DateTimeFunctions
         return unpackMillisUtc(timestampWithTimeZone) / 1000.0;
     }
 
+    @ScalarFunction("to_unixtime_second")
+    @SqlType(StandardTypes.BIGINT)
+    public static long toUnixTimeSecond(@SqlType(StandardTypes.TIMESTAMP) long timestamp)
+    {
+        return timestamp / 1000;
+    }
+
+    @ScalarFunction("to_unixtime_second")
+    @SqlType(StandardTypes.BIGINT)
+    public static long toUnixTimeFromTimestampWithTimeZoneMillis(@SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long timestampWithTimeZone)
+    {
+        return unpackMillisUtc(timestampWithTimeZone) / 1000;
+    }
+
     @ScalarFunction("to_iso8601")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice toISO8601FromTimestamp(ConnectorSession session, @SqlType(StandardTypes.TIMESTAMP) long timestamp)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -172,6 +172,13 @@ public class TestDateTimeFunctions
     }
 
     @Test
+    public void testToUnixTimeSecond()
+    {
+        assertFunction("to_unixtime_second(" + TIMESTAMP_LITERAL + ")", BIGINT, TIMESTAMP.getMillis() / 1000);
+        assertFunction("to_unixtime_second(" + WEIRD_TIMESTAMP_LITERAL + ")", BIGINT, WEIRD_TIMESTAMP.getMillis() / 1000);
+    }
+
+    @Test
     public void testFromISO8601()
     {
         assertFunction("from_iso8601_timestamp('" + TIMESTAMP_ISO8601_STRING + "')", TIMESTAMP_WITH_TIME_ZONE, toTimestampWithTimeZone(TIMESTAMP_WITH_NUMERICAL_ZONE));


### PR DESCRIPTION
Right now, to_unixdate() returns seconds in double type. These two functions return seconds in bigint type.