### PR TITLE
Allow disabling catalogs from being loaded

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/CatalogManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/CatalogManagerConfig.java
@@ -13,16 +13,22 @@
  */
 package com.facebook.presto.metadata;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.LegacyConfig;
 
 import javax.validation.constraints.NotNull;
 
 import java.io.File;
+import java.util.List;
 
 public class CatalogManagerConfig
 {
+    private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+
     private File catalogConfigurationDir = new File("etc/catalog/");
+    private List<String> disabledCatalogs;
 
     @NotNull
     public File getCatalogConfigurationDir()
@@ -35,6 +41,24 @@ public class CatalogManagerConfig
     public CatalogManagerConfig setCatalogConfigurationDir(File dir)
     {
         this.catalogConfigurationDir = dir;
+        return this;
+    }
+
+    public List<String> getDisabledCatalogs()
+    {
+        return disabledCatalogs;
+    }
+
+    @Config("catalog.disabled-catalogs")
+    public CatalogManagerConfig setDisabledCatalogs(String catalogs)
+    {
+        this.disabledCatalogs = (catalogs == null) ? null : SPLITTER.splitToList(catalogs);
+        return this;
+    }
+
+    public CatalogManagerConfig setDisabledCatalogs(List<String> catalogs)
+    {
+        this.disabledCatalogs = (catalogs == null) ? null : ImmutableList.copyOf(catalogs);
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/CatalogManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/CatalogManagerConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.metadata;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.LegacyConfig;
 
 import javax.validation.constraints.NotNull;
 
@@ -29,10 +30,11 @@ public class CatalogManagerConfig
         return catalogConfigurationDir;
     }
 
-    @Config("plugin.config-dir")
-    public CatalogManagerConfig setCatalogConfigurationDir(File pluginConfigurationDir)
+    @LegacyConfig("plugin.config-dir")
+    @Config("catalog.config-dir")
+    public CatalogManagerConfig setCatalogConfigurationDir(File dir)
     {
-        this.catalogConfigurationDir = pluginConfigurationDir;
+        this.catalogConfigurationDir = dir;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestCatalogManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestCatalogManagerConfig.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.metadata;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
@@ -29,7 +30,8 @@ public class TestCatalogManagerConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(CatalogManagerConfig.class)
-                .setCatalogConfigurationDir(new File("etc/catalog")));
+                .setCatalogConfigurationDir(new File("etc/catalog"))
+                .setDisabledCatalogs((String) null));
     }
 
     @Test
@@ -37,10 +39,12 @@ public class TestCatalogManagerConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("catalog.config-dir", "/foo")
+                .put("catalog.disabled-catalogs", "abc,xyz")
                 .build();
 
         CatalogManagerConfig expected = new CatalogManagerConfig()
-                .setCatalogConfigurationDir(new File("/foo"));
+                .setCatalogConfigurationDir(new File("/foo"))
+                .setDisabledCatalogs(ImmutableList.of("abc", "xyz"));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestCatalogManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestCatalogManagerConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestCatalogManagerConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(CatalogManagerConfig.class)
+                .setCatalogConfigurationDir(new File("etc/catalog")));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("catalog.config-dir", "/foo")
+                .build();
+
+        CatalogManagerConfig expected = new CatalogManagerConfig()
+                .setCatalogConfigurationDir(new File("/foo"));
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
This allows skipping bad catalogs without deleting the catalog
properties file, which is often useful during development.