### PR TITLE
Fixing fragment numbers in EXPLAIN

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -53,7 +53,7 @@ public class PlanFragmenter
         FragmentProperties properties = new FragmentProperties();
         PlanNode root = PlanRewriter.rewriteWith(fragmenter, plan.getRoot(), properties);
 
-        SubPlan result = fragmenter.buildFragment(root, properties);
+        SubPlan result = fragmenter.buildRootFragment(root, properties);
         result.sanityCheck();
 
         return result;
@@ -62,12 +62,19 @@ public class PlanFragmenter
     private static class Fragmenter
             extends PlanRewriter<FragmentProperties>
     {
+        private static final int ROOT_FRAGMENT_ID = 0;
+
         private final Map<Symbol, Type> types;
-        private int nextFragmentId;
+        private int nextFragmentId = ROOT_FRAGMENT_ID + 1;
 
         public Fragmenter(Map<Symbol, Type> types)
         {
             this.types = types;
+        }
+
+        public SubPlan buildRootFragment(PlanNode root, FragmentProperties properties)
+        {
+            return buildFragment(root, properties, new PlanFragmentId(String.valueOf(ROOT_FRAGMENT_ID)));
         }
 
         private PlanFragmentId nextFragmentId()
@@ -75,12 +82,12 @@ public class PlanFragmenter
             return new PlanFragmentId(String.valueOf(nextFragmentId++));
         }
 
-        private SubPlan buildFragment(PlanNode root, FragmentProperties properties)
+        private SubPlan buildFragment(PlanNode root, FragmentProperties properties, PlanFragmentId fragmentId)
         {
             Set<Symbol> dependencies = SymbolExtractor.extract(root);
 
             PlanFragment fragment = new PlanFragment(
-                    nextFragmentId(),
+                    fragmentId,
                     root,
                     Maps.filterKeys(types, in(dependencies)),
                     properties.getOutputLayout(),
@@ -181,8 +188,9 @@ public class PlanFragmenter
 
         private SubPlan buildSubPlan(PlanNode node, FragmentProperties properties, RewriteContext<FragmentProperties> context)
         {
+            PlanFragmentId planFragmentId = nextFragmentId();
             PlanNode child = context.rewrite(node, properties);
-            return buildFragment(child, properties);
+            return buildFragment(child, properties, planFragmentId);
         }
     }
 
@@ -291,10 +299,9 @@ public class PlanFragmenter
 
             if (partitionKeys.isPresent()) {
                 this.outputPartitioning = Optional.of(OutputPartitioning.HASH);
-            this.nullPartitionPolicy = Optional.of(NullPartitioning.HASH);
+                this.nullPartitionPolicy = Optional.of(NullPartitioning.HASH);
                 this.partitionBy = partitionKeys.map(ImmutableList::copyOf);
                 this.hash = hash;
-
             }
             else {
                 this.outputPartitioning = Optional.of(OutputPartitioning.ROUND_ROBIN);


### PR DESCRIPTION
Fragment numbering did not match stage numbers as first was done is post-order and
latter in pre-order manner. This commit changes fragment numbering to match stage
numbering.

Issue: #3157 

Manually tested on this query:
```
presto:tpch_10gb_orc> explain (type distributed) select * from nation n inner join region r on n.regionkey = r.regionkey;
                                                                                                Query Plan                                                                                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Fragment 0 [SINGLE]                                                                                                                                                                                       
     Output layout: [nationkey, name, regionkey, comment, regionkey_0, name_1, comment_2]                                                                                                                  
     - Output[nationkey, name, regionkey, comment, regionkey, name, comment] => [nationkey:bigint, name:varchar, regionkey:bigint, comment:varchar, regionkey_0:bigint, name_1:varchar, comment_2:varchar] 
             regionkey := regionkey_0                                                                                                                                                                      
             name := name_1                                                                                                                                                                                
             comment := comment_2                                                                                                                                                                          
         - RemoteSource[1] => [nationkey:bigint, name:varchar, regionkey:bigint, comment:varchar, regionkey_0:bigint, name_1:varchar, comment_2:varchar]                                                   
                                                                                                                                                                                                           
 Fragment 1 [FIXED]                                                                                                                                                                                        
     Output layout: [nationkey, name, regionkey, comment, regionkey_0, name_1, comment_2]                                                                                                                  
     - InnerJoin[("regionkey" = "regionkey_0")] => [nationkey:bigint, name:varchar, regionkey:bigint, comment:varchar, regionkey_0:bigint, name_1:varchar, comment_2:varchar]                              
         - RemoteSource[2] => [nationkey:bigint, name:varchar, regionkey:bigint, comment:varchar]                                                                                                          
         - RemoteSource[3] => [regionkey_0:bigint, name_1:varchar, comment_2:varchar]                                                                                                                      
                                                                                                                                                                                                           
 Fragment 2 [SOURCE]                                                                                                                                                                                       
     Output layout: [nationkey, name, regionkey, comment]                                                                                                                                                  
     Output partitioning: [regionkey]                                                                                                                                                                      
     - TableScan[hive:hive:tpch_10gb_orc:nation, originalConstraint = true] => [nationkey:bigint, name:varchar, regionkey:bigint, comment:varchar]                                                         
             nationkey := HiveColumnHandle{clientId=hive, name=nationkey, ordinalPosition=0, hiveType=bigint, hiveColumnIndex=0, partitionKey=false}                                                       
             name := HiveColumnHandle{clientId=hive, name=name, ordinalPosition=1, hiveType=string, hiveColumnIndex=1, partitionKey=false}                                                                 
             regionkey := HiveColumnHandle{clientId=hive, name=regionkey, ordinalPosition=2, hiveType=bigint, hiveColumnIndex=2, partitionKey=false}                                                       
             comment := HiveColumnHandle{clientId=hive, name=comment, ordinalPosition=3, hiveType=string, hiveColumnIndex=3, partitionKey=false}                                                           
                                                                                                                                                                                                           
 Fragment 3 [SOURCE]                                                                                                                                                                                       
     Output layout: [regionkey_0, name_1, comment_2]                                                                                                                                                       
     Output partitioning: [regionkey_0]                                                                                                                                                                    
     - TableScan[hive:hive:tpch_10gb_orc:region, originalConstraint = true] => [regionkey_0:bigint, name_1:varchar, comment_2:varchar]                                                                     
             regionkey_0 := HiveColumnHandle{clientId=hive, name=regionkey, ordinalPosition=0, hiveType=bigint, hiveColumnIndex=0, partitionKey=false}                                                     
             name_1 := HiveColumnHandle{clientId=hive, name=name, ordinalPosition=1, hiveType=string, hiveColumnIndex=1, partitionKey=false}                                                               
             comment_2 := HiveColumnHandle{clientId=hive, name=comment, ordinalPosition=2, hiveType=string, hiveColumnIndex=2, partitionKey=false}                                                         
                                                                                                                                                                                                           
                                                                                                                                                                                                           
(1 row)
```

Please note that root node is not wrapped around `ExchangeNode` so numbering needs to start from 1 and root node has directly assigned 0 value.

We might want to consider using `fragmentId` as `stageId` which is currently separately assigned in `SqlStageExecution`.