### PR TITLE
There is a bad contention on `partitions.isEmpty`. 

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -140,16 +140,13 @@ public class BackgroundHiveSplitLoader
 
     private void startLoadSplits()
     {
+        if (stopped || (fileIterators.isEmpty() && partitions.isEmpty())) {
+            return;
+        }
         if (outstandingTasks.incrementAndGet() > maxPartitionBatchSize) {
             outstandingTasks.decrementAndGet();
             return;
         }
-
-        if (stopped || (fileIterators.isEmpty() && partitions.isEmpty())) {
-            outstandingTasks.decrementAndGet();
-            return;
-        }
-
         executor.execute(() -> {
             try {
                 loadSplits();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -140,13 +140,16 @@ public class BackgroundHiveSplitLoader
 
     private void startLoadSplits()
     {
-        if (stopped || (fileIterators.isEmpty() && partitions.isEmpty())) {
-            return;
-        }
         if (outstandingTasks.incrementAndGet() > maxPartitionBatchSize) {
             outstandingTasks.decrementAndGet();
             return;
         }
+
+        if (stopped || (fileIterators.isEmpty() && partitions.isEmpty())) {
+            outstandingTasks.decrementAndGet();
+            return;
+        }
+
         executor.execute(() -> {
             try {
                 loadSplits();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -150,18 +150,18 @@ public class BackgroundHiveSplitLoader
         executor.execute(() -> {
             try {
                 loadSplits();
-                if (outstandingTasks.decrementAndGet() == 0) {
-                    if (fileIterators.isEmpty() && partitions.isEmpty()) {
-                        hiveSplitSource.finished();
-                        return;
-                    }
-                }
                 if (!hiveSplitSource.isQueueFull()) {
                     // Start another task to replace this one
                     startLoadSplits();
                     // Ramp up if we're below the limit and the queue still isn't filled
                     if (outstandingTasks.get() < maxPartitionBatchSize) {
                         startLoadSplits();
+                    }
+                }
+                if (outstandingTasks.decrementAndGet() == 0) {
+                    if (fileIterators.isEmpty() && partitions.isEmpty()) {
+                        hiveSplitSource.finished();
+                        return;
                     }
                 }
             }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -161,7 +161,6 @@ public class BackgroundHiveSplitLoader
                 if (outstandingTasks.decrementAndGet() == 0) {
                     if (fileIterators.isEmpty() && partitions.isEmpty()) {
                         hiveSplitSource.finished();
-                        return;
                     }
                 }
             }


### PR DESCRIPTION
Threads rush to the beginning of `startLoadSplits`, creating contention on `partitions.isEmpty` call without increasing the `outstandingTasks`, eventually one thread (say foo) get `outstandingTasks` equal to zero, although it passes the `fileIterators.isEmpty` check but would again blocks on `partitions.isEmpty`. Other
threads finally get through, poll everything from `partitions` and put them to `fileIterator`. When
thread foo finally gets the chance to check `partitions`, it's empty and then go ahead to stop the
whole thing prematurely, since there are still items in the `fileIterator`.

The fix was to check the `outstandingTasks` later to ensure indeed no other tasks are running when the count drops to zero.