### PR TITLE
Compact dictionary for LazySliceArrayBlock

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.113.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.113.rst
@@ -2,6 +2,10 @@
 Release 0.113
 =============
 
+.. warning::
+
+    The ORC reader in the Hive connector is broken in this release.
+
 Cluster Resource Management
 ---------------------------
 

--- a/presto-docs/src/main/sphinx/release/release-0.114.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.114.rst
@@ -7,3 +7,8 @@ General Changes
 
 * Fix ``%k`` specifier for :func:`date_format` and :func:`date_parse`.
   It previously used ``24`` rather than ``0`` for the midnight hour.
+
+Hive Changes
+------------
+
+* Fix ORC reader for Hive connector.

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
@@ -184,7 +184,8 @@ public class SliceDictionaryStreamReader
         else {
             int[] ids = Arrays.copyOfRange(dataVector, 0, nextBatchSize);
             boolean[] isNullVector = Arrays.copyOfRange(this.isNullVector, 0, nextBatchSize);
-            sliceVector.setDictionary(dictionary, ids, isNullVector);
+            Slice[] values = Arrays.copyOf(dictionary, dictionary.length);
+            sliceVector.setDictionary(values, ids, isNullVector);
         }
 
         readOffset = 0;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazySliceArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazySliceArrayBlock.java
@@ -145,9 +145,10 @@ public class LazySliceArrayBlock
         }
 
         assureLoaded();
+
         if (dictionary) {
             List<Integer> positions = IntStream.range(positionOffset, positionOffset + length).boxed().collect(toList());
-            compactAndGet(positions, false);
+            return compactAndGet(positions, false);
         }
         Slice[] newValues = Arrays.copyOfRange(values, positionOffset, positionOffset + length);
         return new SliceArrayBlock(length, newValues);
@@ -182,8 +183,13 @@ public class LazySliceArrayBlock
             throw new IllegalArgumentException("Lazy block loader did not load this block");
         }
 
-        if (dictionary && ids.length != positionCount) {
-            throw new IllegalArgumentException(format("Expected %s positions, loaded %s", positionCount, ids.length));
+        if (dictionary) {
+            if (ids.length != positionCount) {
+                throw new IllegalArgumentException(format("Expected %s positions, loaded %s", positionCount, ids.length));
+            }
+            if (isNull != null && isNull.length != positionCount) {
+                throw new IllegalArgumentException(format("Expected %s positions, loaded %s", positionCount, isNull.length));
+            }
         }
 
         if (!dictionary && values.length != positionCount) {
@@ -205,31 +211,51 @@ public class LazySliceArrayBlock
 
     private Block compactAndGet(List<Integer> positions, boolean copy)
     {
-        List<Integer> distinctPositions = positions.stream().distinct().collect(toList());
-        List<Integer> currentDictionaryIndexes = distinctPositions.stream().map(this::getPosition).collect(toList());
-        List<Integer> positionsToCopy = currentDictionaryIndexes.stream().distinct().collect(toList());
+        int[] newIds = new int[positions.size()];
+        boolean hasNull = false;
 
-        Slice[] newValues = new Slice[positionsToCopy.size()];
-        for (int i = 0; i < positionsToCopy.size(); i++) {
-            int position = positionsToCopy.get(i);
+        int[] newDictionaryIndexes = new int[values.length];
+        Arrays.fill(newDictionaryIndexes, -1);
+
+        int nextIndex = 0;
+        for (int i = 0; i < positions.size(); i++) {
+            int position = positions.get(i);
             if (isEntryNull(position)) {
-                newValues[i] = null;
+                hasNull = true;
+                newIds[i] = -1;
             }
             else {
-                Slice value = values[position];
-                if (copy) {
-                    newValues[i] = copyOf(value);
+                int oldIndex = ids[position];
+                if (newDictionaryIndexes[oldIndex] == -1) {
+                    newDictionaryIndexes[oldIndex] = nextIndex;
+                    nextIndex++;
                 }
-                else {
-                    newValues[i] = value;
-                }
+                newIds[i] = newDictionaryIndexes[oldIndex];
             }
         }
 
-        int[] newIds = new int[positions.size()];
-        for (int i = 0; i < positions.size(); i++) {
-            int oldIndex = currentDictionaryIndexes.get(distinctPositions.indexOf(positions.get(i)));
-            newIds[i] = positionsToCopy.indexOf(oldIndex);
+        int newDictionaryLength = nextIndex;
+        if (hasNull) {
+            newDictionaryLength++;
+        }
+        Slice[] newValues = new Slice[newDictionaryLength];
+
+        for (int i = 0; i < values.length; i++) {
+            if (newDictionaryIndexes[i] != -1) {
+                // key was referenced
+                Slice value = values[i];
+                int newIndex = newDictionaryIndexes[i];
+                newValues[newIndex] = copy ? copyOf(value) : value;
+            }
+        }
+
+        if (hasNull) {
+            int nullIndex = newValues.length - 1;
+            for (int i = 0; i < newIds.length; i++) {
+                if (newIds[i] == -1) {
+                    newIds[i] = nullIndex;
+                }
+            }
         }
         return new DictionaryBlock(positions.size(), new SliceArrayBlock(newValues.length, newValues), wrappedIntArray(newIds));
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
@@ -45,7 +45,7 @@ public class SliceArrayBlock
         retainedSizeInBytes = getSliceArrayRetainedSizeInBytes(values);
     }
 
-    Slice[] getValues()
+    public Slice[] getValues()
     {
         return values;
     }


### PR DESCRIPTION
For compacting the dictionary representation of the lazySliceArrayBlock, 
- first index all the referenced values and check if null is referenced. 
- create a new dictionary with the referenced values, include null in the dictionary, so that we do not have two representations for null when we create the DictionaryBlock
- create a new Ids block for this dictionary, update the nullIndex 