### PR TITLE
Fix Parquet backward compatibility issue when reading lists

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.115.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.115.rst
@@ -6,4 +6,5 @@ Hive Changes
 ------------
 
 * Fix a race condition which could cause queries to finish without reading all the data.
-
+* Fix a bug in Parquet reader that causes failures while reading lists that has an element
+  schema name other than ``array_element`` in its Parquet-level schema.


### PR DESCRIPTION
Fixes #3227

With this PR, Presto now uses the same rules as Hive when reading lists and conform to Parquet's
backward compatibility rules specified [here](http://git.io/vOpNz).