### PR TITLE
Support for LIMIT ALL

### DIFF
--- a/presto-docs/src/main/sphinx/sql/select.rst
+++ b/presto-docs/src/main/sphinx/sql/select.rst
@@ -15,7 +15,7 @@ Synopsis
     [ HAVING condition]
     [ UNION [ ALL | DISTINCT ] select ]
     [ ORDER BY expression [ ASC | DESC ] [, ...] ]
-    [ LIMIT count ]
+    [ LIMIT [ ALL | count] ]
 
 where ``from_item`` is one of
 
@@ -189,6 +189,7 @@ LIMIT Clause
 ------------
 
 The ``LIMIT`` clause restricts the number of rows in the result set.
+The argument ``ALL`` effectively returns all rows from the result set.
 The following example queries a large table, but the limit clause restricts
 the output to only have five rows (because the query lacks an ``ORDER BY``,
 exactly which rows are returned is arbitrary)::

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -55,7 +55,7 @@ statement
     | SHOW PARTITIONS (FROM | IN) qualifiedName
         (WHERE booleanExpression)?
         (ORDER BY sortItem (',' sortItem)*)?
-        (LIMIT limit=INTEGER_VALUE)?                                   #showPartitions
+        (LIMIT (ALL | (limit=INTEGER_VALUE)))?                         #showPartitions
     ;
 
 query
@@ -73,7 +73,7 @@ tableElement
 queryNoWith:
       queryTerm
       (ORDER BY sortItem (',' sortItem)*)?
-      (LIMIT limit=INTEGER_VALUE)?
+      (LIMIT (ALL | (limit=INTEGER_VALUE)))?
       (APPROXIMATE AT confidence=number CONFIDENCE)?
     ;
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -748,6 +748,14 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testLimitAll()
+            throws Exception
+    {
+        assertQuery("SELECT COUNT(*) FROM (SELECT * FROM nation LIMIT 10)", "SELECT 10");
+        assertQuery("SELECT COUNT(*) FROM (SELECT * FROM nation LIMIT ALL)", "SELECT 25");
+    }
+
+    @Test
     public void testCountAll()
             throws Exception
     {


### PR DESCRIPTION
Added support for ALL argument in LIMIT clause which has the same effect
as removing the LIMIT clause from the query.

Issue: #3158

Sample:
```
presto:default> SELECT COUNT(*) FROM (SELECT * FROM tpch.sf1.nation LIMIT 10);
 _col0 
-------
    10 
(1 row)

Query 20150805_151333_00004_z2in4, FINISHED, 1 node
Splits: 5 total, 5 done (100.00%)
0:03 [25 rows, 0B] [8 rows/s, 0B/s]

presto:default> SELECT COUNT(*) FROM (SELECT * FROM tpch.sf1.nation LIMIT ALL);
 _col0 
-------
    25 
(1 row)

Query 20150805_151340_00005_z2in4, FINISHED, 1 node
Splits: 5 total, 5 done (100.00%)
0:00 [25 rows, 0B] [255 rows/s, 0B/s]

presto:default> SELECT COUNT(*) FROM (SELECT * FROM tpch.sf1.nation LIMIT);
Query 20150805_151343_00006_z2in4 failed: line 1:58: no viable alternative at input ')'
SELECT COUNT(*) FROM (SELECT * FROM tpch.sf1.nation LIMIT)
```