### PR TITLE
Minor Parquet map compatibility fix

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ParquetHiveRecordCursor.java
@@ -963,8 +963,7 @@ class ParquetHiveRecordCursor
 
             parquet.schema.Type entryType = mapType.getFields().get(0);
 
-            // original versions of parquet had map end entry swapped
-            if (mapType.getOriginalType() != MAP_KEY_VALUE) {
+            if (entryType.getOriginalType() != MAP_KEY_VALUE) {
                 checkArgument(entryType.getOriginalType() == MAP_KEY_VALUE,
                         "Expected MAP column '%s' field to be type %s, but is %s",
                         mapType.getName(),


### PR DESCRIPTION
Previously the original type of the map is compared against `MAP_KEY_VALUE`, but the `checkArgument()` call checks the original type of the entry. There was a comment here saying ``// original versions of parquet had map end entry swapped``, but I am not sure this is true and I couldn't reproduce that.