### PR TITLE
Fix NPE with hive tables using ThriftDeserializer

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -332,7 +332,7 @@ public final class HiveUtil
     private static void initializeDeserializer(Deserializer deserializer, Properties schema)
     {
         try {
-            deserializer.initialize(null, schema);
+            deserializer.initialize(new Configuration(), schema);
         }
         catch (SerDeException e) {
             throw new RuntimeException("error initializing deserializer: " + deserializer.getClass().getName());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveUtil.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveUtil.java
@@ -13,13 +13,19 @@
  */
 package com.facebook.presto.hive;
 
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.thrift.ThriftDeserializer;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.testng.annotations.Test;
 
+import java.util.Properties;
+
+import static com.facebook.presto.hive.HiveUtil.getDeserializer;
 import static com.facebook.presto.hive.HiveUtil.parseHiveTimestamp;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestHiveUtil
 {
@@ -32,6 +38,30 @@ public class TestHiveUtil
         assertEquals(parse(time, "yyyy-MM-dd HH:mm:ss.SSS"), unixTime(time, 3));
         assertEquals(parse(time, "yyyy-MM-dd HH:mm:ss.SSSSSSS"), unixTime(time, 6));
         assertEquals(parse(time, "yyyy-MM-dd HH:mm:ss.SSSSSSSSS"), unixTime(time, 7));
+    }
+
+    @Test
+    public void testGetDeserializer()
+    {
+        assertTrue(getDeserializer(thriftTestSchema()) instanceof ThriftDeserializer);
+    }
+
+    private static Properties thriftTestSchema()
+    {
+        Properties schema = new Properties();
+        schema.setProperty(
+                org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_LIB,
+                org.apache.hadoop.hive.serde2.thrift.ThriftDeserializer.class.getName()
+        );
+        schema.setProperty(
+                serdeConstants.SERIALIZATION_CLASS,
+                org.apache.hadoop.hive.serde2.thrift.test.IntString.class.getName()
+        );
+        schema.setProperty(
+                serdeConstants.SERIALIZATION_FORMAT,
+                org.apache.thrift.protocol.TBinaryProtocol.class.getName()
+        );
+        return schema;
     }
 
     private static long parse(DateTime time, String pattern)


### PR DESCRIPTION
Pass a default Configuration to initializeDeserializer() instead of
null. The ThriftDeserializer needs a non-null configuration because it
uses the Configuration object to load a class.

Testing: unit test.  Verified behavior both for hive tables that use
the ThriftDeserializer and ones that use the default LazySimpleSerde.