### PR TITLE
Fix missed memory tracking at HashBuilderOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/InMemoryJoinHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/InMemoryJoinHash.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import static com.facebook.presto.operator.SyntheticAddress.decodePosition;
 import static com.facebook.presto.operator.SyntheticAddress.decodeSliceIndex;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfBooleanArray;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
 
@@ -53,7 +54,8 @@ public final class InMemoryJoinHash
 
         // reserve memory for the arrays
         int hashSize = HashCommon.arraySize(addresses.size(), 0.75f);
-        size = sizeOfIntArray(hashSize) + sizeOfBooleanArray(hashSize) + sizeOfIntArray(addresses.size());
+        size = sizeOfIntArray(hashSize) + sizeOfBooleanArray(hashSize) + sizeOfIntArray(addresses.size())
+                +  sizeOf(addresses.elements()) + pagesHashStrategy.getSizeInBytes();
 
         mask = hashSize - 1;
         key = new int[hashSize];

--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -121,7 +121,7 @@ public class MultiChannelGroupByHash
     {
         return (sizeOf(channelBuilders.get(0).elements()) * channelBuilders.size()) +
                 completedPagesMemorySize +
-                currentPageBuilder.getSizeInBytes() +
+                currentPageBuilder.getRetainedSizeInBytes() +
                 sizeOf(groupAddressByHash) +
                 sizeOf(groupIdsByHash) +
                 groupAddressByGroupId.sizeOf();
@@ -295,7 +295,7 @@ public class MultiChannelGroupByHash
     private void startNewPage()
     {
         if (currentPageBuilder != null) {
-            completedPagesMemorySize += currentPageBuilder.getSizeInBytes();
+            completedPagesMemorySize += currentPageBuilder.getRetainedSizeInBytes();
         }
 
         currentPageBuilder = new PageBuilder(types);

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesHashStrategy.java
@@ -25,6 +25,11 @@ public interface PagesHashStrategy
     int getChannelCount();
 
     /**
+     * Get the total of allocated size
+     */
+    long getSizeInBytes();
+
+    /**
      * Appends all values at the specified position to the page builder starting at {@code outputChannelOffset}.
      */
     void appendTo(int blockIndex, int position, PageBuilder pageBuilder, int outputChannelOffset);

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
@@ -55,6 +55,15 @@ public class SimplePagesHashStrategy
     }
 
     @Override
+    public long getSizeInBytes()
+    {
+        return channels.stream()
+                .flatMap(List::stream)
+                .mapToLong(Block::getRetainedSizeInBytes)
+                .sum();
+    }
+
+    @Override
     public void appendTo(int blockIndex, int position, PageBuilder pageBuilder, int outputChannelOffset)
     {
         for (int i = 0; i < channels.size(); i++) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
@@ -179,6 +179,12 @@ public class TestJoinCompiler
 
         // verify channel count
         assertEquals(hashStrategy.getChannelCount(), types.size());
+        // verify size
+        long sizeInBytes = channels.stream()
+                .flatMap(List::stream)
+                .mapToLong(Block::getRetainedSizeInBytes)
+                .sum();
+        assertEquals(hashStrategy.getSizeInBytes(), sizeInBytes);
 
         // verify hashStrategy is consistent with equals and hash code from block
         for (int leftBlockIndex = 0; leftBlockIndex < varcharChannel.size(); leftBlockIndex++) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/PageBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/PageBuilder.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.type.Type;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static com.facebook.presto.spi.block.BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
 import static com.facebook.presto.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
@@ -96,6 +97,11 @@ public class PageBuilder
     public long getSizeInBytes()
     {
         return pageBuilderStatus.getSizeInBytes();
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return Stream.of(blockBuilders).mapToLong(BlockBuilder::getRetainedSizeInBytes).sum();
     }
 
     public Page build()


### PR DESCRIPTION
I found that some memory usages are not collected correctly. 
* `PageBuilder.getSizeInBytres` returns  used bytes not allocated bytes. '
* `InMemoryJoinHash` which is created from `PagesIndex.createLookupSource` only returns its own data structures size at `getInMemorySizeInBytes`.

I tried making  `InMemoryJoinHash.getInMemorySizeInBytes ` return total memory usage including `PagesIndex` had used, But it required several interface changes at `JoinCompiler`