### PR TITLE
Add Ambari JDK installation path to RPM

### DIFF
--- a/presto-server-rpm/src/main/rpm/preinstall
+++ b/presto-server-rpm/src/main/rpm/preinstall
@@ -38,6 +38,7 @@ if ! check_if_correct_java_version "$JAVA8_HOME" && ! check_if_correct_java_vers
       /usr/lib/jvm/java-8-oracle* \
       /usr/java/jdk1.8* \
       /usr/java/jre1.8* \
+      /usr/jdk64/jdk1.8* \
       /usr/lib/jvm/default-java \
       /usr/java/default ; do
       if [ -e "$candidate"/bin/java ]; then


### PR DESCRIPTION
* Edit the RPM presintall script to look for java in the
directory where Ambari installs it.

Testing: Built RPM and installed on cluster with JDK from Ambari