### PR TITLE
Refactor type unification code

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/DisjointSets.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DisjointSets.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class DisjointSets<T>
+{
+    private static class Entry<T>
+    {
+        T parent = null;
+        int depth = 0; // depth of 1-node tree is 0
+    }
+
+    private HashMap<T, Entry> map = new HashMap<>();
+
+    private boolean union(T root1, T root2)
+    {
+        Entry value1 = map.get(root1);
+        Entry value2 = map.get(root2);
+        if (value1 == value2) {
+            return false;
+        }
+        if (value1.depth < value2.depth) {
+            value1.parent = root2; // new parent: root2
+        }
+        else {
+            if (value1.depth == value2.depth) {
+                value1.depth++;
+            }
+            value2.parent = root1; // new parent: root1
+        }
+        return true;
+    }
+
+    public boolean findAndUnion(T node1, T node2)
+    {
+        return union(find(node1), find(node2));
+    }
+
+    public T find(T node)
+    {
+        if (!map.containsKey(node)) {
+            map.put(node, new Entry());
+            return node;
+        }
+        return findInternal(node);
+    }
+
+    public boolean inSameSet(T node1, T node2)
+    {
+        return find(node1).equals(find(node2));
+    }
+
+    public DisjointSets<T> clone()
+    {
+        DisjointSets<T> result = new DisjointSets<>();
+        for (T item : map.keySet()) {
+            result.findAndUnion(item, findInternal(item));
+        }
+        return result;
+    }
+
+    private T findInternal(T node)
+    {
+        Entry<T> value = map.get(node);
+        if (value.parent == null) {
+            return node;
+        }
+        else {
+            value.parent = find(value.parent);
+            return value.parent;
+        }
+    }
+
+    public Collection<Set<T>> getEquivalentClasses()
+    {
+        Map<T, Set<T>> result = new HashMap<>();
+        for (Map.Entry<T, Entry> entry : map.entrySet()) {
+            T node = entry.getKey();
+            T root = find(node);
+            result.computeIfAbsent(root, unused -> new HashSet<>());
+            result.get(root).add(node);
+        }
+        return result.values();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DisjointSets<T> that = (DisjointSets<T>) o;
+
+        if (!map.keySet().equals(that.map.keySet())) {
+            return false;
+        }
+
+        for (T t : map.keySet()) {
+            if (!inSameSet(t, that.find(t))) {
+                return false;
+            }
+        }
+
+        for (T t : that.map.keySet()) {
+            if (!that.inSameSet(t, find(t))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DisjointSetsWithData.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DisjointSetsWithData.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class DisjointSetsWithData<K, V>
+{
+    private final DisjointSets<K> sets;
+    private final Map<K, Set<V>> map;
+
+    public DisjointSetsWithData()
+    {
+        this.sets = new DisjointSets<>();
+        this.map = new HashMap<>();
+    }
+
+    public DisjointSetsWithData(DisjointSets<K> sets, Map<K, Set<V>> map)
+    {
+        this.sets = sets;
+        this.map = map;
+    }
+
+    /**
+     * @return <tt>true</tt> if this structure did not already contain the specified equivalence
+     */
+    public boolean union(K left, K right)
+    {
+        K leftRoot = sets.find(left);
+        K rightRoot = sets.find(right);
+        if (leftRoot.equals(rightRoot)) {
+            return false;
+        }
+        sets.findAndUnion(leftRoot, rightRoot);
+        Set<V> leftVs = map.get(leftRoot);
+        Set<V> rightVs = map.get(rightRoot);
+        if (leftVs == null) {
+            leftVs = rightVs;
+        }
+        else if (rightVs != null) {
+            leftVs.addAll(rightVs);
+            map.remove(leftVs);
+        }
+        map.remove(rightRoot);
+        map.put(sets.find(leftRoot), leftVs);
+        return true;
+    }
+
+    /**
+     * @return <tt>true</tt> if this structure did not already contain the specified equivalence
+     */
+    public boolean put(K key, V value)
+    {
+        K keyRoot = sets.find(key);
+        Set<V> set = map.computeIfAbsent(keyRoot, unused -> new HashSet<>());
+        return set.add(value);
+    }
+
+    public Set<V> get(K key)
+    {
+        return map.computeIfAbsent(sets.find(key), unused -> new HashSet<V>());
+    }
+
+    public Map<K, Set<V>> values()
+    {
+        return map;
+    }
+
+    public Map<Set<K>, Set<V>> toMap()
+    {
+        ImmutableMap.Builder<Set<K>, Set<V>> result = ImmutableMap.builder();
+        for (Set<K> ks : sets.getEquivalentClasses()) {
+            Set<V> vs = get(requireNonNull(Iterables.getFirst(ks, null)));
+            result.put(ks, vs);
+        }
+        return result.build();
+    }
+
+    public DisjointSetsWithData<K, V> clone()
+    {
+        return new DisjointSetsWithData<>(sets.clone(), new HashMap<>(map));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
@@ -16,28 +16,23 @@ package com.facebook.presto.metadata;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.util.ImmutableCollectors;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 import javax.annotation.Nullable;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
-import static com.facebook.presto.metadata.FunctionRegistry.canCoerce;
 import static com.facebook.presto.metadata.FunctionRegistry.mangleOperatorName;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 
 public final class Signature
 {
@@ -197,150 +192,70 @@ public final class Signature
     @Nullable
     public Map<String, Type> bindTypeParameters(Type returnType, List<? extends Type> types, boolean allowCoercion, FunctionRegistry functionRegistry, TypeManager typeManager)
     {
-        Map<String, Type> boundParameters = new HashMap<>();
-        ImmutableMap.Builder<String, TypeParameter> builder = ImmutableMap.builder();
-        for (TypeParameter parameter : typeParameters) {
-            builder.put(parameter.getName(), parameter);
-        }
+        ImmutableList.Builder<TypeSignature> expectedTypeSignaturesBuilder = new ImmutableList.Builder<>();
+        expectedTypeSignaturesBuilder.add(this.returnType);
+        expectedTypeSignaturesBuilder.addAll(argumentTypes);
+        ImmutableList.Builder<TypeSignature> actualTypeSignaturesBuilder = new ImmutableList.Builder<>();
+        actualTypeSignaturesBuilder.add(returnType.getTypeSignature());
+        types.stream().map(Type::getTypeSignature).forEach(actualTypeSignaturesBuilder::add);
 
-        ImmutableMap<String, TypeParameter> parameters = builder.build();
-        if (!matchAndBind(boundParameters, parameters, this.returnType, returnType, allowCoercion, typeManager)) {
+        Map<String, TypeSignature> boundParameters = bindTypeParameters(typeParameters, expectedTypeSignaturesBuilder.build(), actualTypeSignaturesBuilder.build(), allowCoercion, variableArity, typeManager);
+
+        if (boundParameters == null) {
             return null;
         }
 
-        if (!matchArguments(boundParameters, parameters, argumentTypes, types, allowCoercion, variableArity, functionRegistry, typeManager)) {
-            return null;
+        ImmutableMap.Builder<String, Type> resultBuilder = new ImmutableMap.Builder<>();
+        for (Map.Entry<String, TypeSignature> entry : boundParameters.entrySet()) {
+            resultBuilder.put(entry.getKey(), typeManager.getType(entry.getValue()));
         }
-
-        checkState(boundParameters.keySet().equals(parameters.keySet()),
-                "%s matched arguments %s, but type parameters %s are still unbound",
-                this,
-                types,
-                Sets.difference(parameters.keySet(), boundParameters.keySet()));
-
-        return boundParameters;
+        return resultBuilder.build();
     }
 
     @Nullable
     public Map<String, Type> bindTypeParameters(List<? extends Type> types, boolean allowCoercion, FunctionRegistry functionRegistry, TypeManager typeManager)
     {
-        Map<String, Type> boundParameters = new HashMap<>();
-        ImmutableMap.Builder<String, TypeParameter> builder = ImmutableMap.builder();
-        for (TypeParameter parameter : typeParameters) {
-            builder.put(parameter.getName(), parameter);
-        }
+        List<? extends TypeSignature> actualTypeSignatures = types.stream()
+                .map(Type::getTypeSignature)
+                .collect(ImmutableCollectors.toImmutableList());
 
-        ImmutableMap<String, TypeParameter> parameters = builder.build();
-        if (!matchArguments(boundParameters, parameters, argumentTypes, types, allowCoercion, variableArity, functionRegistry, typeManager)) {
+        Map<String, TypeSignature> boundParameters = bindTypeParameters(typeParameters, argumentTypes, actualTypeSignatures, allowCoercion, variableArity, typeManager);
+
+        if (boundParameters == null) {
             return null;
         }
 
-        checkState(boundParameters.keySet().equals(parameters.keySet()), "%s matched arguments %s, but type parameters %s are still unbound", this, types, Sets.difference(parameters.keySet(), boundParameters.keySet()));
-
-        return boundParameters;
+        ImmutableMap.Builder<String, Type> resultBuilder = new ImmutableMap.Builder<>();
+        for (Map.Entry<String, TypeSignature> entry : boundParameters.entrySet()) {
+            resultBuilder.put(entry.getKey(), typeManager.getType(entry.getValue()));
+        }
+        return resultBuilder.build();
     }
 
-    private static boolean matchArguments(
-            Map<String, Type> boundParameters,
-            Map<String, TypeParameter> parameters,
-            List<TypeSignature> argumentTypes,
-            List<? extends Type> types,
+    @Nullable
+    private static Map<String, TypeSignature> bindTypeParameters(
+            List<? extends TypeParameter> typeParameters,
+            List<? extends TypeSignature> expectedTypeSignatures,
+            List<? extends TypeSignature> actualTypeSignatures,
             boolean allowCoercion,
-            boolean varArgs,
-            FunctionRegistry functionRegistry,
+            boolean variableArity,
             TypeManager typeManager)
     {
-        if (varArgs) {
-            if (types.size() < argumentTypes.size() - 1) {
-                return false;
-            }
+        ImmutableMap.Builder<String, TypeParameter> typeParameterMapBuilder = ImmutableMap.builder();
+        for (TypeParameter parameter : typeParameters) {
+            typeParameterMapBuilder.put(parameter.getName(), parameter);
         }
-        else {
-            if (argumentTypes.size() != types.size()) {
-                return false;
-            }
-        }
+        ImmutableMap<String, TypeParameter> typeParameterMap = typeParameterMapBuilder.build();
 
-        // Bind the variable arity argument first, to make sure it's bound to the common super type
-        if (varArgs && types.size() >= argumentTypes.size()) {
-            Optional<Type> superType = functionRegistry.getCommonSuperType(types.subList(argumentTypes.size() - 1, types.size()));
-            if (!superType.isPresent()) {
-                return false;
-            }
-            if (!matchAndBind(boundParameters, parameters, argumentTypes.get(argumentTypes.size() - 1), superType.get(), allowCoercion, typeManager)) {
-                return false;
-            }
+        TypeUnification.TypeUnificationResult unificationResult = TypeUnification.unify(typeParameterMap, expectedTypeSignatures, actualTypeSignatures, allowCoercion, variableArity, typeManager);
+        if (unificationResult == null) {
+            return null;
         }
-
-        for (int i = 0; i < types.size(); i++) {
-            // Get the current argument signature, or the last one, if this is a varargs function
-            TypeSignature typeSignature = argumentTypes.get(Math.min(i, argumentTypes.size() - 1));
-            Type type = types.get(i);
-            if (!matchAndBind(boundParameters, parameters, typeSignature, type, allowCoercion, typeManager)) {
-                return false;
-            }
+        Map<String, TypeSignature> boundParameters = unificationResult.getResolvedTypeParameters();
+        if (!boundParameters.keySet().equals(typeParameterMap.keySet())) {
+            return null;
         }
-
-        return true;
-    }
-
-    private static boolean matchAndBind(Map<String, Type> boundParameters, Map<String, TypeParameter> typeParameters, TypeSignature parameter, Type type, boolean allowCoercion, TypeManager typeManager)
-    {
-        // If this parameter is already bound, then match (with coercion)
-        if (boundParameters.containsKey(parameter.getBase())) {
-            checkArgument(parameter.getParameters().isEmpty(), "Unexpected parameteric type");
-            if (allowCoercion) {
-                if (canCoerce(type, boundParameters.get(parameter.getBase()))) {
-                    return true;
-                }
-                else if (canCoerce(boundParameters.get(parameter.getBase()), type) && typeParameters.get(parameter.getBase()).canBind(type)) {
-                    // Broaden the binding
-                    boundParameters.put(parameter.getBase(), type);
-                    return true;
-                }
-                return false;
-            }
-            else {
-                return type.equals(boundParameters.get(parameter.getBase()));
-            }
-        }
-
-        // Recurse into component types
-        if (!parameter.getParameters().isEmpty()) {
-            if (type.getTypeParameters().size() != parameter.getParameters().size()) {
-                return false;
-            }
-            for (int i = 0; i < parameter.getParameters().size(); i++) {
-                Type componentType = type.getTypeParameters().get(i);
-                TypeSignature componentSignature = parameter.getParameters().get(i);
-                if (!matchAndBind(boundParameters, typeParameters, componentSignature, componentType, allowCoercion, typeManager)) {
-                    return false;
-                }
-            }
-        }
-
-        // Bind parameter, if this is a free type parameter
-        if (typeParameters.containsKey(parameter.getBase())) {
-            TypeParameter typeParameter = typeParameters.get(parameter.getBase());
-            if (!typeParameter.canBind(type)) {
-                return false;
-            }
-            boundParameters.put(parameter.getBase(), type);
-            return true;
-        }
-
-        // We've already checked all the components, so just match the base type
-        if (!parameter.getParameters().isEmpty()) {
-            return type.getTypeSignature().getBase().equals(parameter.getBase());
-        }
-
-        // The parameter is not a type parameter, so it must be a concrete type
-        if (allowCoercion) {
-            return canCoerce(type, typeManager.getType(parseTypeSignature(parameter.getBase())));
-        }
-        else {
-            return type.equals(typeManager.getType(parseTypeSignature(parameter.getBase())));
-        }
+        return boundParameters;
     }
 
     /*

--- a/presto-main/src/main/java/com/facebook/presto/metadata/TypeUnification.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/TypeUnification.java
@@ -1,0 +1,464 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.util.ImmutableCollectors;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.metadata.FunctionRegistry.getCommonSuperTypeSignature;
+import static com.facebook.presto.metadata.FunctionRegistry.isCovariantParameterPosition;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.Objects.requireNonNull;
+
+final class TypeUnification
+{
+    private TypeUnification()
+    {
+    }
+
+    public static class TypeUnificationResult
+    {
+        private final Map<String, TypeSignature> resolvedTypeParameters;
+        private final List<TypeSignature> resolvedArguments;
+
+        public TypeUnificationResult(Map<String, TypeSignature> resolvedTypeParameters, List<TypeSignature> resolvedArguments)
+        {
+            this.resolvedTypeParameters = resolvedTypeParameters;
+            this.resolvedArguments = resolvedArguments;
+        }
+
+        public Map<String, TypeSignature> getResolvedTypeParameters()
+        {
+            return resolvedTypeParameters;
+        }
+
+        public List<TypeSignature> getResolvedArguments()
+        {
+            return resolvedArguments;
+        }
+    }
+
+    private static class SymbolsAndConstraints
+    {
+        private final Set<TypeSymbol> symbols;
+        private final Set<TypeConstraint> concreteConstraints;
+        private final Set<TypeConstraint> otherConstraints;
+
+        private SymbolsAndConstraints(Set<TypeSymbol> symbols, Set<TypeConstraint> concreteConstraints, Set<TypeConstraint> otherConstraints)
+        {
+            this.symbols = symbols;
+            this.concreteConstraints = concreteConstraints;
+            this.otherConstraints = otherConstraints;
+        }
+
+        public static SymbolsAndConstraints of(Set<TypeSymbol> symbols, Set<TypeConstraint> constraints, Set<String> typeParameters)
+        {
+            Set<TypeConstraint> concreteConstraints = new HashSet<>();
+            Set<TypeConstraint> otherConstraints = new HashSet<>();
+            for (TypeConstraint constraint : constraints) {
+                if (constraint.isConcrete(typeParameters)) {
+                    concreteConstraints.add(constraint);
+                }
+                else {
+                    otherConstraints.add(constraint);
+                }
+            }
+            return new SymbolsAndConstraints(symbols, concreteConstraints, otherConstraints);
+        }
+
+        public SymbolsAndConstraints replace(Set<String> typeParameters, Set<String> typeParametersToReplace, TypeSignature resolvedTypeSignature)
+        {
+            Set<TypeConstraint> newConcreteConstraints = new HashSet<>();
+            Set<TypeConstraint> newOtherConstraints = new HashSet<>();
+            newConcreteConstraints.addAll(concreteConstraints);
+            for (TypeConstraint constraint : otherConstraints) {
+                TypeConstraint replacedConstraint = constraint.replace(typeParametersToReplace, resolvedTypeSignature);
+                if (replacedConstraint.isConcrete(typeParameters)) {
+                    newConcreteConstraints.add(replacedConstraint);
+                }
+                else {
+                    newOtherConstraints.add(replacedConstraint);
+                }
+            }
+            return new SymbolsAndConstraints(symbols, newConcreteConstraints, newOtherConstraints);
+        }
+    }
+
+    private static class Equivalences
+    {
+        private final Map<String, TypeSymbol> typeParameterToSymbolMap;
+        private final DisjointSetsWithData<TypeSymbol, TypeConstraint> symbolsToConstraints;
+
+        public Equivalences(Map<String, TypeSymbol> typeParameterToSymbolMap)
+        {
+            this.typeParameterToSymbolMap = typeParameterToSymbolMap;
+            this.symbolsToConstraints = new DisjointSetsWithData<>();
+        }
+
+        public Equivalences(Map<String, TypeSymbol> typeParameterToSymbolMap, DisjointSetsWithData<TypeSymbol, TypeConstraint> symbolsToConstraints)
+        {
+            this.typeParameterToSymbolMap = typeParameterToSymbolMap;
+            this.symbolsToConstraints = symbolsToConstraints;
+        }
+
+        public Equivalences clone()
+        {
+            return new Equivalences(typeParameterToSymbolMap, symbolsToConstraints.clone());
+        }
+
+        /**
+         * @return <tt>true</tt> if this structure did not already contain the specified equivalence
+         */
+        public boolean add(TypeSymbol leftTypeSymbol, TypeSymbol rightTypeSymbol)
+        {
+            return symbolsToConstraints.union(leftTypeSymbol, rightTypeSymbol);
+        }
+
+        /**
+         * @return <tt>true</tt> if this structure did not already contain the specified equivalence
+         */
+        public boolean add(TypeSymbol typeSymbol, TypeConstraint constraint)
+        {
+            TypeSignature constraintTypeSignature = constraint.typeSignature;
+            if (typeParameterToSymbolMap.containsKey(constraintTypeSignature.getBase())) {
+                return add(typeSymbol, typeParameterToSymbolMap.get(constraintTypeSignature.getBase()));
+            }
+            else {
+                return symbolsToConstraints.put(typeSymbol, constraint);
+            }
+        }
+
+        /**
+         * @return <tt>true</tt> if this structure did not already contain the specified equivalence
+         */
+        public boolean add(TypeConstraint leftConstraint, TypeConstraint rightConstraint)
+                throws TypeUnificationFailure
+        {
+            if (typeParameterToSymbolMap.containsKey(leftConstraint.typeSignature.getBase())) {
+                return add(typeParameterToSymbolMap.get(leftConstraint.typeSignature.getBase()), rightConstraint);
+            }
+            else if (typeParameterToSymbolMap.containsKey(rightConstraint.typeSignature.getBase())) {
+                return add(typeParameterToSymbolMap.get(rightConstraint.typeSignature.getBase()), leftConstraint);
+            }
+            // do nothing if neither side is a symbol
+            return false;
+        }
+
+        public List<SymbolsAndConstraints> toSymbolsAndConstraints(Set<String> typeParameters)
+        {
+            ImmutableList.Builder<SymbolsAndConstraints> result = new ImmutableList.Builder<>();
+            for (Map.Entry<Set<TypeSymbol>, Set<TypeConstraint>> entry : symbolsToConstraints.toMap().entrySet()) {
+                SymbolsAndConstraints symbolsAndConstraints = SymbolsAndConstraints.of(entry.getKey(), entry.getValue(), typeParameters);
+                result.add(symbolsAndConstraints);
+            }
+            return result.build();
+        }
+    }
+
+    private static class TypeSymbol
+    {
+    }
+
+    private static class TypeConstraint
+    {
+        private final TypeSignature typeSignature;
+        private final boolean canCoerce;
+
+        public TypeConstraint(TypeSignature typeSignature, boolean canCoerce)
+        {
+            this.typeSignature = requireNonNull(typeSignature);
+            this.canCoerce = canCoerce;
+        }
+
+        public boolean isConcrete(Set<String> typeParameters)
+        {
+            return isConcrete(typeSignature, typeParameters);
+        }
+
+        public static boolean isConcrete(TypeSignature typeSignature, Set<String> typeParameters)
+        {
+            if (typeParameters.contains(typeSignature.getBase())) {
+                return false;
+            }
+            for (TypeSignature subSignature : typeSignature.getParameters()) {
+                if (!isConcrete(subSignature, typeParameters)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public TypeConstraint replace(Set<String> typeParametersToReplace, TypeSignature resolvedTypeSignature)
+        {
+            return new TypeConstraint(replace(typeSignature, typeParametersToReplace, resolvedTypeSignature), canCoerce);
+        }
+
+        public static TypeSignature replace(TypeSignature typeSignature, Set<String> typeParametersToReplace, TypeSignature resolvedTypeSignature)
+        {
+            if (typeParametersToReplace.contains(typeSignature.getBase())) {
+                return resolvedTypeSignature;
+            }
+            ImmutableList.Builder<TypeSignature> newSubSignatures = new ImmutableList.Builder<>();
+            for (TypeSignature subSignature : typeSignature.getParameters()) {
+                newSubSignatures.add(replace(subSignature, typeParametersToReplace, resolvedTypeSignature));
+            }
+            return new TypeSignature(typeSignature.getBase(), newSubSignatures.build(), typeSignature.getLiteralParameters());
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            TypeConstraint that = (TypeConstraint) o;
+
+            if (canCoerce != that.canCoerce) {
+                return false;
+            }
+            if (!typeSignature.equals(that.typeSignature)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return 31 * typeSignature.hashCode() + (canCoerce ? 1 : 0);
+        }
+    }
+
+    private static class TypeUnificationFailure
+            extends Exception
+    {
+    }
+
+    private static void checkCondition(boolean expr)
+            throws TypeUnificationFailure
+    {
+        if (!expr) {
+            throw new TypeUnificationFailure();
+        }
+    }
+
+    public static TypeUnificationResult unify(
+            Map<String, TypeParameter> typeParameterMap,
+            List<? extends TypeSignature> expectedTypes,
+            List<? extends TypeSignature> actualTypes,
+            boolean allowCoercion,
+            boolean variableArity,
+            TypeManager typeManager)
+    {
+        Set<String> typeParameters = typeParameterMap.keySet();
+        Map<TypeSymbol, TypeParameter> typeSymbolToParameterMap = new HashMap<>();
+        Map<String, TypeSymbol> typeParameterToSymbolMap = new HashMap<>();
+        for (Map.Entry<String, TypeParameter> entry : typeParameterMap.entrySet()) {
+            TypeSymbol symbol = new TypeSymbol();
+            typeParameterToSymbolMap.put(entry.getKey(), symbol);
+            typeSymbolToParameterMap.put(symbol, entry.getValue());
+        }
+
+        Equivalences equivalences = new Equivalences(typeParameterToSymbolMap);
+        ArrayList<TypeSymbol> symbolForActualTypes = new ArrayList<>(actualTypes.size());
+
+        try {
+            if (variableArity) {
+                checkCondition(expectedTypes.size() - 1 <= actualTypes.size());
+            }
+            else {
+                checkCondition(expectedTypes.size() == actualTypes.size());
+            }
+
+            for (int i = 0; i < Math.min(actualTypes.size(), expectedTypes.size()); i++) {
+                TypeSymbol symbol = new TypeSymbol();
+                symbolForActualTypes.add(symbol);
+                TypeSignature actualType = actualTypes.get(i);
+                equivalences.add(symbol, new TypeConstraint(actualType, allowCoercion));
+                equivalences.add(symbol, new TypeConstraint(expectedTypes.get(i), false));
+            }
+
+            // this for loop only runs if expectedTypes.size() + 1 <= actualTypes.size()
+            for (int i = expectedTypes.size(); i < actualTypes.size(); i++) {
+                equivalences.add(symbolForActualTypes.get(expectedTypes.size() - 1), new TypeConstraint(actualTypes.get(i), allowCoercion));
+            }
+
+            equivalences = deriveEquivalences(equivalences);
+
+            Map<TypeSymbol, TypeSignature> resolvedSymbols = analyzeEquivalences(equivalences.toSymbolsAndConstraints(typeParameters), typeParameters, typeSymbolToParameterMap, typeManager);
+
+            List<TypeSignature> resolvedArguments = symbolForActualTypes.stream()
+                    .map(resolvedSymbols::get)
+                    .collect(Collectors.toList());
+            ImmutableMap.Builder<String, TypeSignature> resolvedTypeParameters = new ImmutableMap.Builder<>();
+            for (String typeParameter : typeParameterMap.keySet()) {
+                TypeSignature resolvedTo = resolvedSymbols.get(typeParameterToSymbolMap.get(typeParameter));
+                if (resolvedTo != null) {
+                    resolvedTypeParameters.put(typeParameter, resolvedTo);
+                }
+            }
+            return new TypeUnificationResult(resolvedTypeParameters.build(), resolvedArguments);
+        }
+        catch (TypeUnificationFailure e) {
+            return null;
+        }
+    }
+
+    public static Equivalences deriveEquivalences(Equivalences inputEquivalence)
+            throws TypeUnificationFailure
+    {
+        Equivalences oldEquivalences = inputEquivalence;
+        while (true) {
+            Equivalences newEquivalences = oldEquivalences.clone();
+            boolean newEquivalenceDerived = false;
+            for (Map.Entry<TypeSymbol, Set<TypeConstraint>> entry : oldEquivalences.symbolsToConstraints.values().entrySet()) {
+                TypeSymbol typeSymbol = entry.getKey();
+                Set<TypeConstraint> constraints = entry.getValue();
+                Set<TypeConstraint> newConstraints = newEquivalences.symbolsToConstraints.get(typeSymbol);
+                for (TypeConstraint constraint : constraints) {
+                    for (TypeConstraint newConstraint : newConstraints) {
+                        newEquivalenceDerived = doDeriveEquivalence(newEquivalences, constraint, newConstraint) || newEquivalenceDerived;
+                    }
+                }
+            }
+            if (!newEquivalenceDerived) {
+                break;
+            }
+            oldEquivalences = newEquivalences;
+        }
+        return oldEquivalences;
+    }
+
+    /**
+     * @return <tt>true</tt> if any new equivalence or constraint is derived.
+     */
+    public static boolean doDeriveEquivalence(Equivalences equiv, TypeConstraint leftConstraint, TypeConstraint rightConstraint)
+            throws TypeUnificationFailure
+    {
+        List<TypeSignature> leftTypeTypeParameters = leftConstraint.typeSignature.getParameters();
+        List<TypeSignature> rightTypeTypeParameters = rightConstraint.typeSignature.getParameters();
+        if ((leftTypeTypeParameters.size() == 0) != (rightTypeTypeParameters.size() == 0)) {
+            // exactly one of expectedTypeParameters and actualTypeParameters has size 0
+            return equiv.add(leftConstraint, rightConstraint);
+        }
+
+        // now that either: (1) both side are empty or, (2) neither side is empty
+        checkCondition(leftTypeTypeParameters.size() == rightTypeTypeParameters.size());
+        int parameterCount = leftTypeTypeParameters.size();
+
+        boolean newEquivalenceDerived = false;
+        if (parameterCount == 0) {
+            newEquivalenceDerived = equiv.add(leftConstraint, rightConstraint) || newEquivalenceDerived;
+        }
+        else {
+            // It is known at this point that base types of both sides are concrete types because T cannot have type parameters. e.g. T<int> is not allowed.
+            // Knowing this, it is not this method's concern how and whether leftConstraint.typeSignature.getBase() match with rightConstraint.typeSignature.getBase()
+            for (int i = 0; i < leftTypeTypeParameters.size(); i++) {
+                newEquivalenceDerived =
+                        equiv.add(new TypeConstraint(leftTypeTypeParameters.get(i), leftConstraint.canCoerce && isCovariantParameterPosition(leftConstraint.typeSignature.getBase(), i)),
+                        new TypeConstraint(rightTypeTypeParameters.get(i), rightConstraint.canCoerce && isCovariantParameterPosition(rightConstraint.typeSignature.getBase(), i)))
+                        || newEquivalenceDerived;
+            }
+        }
+        return newEquivalenceDerived;
+    }
+
+    public static Map<TypeSymbol, TypeSignature> analyzeEquivalences(
+            List<SymbolsAndConstraints> equivalences,
+            Set<String> typeParameters,
+            Map<TypeSymbol, TypeParameter> typeSymbolToParameterMap,
+            TypeManager typeManager)
+            throws TypeUnificationFailure
+    {
+        Map<TypeSymbol, TypeSignature> result = new HashMap<>();
+        Queue<SymbolsAndConstraints> queue = new ArrayDeque<>(equivalences.size());
+        List<SymbolsAndConstraints> newEquivalences = new ArrayList<>(equivalences.size());
+        for (SymbolsAndConstraints symbolsAndConstraints : equivalences) {
+            if (symbolsAndConstraints.otherConstraints.isEmpty()) {
+                queue.add(symbolsAndConstraints);
+            }
+            else {
+                newEquivalences.add(symbolsAndConstraints);
+            }
+        }
+        equivalences = newEquivalences;
+
+        while (!queue.isEmpty()) {
+            SymbolsAndConstraints symbolsAndConstraints = queue.remove();
+            Set<TypeConstraint> concreteConstraints = symbolsAndConstraints.concreteConstraints;
+
+            if (concreteConstraints.size() == 0) {
+                continue; // Still unbound after inference
+            }
+            TypeSignature resolvedTypeSignature;
+            if (concreteConstraints.size() == 1) {
+                resolvedTypeSignature = getOnlyElement(concreteConstraints).typeSignature;
+            }
+            else {
+                Optional<TypeSignature> commonSuperTypeSignature = getCommonSuperTypeSignature(concreteConstraints.stream()
+                        .map(typeConstraint -> typeConstraint.typeSignature)
+                        .collect(ImmutableCollectors.toImmutableList()));
+                checkCondition(commonSuperTypeSignature.isPresent());
+                resolvedTypeSignature = commonSuperTypeSignature.get();
+                for (TypeConstraint concreteConstraint : concreteConstraints) {
+                    checkCondition(concreteConstraint.canCoerce || resolvedTypeSignature.equals(concreteConstraint.typeSignature));
+                }
+            }
+            Type resolvedType = typeManager.getType(resolvedTypeSignature);
+            Set<String> typeParametersToReplace = new HashSet<>();
+            for (TypeSymbol typeSymbol : symbolsAndConstraints.symbols) {
+                TypeParameter typeParameter = typeSymbolToParameterMap.get(typeSymbol);
+                if (typeParameter != null) {
+                    checkCondition(typeParameter.canBind(resolvedType));
+                    typeParametersToReplace.add(typeParameter.getName());
+                }
+                result.put(typeSymbol, resolvedTypeSignature);
+            }
+
+            newEquivalences = new ArrayList<>(equivalences.size());
+            for (SymbolsAndConstraints beforeReplace : equivalences) {
+                SymbolsAndConstraints afterReplace = beforeReplace.replace(typeParameters, typeParametersToReplace, resolvedTypeSignature);
+                if (afterReplace.otherConstraints.isEmpty()) {
+                    queue.add(afterReplace);
+                }
+                else {
+                    newEquivalences.add(afterReplace);
+                }
+            }
+            equivalences = newEquivalences;
+        }
+
+        return result;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -85,7 +85,6 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static com.facebook.presto.metadata.FunctionRegistry.canCoerce;
-import static com.facebook.presto.metadata.FunctionRegistry.getCommonSuperType;
 import static com.facebook.presto.metadata.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -394,7 +393,7 @@ public class ExpressionAnalyzer
             Type firstType = process(node.getFirst(), context);
             Type secondType = process(node.getSecond(), context);
 
-            if (!getCommonSuperType(firstType, secondType).isPresent()) {
+            if (!functionRegistry.getCommonSuperType(firstType, secondType).isPresent()) {
                 throw new SemanticException(TYPE_MISMATCH, node, "Types are not comparable with NULLIF: %s vs %s", firstType, secondType);
             }
 
@@ -903,7 +902,7 @@ public class ExpressionAnalyzer
             // determine super type
             Type superType = UNKNOWN;
             for (Expression expression : expressions) {
-                Optional<Type> newSuperType = getCommonSuperType(superType, process(expression, context));
+                Optional<Type> newSuperType = functionRegistry.getCommonSuperType(superType, process(expression, context));
                 if (!newSuperType.isPresent()) {
                     throw new SemanticException(TYPE_MISMATCH, expression, message, superType);
                 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/TupleAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/TupleAnalyzer.java
@@ -15,7 +15,6 @@ package com.facebook.presto.sql.analyzer;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.FunctionInfo;
-import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataUtil;
 import com.facebook.presto.metadata.QualifiedTableName;
@@ -92,7 +91,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.metadata.FunctionRegistry.getCommonSuperType;
 import static com.facebook.presto.metadata.ViewDefinition.ViewColumn;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -388,7 +386,7 @@ public class TupleAnalyzer
             }
             for (int i = 0; i < descriptor.getVisibleFields().size(); i++) {
                 Type descFieldType = descriptor.getFieldByIndex(i).getType();
-                Optional<Type> commonSuperType = FunctionRegistry.getCommonSuperType(outputFieldTypes[i], descFieldType);
+                Optional<Type> commonSuperType = metadata.getFunctionRegistry().getCommonSuperType(outputFieldTypes[i], descFieldType);
                 if (!commonSuperType.isPresent()) {
                     throw new SemanticException(TYPE_MISMATCH,
                                                 node,
@@ -562,7 +560,7 @@ public class TupleAnalyzer
     {
         Type leftType = analysis.getType(leftExpression);
         Type rightType = analysis.getType(rightExpression);
-        Optional<Type> superType = FunctionRegistry.getCommonSuperType(leftType, rightType);
+        Optional<Type> superType = metadata.getFunctionRegistry().getCommonSuperType(leftType, rightType);
         if (!superType.isPresent()) {
             throw new SemanticException(TYPE_MISMATCH, node, "Join criteria has incompatible types: %s, %s", leftType.getDisplayName(), rightType.getDisplayName());
         }
@@ -597,7 +595,7 @@ public class TupleAnalyzer
                 Type fieldType = rowType.get(i);
                 Type superType = fieldTypes.get(i);
 
-                Optional<Type> commonSuperType = getCommonSuperType(fieldType, superType);
+                Optional<Type> commonSuperType = metadata.getFunctionRegistry().getCommonSuperType(fieldType, superType);
                 if (!commonSuperType.isPresent()) {
                     throw new SemanticException(MISMATCHED_SET_COLUMN_TYPES,
                             node,

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/ByteCodeExpressionVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/ByteCodeExpressionVisitor.java
@@ -70,7 +70,7 @@ public class ByteCodeExpressionVisitor
                     generator = new IfCodeGenerator();
                     break;
                 case NULL_IF:
-                    generator = new NullIfCodeGenerator();
+                    generator = new NullIfCodeGenerator(registry);
                     break;
                 case SWITCH:
                     // (SWITCH <expr> (WHEN <expr> <expr>) (WHEN <expr> <expr>) <expr>)

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/NullIfCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/NullIfCodeGenerator.java
@@ -33,6 +33,13 @@ import static com.facebook.presto.byteCode.expression.ByteCodeExpressions.consta
 public class NullIfCodeGenerator
         implements ByteCodeGenerator
 {
+    private final FunctionRegistry functionRegistry;
+
+    public NullIfCodeGenerator(FunctionRegistry functionRegistry)
+    {
+        this.functionRegistry = functionRegistry;
+    }
+
     @Override
     public ByteCodeNode generateExpression(Signature signature, ByteCodeGeneratorContext generatorContext, Type returnType, List<RowExpression> arguments)
     {
@@ -54,7 +61,7 @@ public class NullIfCodeGenerator
 
         // this is a hack! We shouldn't be determining type coercions at this point, but there's no way
         // around it in the current expression AST
-        Type commonType = FunctionRegistry.getCommonSuperType(firstType, secondType).get();
+        Type commonType = functionRegistry.getCommonSuperType(firstType, secondType).get();
 
         // if (equal(cast(first as <common type>), cast(second as <common type>))
         FunctionInfo equalsFunction = generatorContext.getRegistry().resolveOperator(OperatorType.EQUAL, ImmutableList.of(firstType, secondType));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -629,7 +629,7 @@ public class ExpressionInterpreter
                 return new NullIfExpression(toExpression(first, firstType), toExpression(second, secondType));
             }
 
-            Type commonType = FunctionRegistry.getCommonSuperType(firstType, secondType).get();
+            Type commonType = metadata.getFunctionRegistry().getCommonSuperType(firstType, secondType).get();
 
             FunctionInfo firstCast = metadata.getFunctionRegistry().getCoercion(firstType, commonType);
             FunctionInfo secondCast = metadata.getFunctionRegistry().getCoercion(secondType, commonType);

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionRegistry.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionRegistry.java
@@ -26,13 +26,26 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
+import static com.facebook.presto.metadata.FunctionRegistry.canCoerce;
 import static com.facebook.presto.metadata.FunctionRegistry.getMagicLiteralFunctionSignature;
 import static com.facebook.presto.metadata.FunctionRegistry.mangleOperatorName;
 import static com.facebook.presto.metadata.FunctionRegistry.unmangleOperator;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.HyperLogLogType.HYPER_LOG_LOG;
+import static com.facebook.presto.spi.type.TimeType.TIME;
+import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.type.JsonPathType.JSON_PATH;
+import static com.facebook.presto.type.LikePatternType.LIKE_PATTERN;
+import static com.facebook.presto.type.RegexpType.REGEXP;
 import static com.facebook.presto.type.TypeUtils.resolveTypes;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.collect.Lists.transform;
 import static org.testng.Assert.assertEquals;
@@ -130,6 +143,29 @@ public class TestFunctionRegistry
         assertTrue(names.contains("stddev"), "Expected function names " + names + " to contain 'stddev'");
         assertTrue(names.contains("rank"), "Expected function names " + names + " to contain 'rank'");
         assertFalse(names.contains("like"), "Expected function names " + names + " not to contain 'like'");
+    }
+
+    @Test
+    public void testCanCoerce()
+    {
+        assertTrue(canCoerce(BIGINT, BIGINT));
+
+        assertTrue(canCoerce(UNKNOWN, BIGINT));
+        assertFalse(canCoerce(BIGINT, UNKNOWN));
+
+        assertTrue(canCoerce(BIGINT, DOUBLE));
+        assertTrue(canCoerce(DATE, TIMESTAMP));
+        assertTrue(canCoerce(DATE, TIMESTAMP_WITH_TIME_ZONE));
+        assertTrue(canCoerce(TIME, TIME_WITH_TIME_ZONE));
+        assertTrue(canCoerce(TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE));
+        assertTrue(canCoerce(VARCHAR, REGEXP));
+        assertTrue(canCoerce(VARCHAR, LIKE_PATTERN));
+        assertTrue(canCoerce(VARCHAR, JSON_PATH));
+
+        assertFalse(canCoerce(DOUBLE, BIGINT));
+        assertFalse(canCoerce(TIMESTAMP, TIME_WITH_TIME_ZONE));
+        assertFalse(canCoerce(TIMESTAMP_WITH_TIME_ZONE, TIMESTAMP));
+        assertFalse(canCoerce(VARBINARY, VARCHAR));
     }
 
     public static final class ScalarSum

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestSignature.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestSignature.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.metadata;
 
+import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -43,6 +44,9 @@ import static org.testng.Assert.assertNull;
 
 public class TestSignature
 {
+    TypeManager typeManager = new TypeRegistry();
+    FunctionRegistry functionRegistry = new FunctionRegistry(typeManager, new BlockEncodingManager(typeManager), false);
+
     @Test
     public void testRoundTrip()
     {
@@ -64,12 +68,11 @@ public class TestSignature
     public void testBasic()
             throws Exception
     {
-        TypeManager typeManager = new TypeRegistry();
         Signature signature = new Signature("foo", ImmutableList.of(typeParameter("T")), "T", ImmutableList.of("T"), false, true);
-        assertNotNull(signature.bindTypeParameters(ImmutableList.<Type>of(BIGINT), true, typeManager));
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR), true, typeManager));
-        assertNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR, BIGINT), true, typeManager));
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>"))), true, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.<Type>of(BIGINT), true, functionRegistry, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR), true, functionRegistry, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR, BIGINT), true, functionRegistry, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>"))), true, functionRegistry, typeManager));
     }
 
     @Test
@@ -78,91 +81,85 @@ public class TestSignature
     {
         TypeManager typeManager = new TypeRegistry();
         Signature signature = new Signature("foo", ImmutableList.<TypeParameter>of(), "boolean", ImmutableList.of("bigint"), false, true);
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(BIGINT), true, typeManager));
-        assertNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR), true, typeManager));
-        assertNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR, BIGINT), true, typeManager));
-        assertNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>"))), true, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(BIGINT), true, functionRegistry, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR), true, functionRegistry, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR, BIGINT), true, functionRegistry, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>"))), true, functionRegistry, typeManager));
     }
 
     @Test
     public void testArray()
             throws Exception
     {
-        TypeManager typeManager = new TypeRegistry();
         Signature signature = new Signature("get", ImmutableList.of(typeParameter("T")), "T", ImmutableList.of("array<T>"), false, true);
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>"))), true, typeManager));
-        assertNull(signature.bindTypeParameters(ImmutableList.of(BIGINT), true, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>"))), true, functionRegistry, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(BIGINT), true, functionRegistry, typeManager));
 
         signature = new Signature("contains", ImmutableList.of(comparableTypeParameter("T")), "T", ImmutableList.of("array<T>", "T"), false, true);
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>")), BIGINT), true, typeManager));
-        assertNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>")), VARCHAR), true, typeManager));
-        assertNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<HyperLogLog>")), HYPER_LOG_LOG), true, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>")), BIGINT), true, functionRegistry, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>")), VARCHAR), true, functionRegistry, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<HyperLogLog>")), HYPER_LOG_LOG), true, functionRegistry, typeManager));
 
         signature = new Signature("foo", ImmutableList.of(typeParameter("T")), "T", ImmutableList.of("array<T>", "array<T>"), false, true);
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>")), typeManager.getType(parseTypeSignature("array<bigint>"))), true, typeManager));
-        assertNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>")), typeManager.getType(parseTypeSignature("array<varchar>"))), true, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>")), typeManager.getType(parseTypeSignature("array<bigint>"))), true, functionRegistry, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("array<bigint>")), typeManager.getType(parseTypeSignature("array<varchar>"))), true, functionRegistry, typeManager));
     }
 
     @Test
     public void testMap()
             throws Exception
     {
-        TypeManager typeManager = new TypeRegistry();
         Signature signature = new Signature("get", ImmutableList.of(typeParameter("K"), typeParameter("V")), "V", ImmutableList.of("map<K,V>", "K"), false, true);
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("map<bigint,varchar>")), BIGINT), true, typeManager));
-        assertNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("map<bigint,varchar>")), VARCHAR), true, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("map<bigint,varchar>")), BIGINT), true, functionRegistry, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(typeManager.getType(parseTypeSignature("map<bigint,varchar>")), VARCHAR), true, functionRegistry, typeManager));
     }
 
     @Test
     public void testVariadic()
             throws Exception
     {
-        TypeManager typeManager = new TypeRegistry();
         Type mapType = typeManager.getType(parseTypeSignature("map<bigint,bigint>"));
         Type arrayType = typeManager.getType(parseTypeSignature("array<bigint>"));
         Signature signature = new Signature("foo", ImmutableList.of(withVariadicBound("T", "map")), "bigint", ImmutableList.of("T"), true, true);
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(mapType), true, typeManager));
-        assertNull(signature.bindTypeParameters(ImmutableList.of(arrayType), true, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(mapType), true, functionRegistry, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(arrayType), true, functionRegistry, typeManager));
     }
 
     @Test
     public void testVarArgs()
             throws Exception
     {
-        TypeManager typeManager = new TypeRegistry();
         Signature signature = new Signature("foo", ImmutableList.of(typeParameter("T")), "boolean", ImmutableList.of("T"), true, true);
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(BIGINT), true, typeManager));
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR), true, typeManager));
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(BIGINT, BIGINT), true, typeManager));
-        assertNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR, BIGINT), true, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(BIGINT), true, functionRegistry, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR), true, functionRegistry, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(BIGINT, BIGINT), true, functionRegistry, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR, BIGINT), true, functionRegistry, typeManager));
     }
 
     @Test
     public void testCoercion()
             throws Exception
     {
-        TypeManager typeManager = new TypeRegistry();
         Signature signature = new Signature("foo", ImmutableList.of(typeParameter("T")), "boolean", ImmutableList.of("T", "double"), true, true);
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(DOUBLE, DOUBLE), true, typeManager));
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(BIGINT, BIGINT), true, typeManager));
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR, BIGINT), true, typeManager));
-        assertNull(signature.bindTypeParameters(ImmutableList.of(BIGINT, VARCHAR), true, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(DOUBLE, DOUBLE), true, functionRegistry, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(BIGINT, BIGINT), true, functionRegistry, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR, BIGINT), true, functionRegistry, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(BIGINT, VARCHAR), true, functionRegistry, typeManager));
     }
 
     @Test
     public void testUnknownCoercion()
             throws Exception
     {
-        TypeManager typeManager = new TypeRegistry();
         Signature signature = new Signature("foo", ImmutableList.of(typeParameter("T")), "boolean", ImmutableList.of("T", "T"), false, true);
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(UNKNOWN, UNKNOWN), true, typeManager));
-        assertNotNull(signature.bindTypeParameters(ImmutableList.of(UNKNOWN, BIGINT), true, typeManager));
-        assertNull(signature.bindTypeParameters(ImmutableList.of(BIGINT, VARCHAR), true, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(UNKNOWN, UNKNOWN), true, functionRegistry, typeManager));
+        assertNotNull(signature.bindTypeParameters(ImmutableList.of(UNKNOWN, BIGINT), true, functionRegistry, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(BIGINT, VARCHAR), true, functionRegistry, typeManager));
 
         signature = new Signature("foo", ImmutableList.of(comparableTypeParameter("T")), "boolean", ImmutableList.of("T", "T"), false, true);
-        Map<String, Type> boundParameters = signature.bindTypeParameters(ImmutableList.of(UNKNOWN, BIGINT), true, typeManager);
+        Map<String, Type> boundParameters = signature.bindTypeParameters(ImmutableList.of(UNKNOWN, BIGINT), true, functionRegistry, typeManager);
         assertNotNull(boundParameters);
         assertEquals(boundParameters.get("T"), BIGINT);
-        assertNull(signature.bindTypeParameters(ImmutableList.of(BIGINT, VARCHAR), true, typeManager));
+        assertNull(signature.bindTypeParameters(ImmutableList.of(BIGINT, VARCHAR), true, functionRegistry, typeManager));
     }
 }


### PR DESCRIPTION
The first commit refactors getCommonSuperType and canCoerce:
* Coercion rules were duplicated in the original code (and diverged).   The rules appear only once in the code after this commit.
* Coercion between types with type parameters (e.g. array<T> and array<U>)  could be arbitrary and potentially complex. After this commit,  coercibility between types is decoupled into 2 parts: compatibility between their based types and between their type parameters.

The second commit refactors type unification code to make it more flexible so that it can be extended to support more complex use cases (lambda).