### PR TITLE
Allow non-comparable type for LOWER/UPPER UNBOUNDED

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.Marker;
 import com.facebook.presto.spi.Range;
 import com.facebook.presto.spi.SortedRangeSet;
 import com.facebook.presto.spi.TupleDomain;
-import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.tree.AstVisitor;
@@ -435,7 +434,7 @@ public final class DomainTranslator
 
             Symbol symbol = Symbol.fromQualifiedName(((QualifiedNameReference) node.getValue()).getName());
             Type columnType = checkedTypeLookup(symbol);
-            Domain domain = complementIfNecessary(Domain.onlyNull(fixNonComparableType(wrap(columnType.getJavaType()))), complement);
+            Domain domain = complementIfNecessary(Domain.onlyNull(wrap(columnType.getJavaType())), complement);
             return new ExtractionResult(
                     TupleDomain.withColumnDomains(ImmutableMap.of(symbol, domain)),
                     TRUE_LITERAL);
@@ -451,33 +450,10 @@ public final class DomainTranslator
             Symbol symbol = Symbol.fromQualifiedName(((QualifiedNameReference) node.getValue()).getName());
             Type columnType = checkedTypeLookup(symbol);
 
-            Domain domain = complementIfNecessary(Domain.notNull(fixNonComparableType(wrap(columnType.getJavaType()))), complement);
+            Domain domain = complementIfNecessary(Domain.notNull(wrap(columnType.getJavaType())), complement);
             return new ExtractionResult(
                     TupleDomain.withColumnDomains(ImmutableMap.of(symbol, domain)),
                     TRUE_LITERAL);
-        }
-
-        private static Class<?> fixNonComparableType(Class<?> clazz)
-        {
-            // !!! HACK ALERT !!!
-            // This is needed because SortedRangeSet.all/none requires that the argument type be self-comparable. See Marker#verifySelfComparable
-            // However, the SortedRangeSet works fine when the only value involved are lowerUnbound and upperUnbound.
-            // This hack shall be removed once TupleDomain is updated to support
-            // The same hack can also be found in TupleDomainOrcPredicate
-            if (clazz == Block.class) {
-                return BogusComparable.class;
-            }
-            return clazz;
-        }
-
-        private static class BogusComparable
-                implements Comparable<BogusComparable>
-        {
-            @Override
-            public int compareTo(BogusComparable o)
-            {
-                throw new UnsupportedOperationException();
-            }
         }
 
         @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Marker.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Marker.java
@@ -47,7 +47,16 @@ public final class Marker
     {
         Objects.requireNonNull(type, "type is null");
         Objects.requireNonNull(bound, "bound is null");
-        if (!verifySelfComparable(type)) {
+        if (value != null && !verifySelfComparable(type)) {
+            // Condition "value != null" enables LOWER UNBOUNDED and UPPER UNBOUNDED values for non-comparable types.
+
+            // !!!HACK ALERT!!!
+            // It is planned that we will support non-comparable type in TupleDomain. Until that day comes, the
+            // `value != null` part of this if condition is a HACK so that Block can be used as a native container
+            // type. Consider this a hack and don't rely on it because plans CAN change.
+
+            // Notes: assuming type and value match, one would quickly conclude that type implements some sort of
+            // Comparable. This conclusion is WRONG. For example, type=Object.class and value=null.
             throw new IllegalArgumentException("type must be comparable to itself: " + type);
         }
         if (value == null && bound == Bound.EXACTLY) {


### PR DESCRIPTION
At the time I introduce Block as native container for structural types, I ran into the problem that Block is not self comparable, and cannot be supplied to `TupleDomain`/`Marker`. I had 2 options for this problem.

1. Allow non-comparable type in Marker as long as the value is UPPER UNBOUNDED or LOWER UNBOUNDED.
2. Use BogusComparable instead of the real type whenever Block is about to be passed to constructor of Marker.

I argued for option 1 because
* The theory of tuple domain does not require values to be comparable. And Eric is working toward removing this restriction in Presto.
* Current code works for non-comparable type as long as the value is UPPER UNBOUNDED or LOWER UNBOUNDED.

Eric argued for option 2 because
* Changing Marker (which is in SPI) means we are committed to support this use case, and people may depend on it.

I decided to go for option 2.

Now Nileema brought to my attention that this query failed in the most recent verifier run:

    SELECT * FROM t WHERE ds='2015-07-15' AND array_column IS NOT NULL AND userid=1 LIMIT 100;

I looked into this, and this is the cause:
* At `HttpRemoteTask.scheduleUpdate` line 397, `updateRequest` is json serialized. Through a few other calls, it will end up in `SerializableNativeValue.Serializer.serialize` line 87. When `arrayColumn is not null` is present in the query, `BogusComparable.class.getCanonicalName` will be serialized into json because it's in `updateRequest.fragment.partitionedSourceNode.currentConstraint.domains[x].value.ranges.type`.
* At  `SerializableNativeValue.Deserializer.extractClassType` line 181, it fails because ~~`BogusComparable` is not in SPI~~ `forName` is not a pair with `getCanonicalName`. `forName` is a pair with `getName`.

However, fixing the above serialization code to use `getName` instead of `getCanonicalName` results in another failure:

* At line 226 in `Domain`. IllegalArgumentException: Mismatched Domain types: class `com.facebook.presto.sql.planner.DomainTranslator$Visitor$BogusComparable` vs class `com.facebook.presto.orc.TupleDomainOrcPredicate$BogusComparable`

Now, even if I have only one `BogusComparable`, the above failure won't go away unless that one `BogusComparable` is in `presto-spi` because of how `PluginClassLoader` works.

Now, it means either way, the solution to the problem will end up in SPI. In this case, I prefer option 1.

I talked with @martint and @cberner, they support going for option 1.

cc @dain because you are doing the release.
cc @erichwang because TupleDomain is your territory.
cc @nileema because you found the bug above.