### PR TITLE
Make functions pow and power aliases.

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -80,6 +80,10 @@ Mathematical Functions
 
 .. function:: pow(x, p) -> double
 
+    Alias for :func:`power`
+
+.. function:: power(x, p) -> double
+
     Returns ``x`` raised to the power of ``p``.
 
 .. function:: radians(x) -> double

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -218,9 +218,9 @@ public final class MathFunctions
     }
 
     @Description("value raised to the power of exponent")
-    @ScalarFunction
+    @ScalarFunction(alias = "pow")
     @SqlType(StandardTypes.DOUBLE)
-    public static double pow(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.DOUBLE) double exponent)
+    public static double power(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.DOUBLE) double exponent)
     {
         return Math.pow(num, exponent);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -285,7 +285,7 @@ public class TestMathFunctions
     }
 
     @Test
-    public void testPow()
+    public void testPower()
     {
         for (long left : longLefts) {
             for (long right : longRights) {
@@ -313,6 +313,33 @@ public class TestMathFunctions
         assertFunction("pow(NULL, NULL)", DOUBLE, null);
         assertFunction("pow(5.0, NULL)", DOUBLE, null);
         assertFunction("pow(NULL, 5.0)", DOUBLE, null);
+
+        for (long left : longLefts) {
+            for (long right : longRights) {
+                assertFunction("power(" + left + ", " + right + ")", DOUBLE, Math.pow(left, right));
+            }
+        }
+
+        for (long left : longLefts) {
+            for (double right : doubleRights) {
+                assertFunction("power(" + left + ", " + right + ")", DOUBLE, Math.pow(left, right));
+            }
+        }
+
+        for (double left : doubleLefts) {
+            for (long right : longRights) {
+                assertFunction("power(" + left + ", " + right + ")", DOUBLE, Math.pow(left, right));
+            }
+        }
+
+        for (double left : doubleLefts) {
+            for (double right : doubleRights) {
+                assertFunction("power(" + left + ", " + right + ")", DOUBLE, Math.pow(left, right));
+            }
+        }
+        assertFunction("power(NULL, NULL)", DOUBLE, null);
+        assertFunction("power(5.0, NULL)", DOUBLE, null);
+        assertFunction("power(NULL, 5.0)", DOUBLE, null);
     }
 
     @Test


### PR DESCRIPTION
Currently pow() was the name of the method supported
and this commit added pow as an alias and renamed the
method as power which is conistent with ANSI.

Testing: added unit test