### PR TITLE
Fix starvation and more races in BackgroundHiveSplitLoader

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -173,14 +173,15 @@ public class BackgroundHiveSplitLoader
                 finally {
                     taskExecutionLock.readLock().unlock();
                 }
+                // Decrement must happen before starting new splits. It will otherwise lead to starvation.
+                if (outstandingTasks.decrementAndGet() == 0) {
+                    invokeFinishedIfShould();
+                }
                 if (!hiveSplitSource.isQueueFull()) {
                     // Start another task to replace this one
                     startLoadSplits();
                     // Ramp up if we're below the limit and the queue still isn't filled
                     startLoadSplits();
-                }
-                if (outstandingTasks.decrementAndGet() == 0) {
-                    invokeFinishedIfShould();
                 }
             }
             catch (Exception e) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitLoader.java
@@ -17,7 +17,5 @@ interface HiveSplitLoader
 {
     void start(HiveSplitSource splitSource);
 
-    void resume();
-
     void stop();
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -375,7 +375,7 @@ public class HiveSplitManager
                 maxInitialSplits,
                 recursiveDfsWalkerEnabled);
 
-        HiveSplitSource splitSource = new HiveSplitSource(connectorId, maxOutstandingSplits, hiveSplitLoader);
+        HiveSplitSource splitSource = new HiveSplitSource(connectorId, maxOutstandingSplits, hiveSplitLoader, executor);
         hiveSplitLoader.start(splitSource);
 
         return splitSource;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/ResumableTask.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/ResumableTask.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.util;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface ResumableTask
