### PR TITLE
Fix of '%k' specifier parsing in MySQL date funcs

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -948,7 +948,7 @@ public final class DateTimeFunctions
                         builder.appendDayOfYear(3);
                         break;
                     case 'k': // %k Hour (0..23)
-                        builder.appendClockhourOfDay(1);
+                        builder.appendHourOfDay(1);
                         break;
                     case 'l': // %l Hour (1..12)
                         builder.appendClockhourOfHalfday(1);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -699,6 +699,7 @@ public class TestDateTimeFunctions
         assertFunction("date_format(" + wierdDateTimeLiteral + ", '%x %v')", VARCHAR, "2001 02");
 
         assertFunction("date_format(TIMESTAMP '2001-01-09 13:04:05.32', '%f')", VARCHAR, "320000");
+        assertFunction("date_format(TIMESTAMP '2001-01-09 00:04:05.32', '%k')", VARCHAR, "0");
     }
 
     @Test
@@ -750,6 +751,10 @@ public class TestDateTimeFunctions
         assertFunction("date_parse('1.2006', '%s.%f')",
                 TimestampType.TIMESTAMP,
                 toTimestamp(new DateTime(1970, 1, 1, 0, 0, 1, 200, DATE_TIME_ZONE)));
+
+        assertFunction("date_parse('0', '%k')",
+                TimestampType.TIMESTAMP,
+                toTimestamp(new DateTime(1970, 1, 1, 0, 0, 0, 0, DATE_TIME_ZONE)));
     }
 
     @Test


### PR DESCRIPTION
MySQL '%k' specifier expects 0 as midnight, not 24 as in Java DateTimeFormat. This commit fixes parsing and formatting for MySQL compatible functions: date_format and date_parse.

Issue: #3274 