### PR TITLE
Web app fix reading length of null

### DIFF
--- a/presto-main/src/main/resources/webapp/index.html
+++ b/presto-main/src/main/resources/webapp/index.html
@@ -247,7 +247,7 @@ var QueryPane = React.createClass({
         this.setState({autoRefresh: event.target.checked});
     },
     render: function() {
-        if (this.state.queries.length > 0) {
+        if (this.state.queries !== null && this.state.queries.length > 0) {
             var runningQueries = [];
             var doneQueries = [];
             runningQueries = this.state.queries.filter(function (query) {


### PR DESCRIPTION
```
Uncaught TypeError: Cannot read property 'length' of null
```

which points to this code in webapp/index.html
```
render: function() {
        if (this.state.queries.length > 0) { // this line
```

is thrown if a call to /v1/query fails (e.g. no connectivity, presto restart, etc)

This checks for the variable to be null so auto-update keeps refreshing.