### PR TITLE
Use correct table name in AbstractTestHiveClient.doCreateTable

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1331,7 +1331,7 @@ public abstract class AbstractTestHiveClient
                 .build();
 
         Map<String, Object> properties = ImmutableMap.of(STORAGE_FORMAT_PROPERTY, storageFormat);
-        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(temporaryCreateTable, columns, properties, SESSION.getUser());
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(tableName, columns, properties, SESSION.getUser());
 
         ConnectorOutputTableHandle outputHandle = metadata.beginCreateTable(SESSION, tableMetadata);
 


### PR DESCRIPTION
Test was creting a table using a name in a class field and then
verifying the created table using a name from a method parameter.