+{
+    /**
+     * Process the task either fully, or in part.
+     *
+     * @return a finished status if the task is complete, otherwise includes a continuation future to indicate
+     * when it should be continued to be processed.
+     */
+    TaskStatus process();
+
+    class TaskStatus
+    {
+        private final boolean finished;
+        private final CompletableFuture<?> continuationFuture;
+
+        private TaskStatus(boolean finished, CompletableFuture<?> continuationFuture)
+        {
+            this.finished = finished;
+            this.continuationFuture = continuationFuture;
+        }
+
+        public static TaskStatus finished()
+        {
+            return new TaskStatus(true, CompletableFuture.completedFuture(null));
+        }
+
+        public static TaskStatus continueOn(CompletableFuture<?> continuationFuture)
+        {
+            return new TaskStatus(false, continuationFuture);
+        }
+
+        public boolean isFinished()
+        {
+            return finished;
+        }
+
+        public CompletableFuture<?> getContinuationFuture()
+        {
+            return continuationFuture;
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/ResumableTasks.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/ResumableTasks.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.util;
+
+import io.airlift.log.Logger;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class ResumableTasks
+{
+    private static final Logger log = Logger.get(ResumableTasks.class);
+
+    private ResumableTasks()
+    {
+    }
+
+    public static void submit(Executor executor, ResumableTask task)
+    {
+        AtomicReference<Runnable> runnableReference = new AtomicReference<>();
+        Runnable runnable = () -> {
+            ResumableTask.TaskStatus status = safeProcessTask(task);
+            if (!status.isFinished()) {
+                status.getContinuationFuture().thenRun(() -> executor.execute(runnableReference.get()));
+            }
+        };
+        runnableReference.set(runnable);
+        executor.execute(runnable);
+    }
+
+    private static ResumableTask.TaskStatus safeProcessTask(ResumableTask task)
+    {
+        try {
+            return task.process();
+        }
+        catch (Throwable t) {
+            log.warn(t, "ResumableTask completed exceptionally");
+            return ResumableTask.TaskStatus.finished();
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -20,11 +20,11 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -35,7 +35,7 @@ public class TestHiveSplitSource
     public void testOutstandingSplitCount()
             throws Exception
     {
-        HiveSplitSource hiveSplitSource = new HiveSplitSource("test", 10, new TestingHiveSplitLoader());
+        HiveSplitSource hiveSplitSource = new HiveSplitSource("test", 10, new TestingHiveSplitLoader(), Executors.newFixedThreadPool(5));
 
         // add 10 splits
         for (int i = 0; i < 10; i++) {
@@ -57,35 +57,10 @@ public class TestHiveSplitSource
     }
 
     @Test
-    public void testSuspendResume()
-            throws Exception
-    {
-        TestingHiveSplitLoader splitLoader = new TestingHiveSplitLoader();
-        HiveSplitSource hiveSplitSource = new HiveSplitSource("test", 10, splitLoader);
-
-        // almost fill the source
-        for (int i = 0; i < 9; i++) {
-            hiveSplitSource.addToQueue(new TestSplit(i));
-            assertEquals(hiveSplitSource.getOutstandingSplitCount(), i + 1);
-            assertFalse(splitLoader.isResumed());
-        }
-
-        // add one more split so the source is now full
-        hiveSplitSource.addToQueue(new TestSplit(10));
-        assertEquals(hiveSplitSource.getOutstandingSplitCount(), 10);
-        assertFalse(splitLoader.isResumed());
-
-        // remove one split so the source is no longer full and verify the loader is resumed
-        assertEquals(getFutureValue(hiveSplitSource.getNextBatch(1)).size(), 1);
-        assertEquals(hiveSplitSource.getOutstandingSplitCount(), 9);
-        assertTrue(splitLoader.isResumed());
-    }
-
-    @Test
     public void testFail()
             throws Exception
     {
-        HiveSplitSource hiveSplitSource = new HiveSplitSource("test", 10, new TestingHiveSplitLoader());
+        HiveSplitSource hiveSplitSource = new HiveSplitSource("test", 10, new TestingHiveSplitLoader(), Executors.newFixedThreadPool(5));
 
         // add some splits
         for (int i = 0; i < 5; i++) {
@@ -109,15 +84,15 @@ public class TestHiveSplitSource
         catch (RuntimeException e) {
             assertEquals(e.getMessage(), "test");
         }
-        assertEquals(hiveSplitSource.getOutstandingSplitCount(), 4);
+        assertEquals(hiveSplitSource.getOutstandingSplitCount(), 3);
 
         // attempt to add another split and verify it does not work
         hiveSplitSource.addToQueue(new TestSplit(99));
-        assertEquals(hiveSplitSource.getOutstandingSplitCount(), 4);
+        assertEquals(hiveSplitSource.getOutstandingSplitCount(), 3);
 
         // fail source again
         hiveSplitSource.fail(new RuntimeException("another failure"));
-        assertEquals(hiveSplitSource.getOutstandingSplitCount(), 4);
+        assertEquals(hiveSplitSource.getOutstandingSplitCount(), 3);
 
         // try to remove a split and verify we got the first exception
         try {
@@ -133,7 +108,7 @@ public class TestHiveSplitSource
     public void testReaderWaitsForSplits()
             throws Exception
     {
-        final HiveSplitSource hiveSplitSource = new HiveSplitSource("test", 10, new TestingHiveSplitLoader());
+        final HiveSplitSource hiveSplitSource = new HiveSplitSource("test", 10, new TestingHiveSplitLoader(), Executors.newFixedThreadPool(5));
 
         final SettableFuture<ConnectorSplit> splits = SettableFuture.create();
 
@@ -181,27 +156,14 @@ public class TestHiveSplitSource
     private static class TestingHiveSplitLoader
             implements HiveSplitLoader
     {
-        private boolean resumed;
-
         @Override
         public void start(HiveSplitSource splitSource)
         {
         }
 
         @Override
-        public void resume()
-        {
-            resumed = true;
-        }
-
-        @Override
         public void stop()
         {
-        }
-
-        public boolean isResumed()
-        {
-            return resumed;
         }
     }
 


### PR DESCRIPTION
The race was not solved in #3411 once `resume()` invocation is taken into consideration.

#3411 also introduced starvation.