### PR TITLE
Set provided scope for joda in presto-teradata-functions

### DIFF
--- a/presto-teradata-functions/pom.xml
+++ b/presto-teradata-functions/pom.xml
@@ -43,11 +43,13 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Set provided scope for joda in presto-teradata-functions

Change scope of joda-time library used by presto-teradata-functions
module from 'compile' to 'provided'.
Fixes LinkageError due to incompatibility of ISOChronologi class
between PluginClassLoader and main Presto classloader.
