### PR TITLE
decrementAndGet should be used in QueryQueue reserve method

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryQueue.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryQueue.java
@@ -61,7 +61,7 @@ public class QueryQueue
 
     public boolean reserve(QueryExecution queryExecution)
     {
-        if (queuePermits.getAndDecrement() < 0) {
+        if (queuePermits.decrementAndGet() < 0) {
             queuePermits.incrementAndGet();
             return false;
         }


### PR DESCRIPTION
Previously getAndDecrement was used. This allowed more permits
than maxQueuedQueries + maxConcurrentQueries.