### PR TITLE
Add permission checks to analyzer

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ConditionalModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ConditionalModule.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.configuration.ConfigurationAwareModule;
+
+import java.util.function.Predicate;
+
+public class ConditionalModule<T>
+        extends AbstractConfigurationAwareModule
+{
+    public static <T> Module installModuleIf(Class<T> config, Predicate<T> predicate, Module module)
+    {
+        return new ConditionalModule<>(config, predicate, module);
+    }
+
+    private final Class<T> config;
+    private final Predicate<T> predicate;
+    private final Module module;
+
+    private ConditionalModule(Class<T> config, Predicate<T> predicate, Module module)
+    {
+        this.config = config;
+        this.predicate = predicate;
+        this.module = module;
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        T configuration = buildConfigObject(config);
+        if (predicate.test(configuration)) {
+            if (module instanceof ConfigurationAwareModule) {
+                install((ConfigurationAwareModule) module);
+            }
+            else {
+                binder.install(module);
+            }
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnector.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnector.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.ConnectorRecordSinkProvider;
 import com.facebook.presto.spi.ConnectorSplitManager;
 import com.facebook.presto.spi.SystemTable;
+import com.facebook.presto.spi.security.ConnectorAccessControl;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -45,6 +46,7 @@ public class HiveConnector
     private final Set<SystemTable> systemTables;
     private final List<PropertyMetadata<?>> sessionProperties;
     private final List<PropertyMetadata<?>> tableProperties;
+    private final ConnectorAccessControl accessControl;
 
     public HiveConnector(
             LifeCycleManager lifeCycleManager,
@@ -55,7 +57,8 @@ public class HiveConnector
             ConnectorHandleResolver handleResolver,
             Set<SystemTable> systemTables,
             List<PropertyMetadata<?>> sessionProperties,
-            List<PropertyMetadata<?>> tableProperties)
+            List<PropertyMetadata<?>> tableProperties,
+            ConnectorAccessControl accessControl)
     {
         this.lifeCycleManager = checkNotNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = checkNotNull(metadata, "metadata is null");
@@ -66,6 +69,7 @@ public class HiveConnector
         this.systemTables = ImmutableSet.copyOf(checkNotNull(systemTables, "systemTables is null"));
         this.sessionProperties = ImmutableList.copyOf(checkNotNull(sessionProperties, "sessionProperties is null"));
         this.tableProperties = ImmutableList.copyOf(checkNotNull(tableProperties, "tableProperties is null"));
+        this.accessControl = checkNotNull(accessControl, "accessControl is null");
     }
 
     @Override
@@ -114,6 +118,12 @@ public class HiveConnector
     public List<PropertyMetadata<?>> getTableProperties()
     {
         return tableProperties;
+    }
+
+    @Override
+    public ConnectorAccessControl getAccessControl()
+    {
+        return accessControl;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
@@ -87,6 +87,10 @@ public class HiveConnectorFactory
                             SecurityConfig.class,
                             security -> "none".equalsIgnoreCase(security.getSecuritySystem()),
                             new NoSecurityModule()),
+                    installModuleIf(
+                            SecurityConfig.class,
+                            security -> "read-only".equalsIgnoreCase(security.getSecuritySystem()),
+                            new ReadOnlySecurityModule()),
                     binder -> {
                         MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
                         binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(platformMBeanServer));

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
@@ -42,6 +42,7 @@ import javax.management.MBeanServer;
 import java.lang.management.ManagementFactory;
 import java.util.Map;
 
+import static com.facebook.presto.hive.ConditionalModule.installModuleIf;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -82,6 +83,10 @@ public class HiveConnectorFactory
                     new MBeanModule(),
                     new JsonModule(),
                     new HiveClientModule(connectorId, metastore, typeManager),
+                    installModuleIf(
+                            SecurityConfig.class,
+                            security -> "none".equalsIgnoreCase(security.getSecuritySystem()),
+                            new NoSecurityModule()),
                     binder -> {
                         MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
                         binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(platformMBeanServer));

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -45,6 +45,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet;
+import org.apache.hadoop.hive.metastore.api.PrincipalType;
+import org.apache.hadoop.hive.metastore.api.PrivilegeGrantInfo;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -366,6 +369,12 @@ public class HiveMetadata
         table.setPartitionKeys(partitionKeys.build());
         table.setSd(sd);
 
+        PrivilegeGrantInfo allPrivileges = new PrivilegeGrantInfo("all", 0, tableMetadata.getOwner(), PrincipalType.USER, true);
+        table.setPrivileges(new PrincipalPrivilegeSet(
+                ImmutableMap.of(tableMetadata.getOwner(), ImmutableList.of(allPrivileges)),
+                ImmutableMap.of(),
+                ImmutableMap.of()));
+
         metastore.createTable(table);
     }
 
@@ -522,6 +531,12 @@ public class HiveMetadata
         table.setPartitionKeys(ImmutableList.<FieldSchema>of());
         table.setSd(sd);
 
+        PrivilegeGrantInfo allPrivileges = new PrivilegeGrantInfo("all", 0, handle.getTableOwner(), PrincipalType.USER, true);
+        table.setPrivileges(new PrincipalPrivilegeSet(
+                ImmutableMap.of(handle.getTableOwner(), ImmutableList.of(allPrivileges)),
+                ImmutableMap.of(),
+                ImmutableMap.of()));
+
         metastore.createTable(table);
     }
 
@@ -660,6 +675,12 @@ public class HiveMetadata
         table.setViewOriginalText(encodeViewData(viewData));
         table.setViewExpandedText("/* Presto View */");
         table.setSd(sd);
+
+        PrivilegeGrantInfo allPrivileges = new PrivilegeGrantInfo("all", 0, session.getUser(), PrincipalType.USER, true);
+        table.setPrivileges(new PrincipalPrivilegeSet(
+                ImmutableMap.of(session.getUser(), ImmutableList.of(allPrivileges)),
+                ImmutableMap.of(),
+                ImmutableMap.of()));
 
         try {
             metastore.createTable(table);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/NoAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/NoAccessControl.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.security.ConnectorAccessControl;
+import com.facebook.presto.spi.security.Identity;
+
+import javax.inject.Inject;
+
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
+import static java.util.Objects.requireNonNull;
+
+public class NoAccessControl
+        implements ConnectorAccessControl
+{
+    private final boolean allowDropTable;
+    private final boolean allowRenameTable;
+
+    @Inject
+    public NoAccessControl(HiveClientConfig hiveClientConfig)
+    {
+        requireNonNull(hiveClientConfig, "hiveClientConfig is null");
+        allowDropTable = hiveClientConfig.getAllowDropTable();
+        allowRenameTable = hiveClientConfig.getAllowRenameTable();
+    }
+
+    @Override
+    public void checkCanCreateTable(Identity identity, SchemaTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanDropTable(Identity identity, SchemaTableName tableName)
+    {
+        if (!allowDropTable) {
+            denyDropTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanRenameTable(Identity identity, SchemaTableName tableName, SchemaTableName newTableName)
+    {
+        if (!allowRenameTable) {
+            denyRenameTable(tableName.toString(), newTableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanSelectFromTable(Identity identity, SchemaTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(Identity identity, SchemaTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(Identity identity, SchemaTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanCreateView(Identity identity, SchemaTableName viewName)
+    {
+    }
+
+    @Override
+    public void checkCanDropView(Identity identity, SchemaTableName viewName)
+    {
+    }
+
+    @Override
+    public void checkCanSelectFromView(Identity identity, SchemaTableName viewName)
+    {
+    }
+
+    @Override
+    public void checkCanSetCatalogSessionProperty(Identity identity, String propertyName)
+    {
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/NoSecurityModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/NoSecurityModule.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.security.ConnectorAccessControl;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+public class NoSecurityModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(ConnectorAccessControl.class).to(NoAccessControl.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ReadOnlyAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ReadOnlyAccessControl.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.security.ConnectorAccessControl;
+import com.facebook.presto.spi.security.Identity;
+
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDeleteTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyInsertTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
+
+public class ReadOnlyAccessControl
+        implements ConnectorAccessControl
+{
+    @Override
+    public void checkCanCreateTable(Identity identity, SchemaTableName tableName)
+    {
+        denyCreateTable(tableName.toString());
+    }
+
+    @Override
+    public void checkCanDropTable(Identity identity, SchemaTableName tableName)
+    {
+        denyDropTable(tableName.toString());
+    }
+
+    @Override
+    public void checkCanRenameTable(Identity identity, SchemaTableName tableName, SchemaTableName newTableName)
+    {
+        denyRenameTable(tableName.toString(), newTableName.toString());
+    }
+
+    @Override
+    public void checkCanSelectFromTable(Identity identity, SchemaTableName tableName)
+    {
+        // allow
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(Identity identity, SchemaTableName tableName)
+    {
+        denyInsertTable(tableName.toString());
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(Identity identity, SchemaTableName tableName)
+    {
+        denyDeleteTable(tableName.toString());
+    }
+
+    @Override
+    public void checkCanCreateView(Identity identity, SchemaTableName viewName)
+    {
+        denyCreateView(viewName.toString());
+    }
+
+    @Override
+    public void checkCanDropView(Identity identity, SchemaTableName viewName)
+    {
+        denyDropView(viewName.toString());
+    }
+
+    @Override
+    public void checkCanSelectFromView(Identity identity, SchemaTableName viewName)
+    {
+        // allow
+    }
+
+    @Override
+    public void checkCanSetCatalogSessionProperty(Identity identity, String propertyName)
+    {
+        // allow
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ReadOnlySecurityModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ReadOnlySecurityModule.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.security.ConnectorAccessControl;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+public class ReadOnlySecurityModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(ConnectorAccessControl.class).to(ReadOnlyAccessControl.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SecurityConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SecurityConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import io.airlift.configuration.Config;
+
+public class SecurityConfig
+{
+    private String securitySystem = "none";
+
+    public String getSecuritySystem()
+    {
+        return securitySystem;
+    }
+
+    @Config("hive.security")
+    public SecurityConfig setSecuritySystem(String securitySystem)
+    {
+        this.securitySystem = securitySystem;
+        return this;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SqlStandardAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SqlStandardAccessControl.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.HiveMetastore;
+import com.facebook.presto.hive.metastore.HivePrivilege;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.security.ConnectorAccessControl;
+import com.facebook.presto.spi.security.Identity;
+import com.google.common.collect.ImmutableSet;
+
+import javax.inject.Inject;
+
+import java.util.Set;
+
+import static com.facebook.presto.hive.metastore.HivePrivilege.DELETE;
+import static com.facebook.presto.hive.metastore.HivePrivilege.INSERT;
+import static com.facebook.presto.hive.metastore.HivePrivilege.OWNERSHIP;
+import static com.facebook.presto.hive.metastore.HivePrivilege.SELECT;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDeleteTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyInsertTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
+import static java.util.Objects.requireNonNull;
+
+public class SqlStandardAccessControl
+        implements ConnectorAccessControl
+{
+    private static final String ADMIN_ROLE_NAME = "admin";
+    private static final String INFORMATION_SCHEMA_NAME = "information_schema";
+
+    private final String connectorId;
+    private final HiveMetastore metastore;
+    private final boolean allowDropTable;
+    private final boolean allowRenameTable;
+
+    @Inject
+    public SqlStandardAccessControl(HiveConnectorId connectorId, HiveMetastore metastore, HiveClientConfig hiveClientConfig)
+    {
+        this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
+        this.metastore = requireNonNull(metastore, "metastore is null");
+
+        requireNonNull(hiveClientConfig, "hiveClientConfig is null");
+        allowDropTable = hiveClientConfig.getAllowDropTable();
+        allowRenameTable = hiveClientConfig.getAllowRenameTable();
+    }
+
+    @Override
+    public void checkCanCreateTable(Identity identity, SchemaTableName tableName)
+    {
+        if (!checkDatabasePermission(identity, tableName.getSchemaName(), OWNERSHIP)) {
+            denyCreateTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanDropTable(Identity identity, SchemaTableName tableName)
+    {
+        if (!allowDropTable || !checkTablePermission(identity, tableName, OWNERSHIP)) {
+            denyDropTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanRenameTable(Identity identity, SchemaTableName tableName, SchemaTableName newTableName)
+    {
+        if (!allowRenameTable || !checkTablePermission(identity, tableName, OWNERSHIP)) {
+            denyRenameTable(tableName.toString(), newTableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanSelectFromTable(Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTablePermission(identity, tableName, SELECT)) {
+            denySelectTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTablePermission(identity, tableName, INSERT)) {
+            denyInsertTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTablePermission(identity, tableName, DELETE)) {
+            denyDeleteTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanCreateView(Identity identity, SchemaTableName viewName)
+    {
+        if (!checkDatabasePermission(identity, viewName.getSchemaName(), OWNERSHIP)) {
+            denyCreateView(viewName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanDropView(Identity identity, SchemaTableName viewName)
+    {
+        if (!checkTablePermission(identity, viewName, OWNERSHIP)) {
+            denyDropView(viewName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanSelectFromView(Identity identity, SchemaTableName viewName)
+    {
+        if (!checkTablePermission(identity, viewName, SELECT)) {
+            denySelectView(viewName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanSetCatalogSessionProperty(Identity identity, String propertyName)
+    {
+        if (!metastore.getRoles(identity.getUser()).contains(ADMIN_ROLE_NAME)) {
+            denySetCatalogSessionProperty(connectorId, propertyName);
+        }
+    }
+
+    private boolean checkDatabasePermission(Identity identity, String schemaName, HivePrivilege... requiredPrivileges)
+    {
+        Set<HivePrivilege> privilegeSet = metastore.getDatabasePrivileges(identity.getUser(), schemaName);
+        return privilegeSet.containsAll(ImmutableSet.copyOf(requiredPrivileges));
+    }
+
+    private boolean checkTablePermission(Identity identity, SchemaTableName tableName, HivePrivilege requiredPrivilege)
+    {
+        if (INFORMATION_SCHEMA_NAME.equals(tableName.getSchemaName())) {
+            return true;
+        }
+
+        Set<HivePrivilege> privilegeSet = metastore.getTablePrivileges(identity.getUser(), tableName.getSchemaName(), tableName.getTableName());
+        return privilegeSet.contains(requiredPrivilege);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SqlStandardSecurityModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SqlStandardSecurityModule.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.security.ConnectorAccessControl;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+public class SqlStandardSecurityModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(ConnectorAccessControl.class).to(SqlStandardAccessControl.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePrivilege.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePrivilege.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.hive.metastore.api.PrivilegeGrantInfo;
+
+import java.util.Set;
+
+import static java.util.Locale.ENGLISH;
+
+public enum HivePrivilege
+{
+    SELECT, INSERT, UPDATE, DELETE, OWNERSHIP, GRANT;
+
+    public static Set<HivePrivilege> parsePrivilege(PrivilegeGrantInfo userGrant)
+    {
+        String name = userGrant.getPrivilege().toUpperCase(ENGLISH);
+        switch (name) {
+            case "ALL":
+                return ImmutableSet.copyOf(values());
+            case "SELECT":
+                return ImmutableSet.of(SELECT);
+            case "INSERT":
+                return ImmutableSet.of(INSERT);
+            case "UPDATE":
+                return ImmutableSet.of(UPDATE);
+            case "DELETE":
+                return ImmutableSet.of(DELETE);
+        }
+        return ImmutableSet.of();
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/InMemoryHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/InMemoryHiveMetastore.java
@@ -16,30 +16,48 @@ package com.facebook.presto.hive.metastore;
 import com.facebook.presto.hive.TableAlreadyExistsException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet;
+import org.apache.hadoop.hive.metastore.api.PrincipalType;
+import org.apache.hadoop.hive.metastore.api.PrivilegeGrantInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.facebook.presto.hive.metastore.HivePrivilege.OWNERSHIP;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.airlift.testing.FileUtils.deleteRecursively;
+import static org.apache.hadoop.hive.metastore.api.PrincipalType.ROLE;
+import static org.apache.hadoop.hive.metastore.api.PrincipalType.USER;
 
 public class InMemoryHiveMetastore
         implements HiveMetastore
 {
+    private static final String PUBLIC_ROLE_NAME = "public";
     private final ConcurrentHashMap<String, Database> databases = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<SchemaTableName, Table> relations = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<SchemaTableName, Table> views = new ConcurrentHashMap<>();
+
+    private final ConcurrentHashMap<String, Set<String>> roleGrants = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<PrincipalTableKey, Set<HivePrivilege>> tablePrivileges = new ConcurrentHashMap<>();
 
     private final File baseDirectory;
 
@@ -90,6 +108,26 @@ public class InMemoryHiveMetastore
 
         if (tableCopy.getTableType().equals(TableType.VIRTUAL_VIEW.name())) {
             views.put(schemaTableName, tableCopy);
+        }
+
+        PrincipalPrivilegeSet privileges = table.getPrivileges();
+        if (privileges != null) {
+            for (Entry<String, List<PrivilegeGrantInfo>> entry : privileges.getUserPrivileges().entrySet()) {
+                String user = entry.getKey();
+                Set<HivePrivilege> userPrivileges = entry.getValue().stream()
+                        .map(HivePrivilege::parsePrivilege)
+                        .flatMap(Collection::stream)
+                        .collect(toImmutableSet());
+                setTablePrivileges(user, USER, table.getDbName(), table.getTableName(), userPrivileges);
+            }
+            for (Entry<String, List<PrivilegeGrantInfo>> entry : privileges.getRolePrivileges().entrySet()) {
+                String role = entry.getKey();
+                Set<HivePrivilege> rolePrivileges = entry.getValue().stream()
+                        .map(HivePrivilege::parsePrivilege)
+                        .flatMap(Collection::stream)
+                        .collect(toImmutableSet());
+                setTablePrivileges(role, ROLE, table.getDbName(), table.getTableName(), rolePrivileges);
+            }
         }
     }
 
@@ -185,6 +223,56 @@ public class InMemoryHiveMetastore
     }
 
     @Override
+    public Set<String> getRoles(String user)
+    {
+        return roleGrants.getOrDefault(user, ImmutableSet.of(PUBLIC_ROLE_NAME));
+    }
+
+    public void setUserRoles(String user, Set<String> roles)
+    {
+        if (!roles.contains(PUBLIC_ROLE_NAME)) {
+            roles = ImmutableSet.<String>builder()
+                    .addAll(roles)
+                    .add(PUBLIC_ROLE_NAME)
+                    .build();
+        }
+        roleGrants.put(user, ImmutableSet.copyOf(roles));
+    }
+
+    @Override
+    public Set<HivePrivilege> getDatabasePrivileges(String user, String databaseName)
+    {
+        Set<HivePrivilege> privileges = new HashSet<>();
+        if (isDatabaseOwner(user, databaseName)) {
+            privileges.add(OWNERSHIP);
+        }
+        return privileges;
+    }
+
+    @Override
+    public Set<HivePrivilege> getTablePrivileges(String user, String databaseName, String tableName)
+    {
+        Set<HivePrivilege> privileges = new HashSet<>();
+        if (isTableOwner(user, databaseName, tableName)) {
+            privileges.add(OWNERSHIP);
+        }
+        privileges.addAll(tablePrivileges.getOrDefault(new PrincipalTableKey(user, USER, tableName, databaseName), ImmutableSet.of()));
+        for (String role : getRoles(user)) {
+            privileges.addAll(tablePrivileges.getOrDefault(new PrincipalTableKey(role, ROLE, tableName, databaseName), ImmutableSet.of()));
+        }
+        return privileges;
+    }
+
+    public void setTablePrivileges(String principalName,
+            PrincipalType principalType,
+            String databaseName,
+            String tableName,
+            Set<HivePrivilege> privileges)
+    {
+        tablePrivileges.put(new PrincipalTableKey(principalName, principalType, tableName, databaseName), ImmutableSet.copyOf(privileges));
+    }
+
+    @Override
     public void flushCache()
     {
     }
@@ -197,5 +285,54 @@ public class InMemoryHiveMetastore
             }
         }
         return false;
+    }
+
+    private static class PrincipalTableKey
+    {
+        private final String principalName;
+        private final PrincipalType principalType;
+        private final String database;
+        private final String table;
+
+        public PrincipalTableKey(String principalName, PrincipalType principalType, String table, String database)
+        {
+            this.principalName = checkNotNull(principalName, "principalName is null");
+            this.principalType = checkNotNull(principalType, "principalType is null");
+            this.table = checkNotNull(table, "table is null");
+            this.database = checkNotNull(database, "database is null");
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PrincipalTableKey that = (PrincipalTableKey) o;
+            return Objects.equals(principalName, that.principalName) &&
+                    Objects.equals(principalType, that.principalType) &&
+                    Objects.equals(table, that.table) &&
+                    Objects.equals(database, that.database);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(principalName, principalType, table, database);
+        }
+
+        @Override
+        public String toString()
+        {
+            return MoreObjects.toStringHelper(this)
+                    .add("principalName", principalName)
+                    .add("principalType", principalType)
+                    .add("table", table)
+                    .add("database", database)
+                    .toString();
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
@@ -14,6 +14,7 @@
 package com.facebook.presto;
 
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.StandardErrorCode;
@@ -29,7 +30,7 @@ import static java.util.Objects.requireNonNull;
 public class FullConnectorSession
         implements ConnectorSession
 {
-    private final String user;
+    private final Identity identity;
     private final TimeZoneKey timeZoneKey;
     private final Locale locale;
     private final long startTime;
@@ -38,12 +39,12 @@ public class FullConnectorSession
     private final SessionPropertyManager sessionPropertyManager;
 
     public FullConnectorSession(
-            String user,
+            Identity identity,
             TimeZoneKey timeZoneKey,
             Locale locale,
             long startTime)
     {
-        this.user = requireNonNull(user, "user is null");
+        this.identity = requireNonNull(identity, "identity is null");
         this.timeZoneKey = requireNonNull(timeZoneKey, "timeZoneKey is null");
         this.locale = requireNonNull(locale, "locale is null");
         this.startTime = startTime;
@@ -54,7 +55,7 @@ public class FullConnectorSession
     }
 
     public FullConnectorSession(
-            String user,
+            Identity identity,
             TimeZoneKey timeZoneKey,
             Locale locale,
             long startTime,
@@ -62,7 +63,7 @@ public class FullConnectorSession
             String catalog,
             SessionPropertyManager sessionPropertyManager)
     {
-        this.user = requireNonNull(user, "user is null");
+        this.identity = requireNonNull(identity, "identity is null");
         this.timeZoneKey = requireNonNull(timeZoneKey, "timeZoneKey is null");
         this.locale = requireNonNull(locale, "locale is null");
         this.startTime = startTime;
@@ -73,9 +74,9 @@ public class FullConnectorSession
     }
 
     @Override
-    public String getUser()
+    public Identity getIdentity()
     {
-        return user;
+        return identity;
     }
 
     @Override
@@ -111,7 +112,7 @@ public class FullConnectorSession
     {
         return toStringHelper(this)
                 .omitNullValues()
-                .add("user", user)
+                .add("user", getUser())
                 .add("timeZoneKey", timeZoneKey)
                 .add("locale", locale)
                 .add("startTime", startTime)

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -64,15 +64,15 @@ public final class Session
             SessionPropertyManager sessionPropertyManager)
     {
         this.user = requireNonNull(user, "user is null");
-        this.source = source;
+        this.source = requireNonNull(source, "source is null");
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.timeZoneKey = requireNonNull(timeZoneKey, "timeZoneKey is null");
         this.locale = requireNonNull(locale, "locale is null");
-        this.remoteUserAddress = remoteUserAddress;
-        this.userAgent = userAgent;
+        this.remoteUserAddress = requireNonNull(remoteUserAddress, "remoteUserAddress is null");
+        this.userAgent = requireNonNull(userAgent, "userAgent is null");
         this.startTime = startTime;
-        this.systemProperties = ImmutableMap.copyOf(systemProperties);
+        this.systemProperties = ImmutableMap.copyOf(requireNonNull(systemProperties, "systemProperties is null"));
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
 
         ImmutableMap.Builder<String, Map<String, String>> catalogPropertiesBuilder = ImmutableMap.<String, Map<String, String>>builder();

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -16,6 +16,7 @@ package com.facebook.presto;
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.type.TimeZoneKey;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -36,7 +37,7 @@ import static java.util.Objects.requireNonNull;
 
 public final class Session
 {
-    private final String user;
+    private final Identity identity;
     private final Optional<String> source;
     private final String catalog;
     private final String schema;
@@ -50,7 +51,7 @@ public final class Session
     private final SessionPropertyManager sessionPropertyManager;
 
     public Session(
-            String user,
+            Identity identity,
             Optional<String> source,
             String catalog,
             String schema,
@@ -63,7 +64,7 @@ public final class Session
             Map<String, Map<String, String>> catalogProperties,
             SessionPropertyManager sessionPropertyManager)
     {
-        this.user = requireNonNull(user, "user is null");
+        this.identity = identity;
         this.source = requireNonNull(source, "source is null");
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
@@ -84,7 +85,12 @@ public final class Session
 
     public String getUser()
     {
-        return user;
+        return identity.getUser();
+    }
+
+    public Identity getIdentity()
+    {
+        return identity;
     }
 
     public Optional<String> getSource()
@@ -156,7 +162,7 @@ public final class Session
         systemProperties.put(key, value);
 
         return new Session(
-                user,
+                identity,
                 source,
                 catalog,
                 schema,
@@ -188,7 +194,7 @@ public final class Session
         catalogProperties.put(catalog, properties);
 
         return new Session(
-                user,
+                identity,
                 source,
                 catalog,
                 schema,
@@ -204,14 +210,14 @@ public final class Session
 
     public ConnectorSession toConnectorSession()
     {
-        return new FullConnectorSession(user, timeZoneKey, locale, startTime);
+        return new FullConnectorSession(identity, timeZoneKey, locale, startTime);
     }
 
     public ConnectorSession toConnectorSession(String catalog)
     {
         checkNotNull(catalog, "catalog is null");
         return new FullConnectorSession(
-                user,
+                identity,
                 timeZoneKey,
                 locale,
                 startTime,
@@ -233,7 +239,7 @@ public final class Session
 
         return new ClientSession(
                 checkNotNull(server, "server is null"),
-                user,
+                identity.getUser(),
                 source.orElse(null),
                 catalog,
                 schema,
@@ -246,7 +252,7 @@ public final class Session
     public SessionRepresentation toSessionRepresentation()
     {
         return new SessionRepresentation(
-                user,
+                identity.getUser(),
                 source,
                 catalog,
                 schema,
@@ -263,7 +269,7 @@ public final class Session
     public String toString()
     {
         return toStringHelper(this)
-                .add("user", user)
+                .add("user", getUser())
                 .add("source", source)
                 .add("catalog", catalog)
                 .add("schema", schema)
@@ -282,7 +288,7 @@ public final class Session
 
     public static class SessionBuilder
     {
-        private String user;
+        private Identity identity;
         private String source;
         private String catalog;
         private String schema;
@@ -342,9 +348,9 @@ public final class Session
             return this;
         }
 
-        public SessionBuilder setUser(String user)
+        public SessionBuilder setIdentity(Identity identity)
         {
-            this.user = user;
+            this.identity = identity;
             return this;
         }
 
@@ -380,7 +386,7 @@ public final class Session
         public Session build()
         {
             return new Session(
-                    user,
+                    identity,
                     Optional.ofNullable(source),
                     catalog,
                     schema,

--- a/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
+++ b/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
@@ -14,6 +14,7 @@
 package com.facebook.presto;
 
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.type.TimeZoneKey;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -141,7 +142,7 @@ public final class SessionRepresentation
     public Session toSession(SessionPropertyManager sessionPropertyManager)
     {
         return new Session(
-                user,
+                new Identity(user, Optional.empty()),
                 source,
                 catalog,
                 schema,

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -114,7 +114,7 @@ public class InformationSchemaPageSourceProvider
         Map<String, SerializableNativeValue> filters = split.getFilters();
 
         Session session = Session.builder(metadata.getSessionPropertyManager())
-                .setUser(connectorSession.getUser())
+                .setIdentity(connectorSession.getIdentity())
                 .setSource("information_schema")
                 .setCatalog("") // default catalog is not be used
                 .setSchema("") // default schema is not be used

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedTableName;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.metadata.TableMetadata;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.type.Type;
@@ -53,7 +54,7 @@ public class CreateTableTask
     }
 
     @Override
-    public void execute(CreateTable statement, Session session, Metadata metadata, QueryStateMachine stateMachine)
+    public void execute(CreateTable statement, Session session, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine)
     {
         checkArgument(!statement.getElements().isEmpty(), "no columns for table");
 
@@ -74,6 +75,8 @@ public class CreateTableTask
             }
             columns.add(new ColumnMetadata(element.getName(), type, false));
         }
+
+        accessControl.checkCanCreateTable(session.getIdentity(), tableName);
 
         Map<String, Object> properties = metadata.getTablePropertyManager().getTableProperties(
                 tableName.getCatalogName(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
@@ -17,10 +17,12 @@ import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedTableName;
 import com.facebook.presto.metadata.ViewDefinition;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Analyzer;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.CreateView;
@@ -45,13 +47,19 @@ public class CreateViewTask
 {
     private final JsonCodec<ViewDefinition> codec;
     private final SqlParser sqlParser;
+    private final AccessControl accessControl;
     private final boolean experimentalSyntaxEnabled;
 
     @Inject
-    public CreateViewTask(JsonCodec<ViewDefinition> codec, SqlParser sqlParser, FeaturesConfig featuresConfig)
+    public CreateViewTask(
+            JsonCodec<ViewDefinition> codec,
+            SqlParser sqlParser,
+            AccessControl accessControl,
+            FeaturesConfig featuresConfig)
     {
         this.codec = checkNotNull(codec, "codec is null");
         this.sqlParser = checkNotNull(sqlParser, "sqlParser is null");
+        this.accessControl = checkNotNull(accessControl, "accessControl is null");
         checkNotNull(featuresConfig, "featuresConfig is null");
         this.experimentalSyntaxEnabled = featuresConfig.isExperimentalSyntaxEnabled();
     }
@@ -69,9 +77,11 @@ public class CreateViewTask
     }
 
     @Override
-    public void execute(CreateView statement, Session session, Metadata metadata, QueryStateMachine stateMachine)
+    public void execute(CreateView statement, Session session, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine)
     {
         QualifiedTableName name = createQualifiedTableName(session, statement.getName());
+
+        accessControl.checkCanCreateView(session.getIdentity(), name);
 
         String sql = getFormattedSql(statement);
 
@@ -89,7 +99,7 @@ public class CreateViewTask
 
     private Analysis analyzeStatement(Statement statement, Session session, Metadata metadata)
     {
-        Analyzer analyzer = new Analyzer(session, metadata, sqlParser, Optional.empty(), experimentalSyntaxEnabled);
+        Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.<QueryExplainer>empty(), experimentalSyntaxEnabled);
         return analyzer.analyze(statement);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/DropTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DropTableTask.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedTableName;
 import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.DropTable;
 
@@ -35,7 +36,7 @@ public class DropTableTask
     }
 
     @Override
-    public void execute(DropTable statement, Session session, Metadata metadata, QueryStateMachine stateMachine)
+    public void execute(DropTable statement, Session session, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine)
     {
         QualifiedTableName tableName = createQualifiedTableName(session, statement.getTableName());
 
@@ -46,6 +47,8 @@ public class DropTableTask
             }
             return;
         }
+
+        accessControl.checkCanDropTable(session.getIdentity(), tableName);
 
         metadata.dropTable(session, tableHandle.get());
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/DropViewTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DropViewTask.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedTableName;
 import com.facebook.presto.metadata.ViewDefinition;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.DropView;
 
@@ -35,7 +36,7 @@ public class DropViewTask
     }
 
     @Override
-    public void execute(DropView statement, Session session, Metadata metadata, QueryStateMachine stateMachine)
+    public void execute(DropView statement, Session session, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine)
     {
         QualifiedTableName name = createQualifiedTableName(session, statement.getName());
 
@@ -46,6 +47,8 @@ public class DropViewTask
             }
             return;
         }
+
+        accessControl.checkCanDropView(session.getIdentity(), name);
 
         metadata.dropView(session, name);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/RenameColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RenameColumnTask.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedTableName;
 import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.RenameColumn;
@@ -40,7 +41,7 @@ public class RenameColumnTask
     }
 
     @Override
-    public void execute(RenameColumn statement, Session session, Metadata metadata, QueryStateMachine stateMachine)
+    public void execute(RenameColumn statement, Session session, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine)
     {
         QualifiedTableName tableName = createQualifiedTableName(session, statement.getTable());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);

--- a/presto-main/src/main/java/com/facebook/presto/execution/RenameTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RenameTableTask.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedTableName;
 import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.RenameTable;
 
@@ -25,6 +26,7 @@ import java.util.Optional;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedTableName;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.TABLE_ALREADY_EXISTS;
 
 public class RenameTableTask
@@ -51,6 +53,9 @@ public class RenameTableTask
         }
         if (metadata.getTableHandle(session, target).isPresent()) {
             throw new SemanticException(TABLE_ALREADY_EXISTS, statement, "Target table '%s' already exists", target);
+        }
+        if (!tableName.getCatalogName().equals(target.getCatalogName())) {
+            throw new SemanticException(NOT_SUPPORTED, statement, "Table rename across catalogs is not supported");
         }
 
         metadata.renameTable(session, tableHandle.get(), target);

--- a/presto-main/src/main/java/com/facebook/presto/execution/RenameTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RenameTableTask.java
@@ -39,7 +39,7 @@ public class RenameTableTask
     }
 
     @Override
-    public void execute(RenameTable statement, Session session, Metadata metadata, QueryStateMachine stateMachine)
+    public void execute(RenameTable statement, Session session, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine)
     {
         QualifiedTableName tableName = createQualifiedTableName(session, statement.getSource());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
@@ -57,6 +57,7 @@ public class RenameTableTask
         if (!tableName.getCatalogName().equals(target.getCatalogName())) {
             throw new SemanticException(NOT_SUPPORTED, statement, "Table rename across catalogs is not supported");
         }
+        accessControl.checkCanRenameTable(session.getIdentity(), tableName, target);
 
         metadata.renameTable(session, tableHandle.get(), target);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/ResetSessionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ResetSessionTask.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.ResetSession;
 
@@ -30,7 +31,7 @@ public class ResetSessionTask
     }
 
     @Override
-    public void execute(ResetSession statement, Session session, Metadata metadata, QueryStateMachine stateMachine)
+    public void execute(ResetSession statement, Session session, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine)
     {
         if (statement.getName().getParts().size() > 2) {
             throw new SemanticException(INVALID_SESSION_PROPERTY, statement, "Invalid session property '%s'", statement.getName());

--- a/presto-main/src/main/java/com/facebook/presto/execution/SetSessionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SetSessionTask.java
@@ -15,9 +15,11 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.SemanticException;
+import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.SetSession;
 
 import static com.facebook.presto.metadata.SessionPropertyManager.evaluatePropertyValue;
@@ -34,22 +36,30 @@ public class SetSessionTask
     }
 
     @Override
-    public void execute(SetSession statement, Session session, Metadata metadata, QueryStateMachine stateMachine)
+    public void execute(SetSession statement, Session session, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine)
     {
-        if (statement.getName().getParts().size() > 2) {
-            throw new SemanticException(INVALID_SESSION_PROPERTY, statement, "Invalid session property '%s'", statement.getName());
+        QualifiedName propertyName = statement.getName();
+        if (propertyName.getParts().size() > 2) {
+            throw new SemanticException(INVALID_SESSION_PROPERTY, statement, "Invalid session property '%s'", propertyName);
         }
-        String name = statement.getName().toString();
 
-        PropertyMetadata<?> propertyMetadata = metadata.getSessionPropertyManager().getSessionPropertyMetadata(name);
+        PropertyMetadata<?> propertyMetadata = metadata.getSessionPropertyManager().getSessionPropertyMetadata(propertyName.toString());
+
+        if (propertyName.getParts().size() == 1) {
+            accessControl.checkCanSetSystemSessionProperty(session.getIdentity(), propertyName.getParts().get(0));
+        }
+        else if (propertyName.getParts().size() == 2) {
+            accessControl.checkCanSetCatalogSessionProperty(session.getIdentity(), propertyName.getParts().get(0), propertyName.getParts().get(1));
+        }
+
         Type type = propertyMetadata.getSqlType();
 
         Object objectValue = evaluatePropertyValue(statement.getValue(), type, session, metadata);
         String value = serializeSessionProperty(type, objectValue);
 
         // verify the SQL value can be decoded by the property
-        metadata.getSessionPropertyManager().decodeProperty(name, value, propertyMetadata.getJavaType());
+        metadata.getSessionPropertyManager().decodeProperty(propertyName.toString(), value, propertyMetadata.getJavaType());
 
-        stateMachine.addSetSessionProperties(name, value);
+        stateMachine.addSetSessionProperties(propertyName.toString(), value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.security;
+
+import com.facebook.presto.metadata.QualifiedTableName;
+import com.facebook.presto.spi.security.Identity;
+
+import java.security.Principal;
+
+public interface AccessControl
+{
+    /**
+     * Check if the principal is allowed to be the specified user.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanSetUser(Principal principal, String userName);
+
+    /**
+     * Check if identity is allowed to create the specified table.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanCreateTable(Identity identity, QualifiedTableName tableName);
+
+    /**
+     * Check if identity is allowed to drop the specified table.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanDropTable(Identity identity, QualifiedTableName tableName);
+
+    /**
+     * Check if identity is allowed to rename the specified table.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanRenameTable(Identity identity, QualifiedTableName tableName, QualifiedTableName newTableName);
+
+    /**
+     * Check if identity is allowed to select from the specified table.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanSelectFromTable(Identity identity, QualifiedTableName tableName);
+
+    /**
+     * Check if identity is allowed to insert into the specified table.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanInsertIntoTable(Identity identity, QualifiedTableName tableName);
+
+    /**
+     * Check if identity is allowed to delete from the specified table.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanDeleteFromTable(Identity identity, QualifiedTableName tableName);
+
+    /**
+     * Check if identity is allowed to create the specified view.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanCreateView(Identity identity, QualifiedTableName viewName);
+
+    /**
+     * Check if identity is allowed to drop the specified view.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanDropView(Identity identity, QualifiedTableName viewName);
+
+    /**
+     * Check if identity is allowed to select from the specified view.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanSelectFromView(Identity identity, QualifiedTableName viewName);
+
+    /**
+     * Check if identity is allowed to set the specified system property.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanSetSystemSessionProperty(Identity identity, String propertyName);
+
+    /**
+     * Check if identity is allowed to set the specified catalog property.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanSetCatalogSessionProperty(Identity identity, String catalogName, String propertyName);
+}

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.security;
+
+import com.facebook.presto.metadata.QualifiedTableName;
+import com.facebook.presto.spi.security.ConnectorAccessControl;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.SystemAccessControl;
+import com.google.common.collect.Sets;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class AccessControlManager
+        implements AccessControl
+{
+    private final Set<SystemAccessControl> systemAccessControllers = Sets.newConcurrentHashSet();
+    private final Map<String, ConnectorAccessControl> catalogAccessControl = new ConcurrentHashMap<>();
+
+    public void addSystemAccessControl(SystemAccessControl accessControl)
+    {
+        requireNonNull(accessControl, "accessControl is null");
+
+        systemAccessControllers.add(accessControl);
+    }
+
+    public void addCatalogAccessControl(String catalogName, ConnectorAccessControl accessControl)
+    {
+        requireNonNull(catalogName, "catalogName is null");
+        requireNonNull(accessControl, "accessControl is null");
+
+        if (catalogAccessControl.putIfAbsent(catalogName, accessControl) != null) {
+            throw new IllegalArgumentException(format("Access control for catalog '%s' is already registered", catalogName));
+        }
+    }
+
+    @Override
+    public void checkCanSetUser(Principal principal, String userName)
+    {
+        requireNonNull(userName, "tableName is null");
+
+        for (SystemAccessControl accessControl : systemAccessControllers) {
+            accessControl.checkCanSetUser(principal, userName);
+        }
+    }
+
+    @Override
+    public void checkCanCreateTable(Identity identity, QualifiedTableName tableName)
+    {
+        requireNonNull(identity, "identity is null");
+        requireNonNull(tableName, "tableName is null");
+
+        ConnectorAccessControl accessControl = catalogAccessControl.get(tableName.getCatalogName());
+        if (accessControl != null) {
+            accessControl.checkCanCreateTable(identity, tableName.asSchemaTableName());
+        }
+    }
+
+    @Override
+    public void checkCanDropTable(Identity identity, QualifiedTableName tableName)
+    {
+        requireNonNull(identity, "identity is null");
+        requireNonNull(tableName, "tableName is null");
+
+        ConnectorAccessControl accessControl = catalogAccessControl.get(tableName.getCatalogName());
+        if (accessControl != null) {
+            accessControl.checkCanDropTable(identity, tableName.asSchemaTableName());
+        }
+    }
+
+    @Override
+    public void checkCanRenameTable(Identity identity, QualifiedTableName tableName, QualifiedTableName newTableName)
+    {
+        requireNonNull(identity, "identity is null");
+        requireNonNull(tableName, "tableName is null");
+        requireNonNull(newTableName, "newTableName is null");
+
+        ConnectorAccessControl accessControl = catalogAccessControl.get(tableName.getCatalogName());
+        if (accessControl != null) {
+            accessControl.checkCanRenameTable(identity, tableName.asSchemaTableName(), newTableName.asSchemaTableName());
+        }
+    }
+
+    @Override
+    public void checkCanSelectFromTable(Identity identity, QualifiedTableName tableName)
+    {
+        requireNonNull(identity, "identity is null");
+        requireNonNull(tableName, "tableName is null");
+
+        ConnectorAccessControl accessControl = catalogAccessControl.get(tableName.getCatalogName());
+        if (accessControl != null) {
+            accessControl.checkCanSelectFromTable(identity, tableName.asSchemaTableName());
+        }
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(Identity identity, QualifiedTableName tableName)
+    {
+        requireNonNull(identity, "identity is null");
+        requireNonNull(tableName, "tableName is null");
+
+        ConnectorAccessControl accessControl = catalogAccessControl.get(tableName.getCatalogName());
+        if (accessControl != null) {
+            accessControl.checkCanInsertIntoTable(identity, tableName.asSchemaTableName());
+        }
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(Identity identity, QualifiedTableName tableName)
+    {
+        requireNonNull(identity, "identity is null");
+        requireNonNull(tableName, "tableName is null");
+
+        ConnectorAccessControl accessControl = catalogAccessControl.get(tableName.getCatalogName());
+        if (accessControl != null) {
+            accessControl.checkCanDeleteFromTable(identity, tableName.asSchemaTableName());
+        }
+    }
+
+    @Override
+    public void checkCanCreateView(Identity identity, QualifiedTableName viewName)
+    {
+        requireNonNull(identity, "identity is null");
+        requireNonNull(viewName, "viewName is null");
+
+        ConnectorAccessControl accessControl = catalogAccessControl.get(viewName.getCatalogName());
+        if (accessControl != null) {
+            accessControl.checkCanCreateView(identity, viewName.asSchemaTableName());
+        }
+    }
+
+    @Override
+    public void checkCanDropView(Identity identity, QualifiedTableName viewName)
+    {
+        requireNonNull(identity, "identity is null");
+        requireNonNull(viewName, "viewName is null");
+
+        ConnectorAccessControl accessControl = catalogAccessControl.get(viewName.getCatalogName());
+        if (accessControl != null) {
+            accessControl.checkCanDropView(identity, viewName.asSchemaTableName());
+        }
+    }
+
+    @Override
+    public void checkCanSelectFromView(Identity identity, QualifiedTableName viewName)
+    {
+        requireNonNull(identity, "identity is null");
+        requireNonNull(viewName, "viewName is null");
+
+        ConnectorAccessControl accessControl = catalogAccessControl.get(viewName.getCatalogName());
+        if (accessControl != null) {
+            accessControl.checkCanSelectFromView(identity, viewName.asSchemaTableName());
+        }
+    }
+
+    @Override
+    public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
+    {
+        requireNonNull(identity, "identity is null");
+        requireNonNull(propertyName, "propertyName is null");
+
+        for (SystemAccessControl accessControl : systemAccessControllers) {
+            accessControl.checkCanSetSystemSessionProperty(identity, propertyName);
+        }
+    }
+
+    @Override
+    public void checkCanSetCatalogSessionProperty(Identity identity, String catalogName, String propertyName)
+    {
+        requireNonNull(identity, "identity is null");
+        requireNonNull(catalogName, "catalogName is null");
+        requireNonNull(propertyName, "propertyName is null");
+
+        ConnectorAccessControl accessControl = catalogAccessControl.get(catalogName);
+        if (accessControl != null) {
+            accessControl.checkCanSetCatalogSessionProperty(identity, propertyName);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlModule.java
@@ -11,22 +11,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.execution;
+package com.facebook.presto.security;
 
-import com.facebook.presto.Session;
-import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.sql.SqlFormatter;
-import com.facebook.presto.security.AccessControl;
-import com.facebook.presto.sql.tree.Statement;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
 
-public interface DataDefinitionTask<T extends Statement>
+public class AccessControlModule
+    implements Module
 {
-    String getName();
-
-    void execute(T statement, Session session, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine);
-
-    default String explain(T statement)
+    @Override
+    public void configure(Binder binder)
     {
-        return SqlFormatter.formatSql(statement);
+        binder.bind(AccessControlManager.class).in(Scopes.SINGLETON);
+        binder.bind(AccessControl.class).to(AccessControlManager.class).in(Scopes.SINGLETON);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.security;
+
+import com.facebook.presto.metadata.QualifiedTableName;
+import com.facebook.presto.spi.security.Identity;
+
+import java.security.Principal;
+
+public class AllowAllAccessControl
+        implements AccessControl
+{
+    @Override
+    public void checkCanSetUser(Principal principal, String userName)
+    {
+    }
+
+    @Override
+    public void checkCanCreateTable(Identity identity, QualifiedTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanDropTable(Identity identity, QualifiedTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanRenameTable(Identity identity, QualifiedTableName tableName, QualifiedTableName newTableName)
+    {
+    }
+
+    @Override
+    public void checkCanSelectFromTable(Identity identity, QualifiedTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(Identity identity, QualifiedTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(Identity identity, QualifiedTableName tableName)
+    {
+    }
+
+    @Override
+    public void checkCanCreateView(Identity identity, QualifiedTableName viewName)
+    {
+    }
+
+    @Override
+    public void checkCanDropView(Identity identity, QualifiedTableName viewName)
+    {
+    }
+
+    @Override
+    public void checkCanSelectFromView(Identity identity, QualifiedTableName viewName)
+    {
+    }
+
+    @Override
+    public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
+    {
+    }
+
+    @Override
+    public void checkCanSetCatalogSessionProperty(Identity identity, String catalogName, String propertyName)
+    {
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.security;
+
+import com.facebook.presto.metadata.QualifiedTableName;
+import com.facebook.presto.spi.security.Identity;
+
+import java.security.Principal;
+
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDeleteTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyInsertTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySetSystemSessionProperty;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySetUser;
+
+public class DenyAllAccessControl
+        implements AccessControl
+{
+    @Override
+    public void checkCanSetUser(Principal principal, String userName)
+    {
+        denySetUser(principal, userName);
+    }
+
+    @Override
+    public void checkCanCreateTable(Identity identity, QualifiedTableName tableName)
+    {
+        denyCreateTable(tableName.toString());
+    }
+
+    @Override
+    public void checkCanDropTable(Identity identity, QualifiedTableName tableName)
+    {
+        denyDropTable(tableName.toString());
+    }
+
+    @Override
+    public void checkCanRenameTable(Identity identity, QualifiedTableName tableName, QualifiedTableName newTableName)
+    {
+        denyRenameTable(tableName.toString(), newTableName.toString());
+    }
+
+    @Override
+    public void checkCanSelectFromTable(Identity identity, QualifiedTableName tableName)
+    {
+        denySelectTable(tableName.toString());
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(Identity identity, QualifiedTableName tableName)
+    {
+        denyInsertTable(tableName.toString());
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(Identity identity, QualifiedTableName tableName)
+    {
+        denyDeleteTable(tableName.toString());
+    }
+
+    @Override
+    public void checkCanCreateView(Identity identity, QualifiedTableName viewName)
+    {
+        denyCreateView(viewName.toString());
+    }
+
+    @Override
+    public void checkCanDropView(Identity identity, QualifiedTableName viewName)
+    {
+        denyDropView(viewName.toString());
+    }
+
+    @Override
+    public void checkCanSelectFromView(Identity identity, QualifiedTableName viewName)
+    {
+        denySelectView(viewName.toString());
+    }
+
+    @Override
+    public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
+    {
+        denySetSystemSessionProperty(propertyName);
+    }
+
+    @Override
+    public void checkCanSetCatalogSessionProperty(Identity identity, String catalogName, String propertyName)
+    {
+        denySetCatalogSessionProperty(catalogName, propertyName);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ExecuteResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ExecuteResource.java
@@ -19,6 +19,7 @@ import com.facebook.presto.client.Column;
 import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.security.AccessControl;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.AbstractIterator;
 import io.airlift.http.client.HttpClient;
@@ -61,6 +62,7 @@ import static javax.ws.rs.core.Response.status;
 public class ExecuteResource
 {
     private final HttpServerInfo serverInfo;
+    private final AccessControl accessControl;
     private final SessionPropertyManager sessionPropertyManager;
     private final HttpClient httpClient;
     private final JsonCodec<QueryResults> queryResultsCodec;
@@ -68,11 +70,13 @@ public class ExecuteResource
     @Inject
     public ExecuteResource(
             HttpServerInfo serverInfo,
+            AccessControl accessControl,
             SessionPropertyManager sessionPropertyManager,
             @ForExecute HttpClient httpClient,
             JsonCodec<QueryResults> queryResultsCodec)
     {
         this.serverInfo = checkNotNull(serverInfo, "serverInfo is null");
+        this.accessControl = checkNotNull(accessControl, "accessControl is null");
         this.sessionPropertyManager = checkNotNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.httpClient = checkNotNull(httpClient, "httpClient is null");
         this.queryResultsCodec = checkNotNull(queryResultsCodec, "queryResultsCodec is null");
@@ -92,7 +96,7 @@ public class ExecuteResource
     {
         assertRequest(!isNullOrEmpty(query), "SQL query is empty");
 
-        Session session = createSessionForRequest(servletRequest, sessionPropertyManager);
+        Session session = createSessionForRequest(servletRequest, accessControl, sessionPropertyManager);
         ClientSession clientSession = session.toClientSession(serverUri(), false);
 
         StatementClient client = new StatementClient(httpClient, queryResultsCodec, clientSession, query);

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -17,10 +17,12 @@ import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.metadata.FunctionFactory;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.spi.ConnectorFactory;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.block.BlockEncodingFactory;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.security.SystemAccessControl;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.type.ParametricType;
 import com.facebook.presto.type.TypeRegistry;
@@ -76,6 +78,7 @@ public class PluginManager
     private final Injector injector;
     private final ConnectorManager connectorManager;
     private final Metadata metadata;
+    private final AccessControlManager accessControlManager;
     private final BlockEncodingManager blockEncodingManager;
     private final TypeRegistry typeRegistry;
     private final ArtifactResolver resolver;
@@ -93,6 +96,7 @@ public class PluginManager
             ConnectorManager connectorManager,
             ConfigurationFactory configurationFactory,
             Metadata metadata,
+            AccessControlManager accessControlManager,
             BlockEncodingManager blockEncodingManager,
             TypeRegistry typeRegistry)
     {
@@ -120,6 +124,7 @@ public class PluginManager
 
         this.connectorManager = checkNotNull(connectorManager, "connectorManager is null");
         this.metadata = checkNotNull(metadata, "metadata is null");
+        this.accessControlManager = checkNotNull(accessControlManager, "accessControlManager is null");
         this.blockEncodingManager = checkNotNull(blockEncodingManager, "blockEncodingManager is null");
         this.typeRegistry = checkNotNull(typeRegistry, "typeRegistry is null");
     }
@@ -207,6 +212,11 @@ public class PluginManager
         for (FunctionFactory functionFactory : plugin.getServices(FunctionFactory.class)) {
             log.info("Registering functions from %s", functionFactory.getClass().getName());
             metadata.addFunctions(functionFactory.listFunctions());
+        }
+
+        for (SystemAccessControl accessControl : plugin.getServices(SystemAccessControl.class)) {
+            log.info("Registering system access control %s", accessControl.getClass().getName());
+            accessControlManager.addSystemAccessControl(accessControl);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -17,6 +17,7 @@ import com.facebook.presto.discovery.EmbeddedDiscoveryModule;
 import com.facebook.presto.execution.NodeSchedulerConfig;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControlModule;
 import com.facebook.presto.server.security.ServerSecurityModule;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.google.common.base.Joiner;
@@ -97,6 +98,7 @@ public class PrestoServer
                 new HttpEventModule(),
                 new EmbeddedDiscoveryModule(),
                 new ServerSecurityModule(),
+                new AccessControlModule(),
                 new ServerMainModule(sqlParserOptions));
 
         modules.addAll(getAdditionalModules());

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryResource.java
@@ -19,6 +19,7 @@ import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.StageId;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.security.AccessControl;
 import com.google.common.collect.ImmutableList;
 
 import javax.inject.Inject;
@@ -52,12 +53,14 @@ import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 public class QueryResource
 {
     private final QueryManager queryManager;
+    private final AccessControl accessControl;
     private final SessionPropertyManager sessionPropertyManager;
 
     @Inject
-    public QueryResource(QueryManager queryManager, SessionPropertyManager sessionPropertyManager)
+    public QueryResource(QueryManager queryManager, AccessControl accessControl, SessionPropertyManager sessionPropertyManager)
     {
         this.queryManager = checkNotNull(queryManager, "queryManager is null");
+        this.accessControl = checkNotNull(accessControl, "accessControl is null");
         this.sessionPropertyManager = checkNotNull(sessionPropertyManager, "sessionPropertyManager is null");
     }
 
@@ -100,7 +103,7 @@ public class QueryResource
     {
         assertRequest(!isNullOrEmpty(statement), "SQL statement is empty");
 
-        Session session = createSessionForRequest(servletRequest, sessionPropertyManager);
+        Session session = createSessionForRequest(servletRequest, accessControl, sessionPropertyManager);
 
         QueryInfo queryInfo = queryManager.createQuery(session, statement);
         URI pagesUri = uriBuilderFrom(uriInfo.getRequestUri()).appendPath(queryInfo.getQueryId().toString()).build();

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -20,19 +20,24 @@ import com.facebook.presto.memory.LocalMemoryManager;
 import com.facebook.presto.metadata.AllNodes;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.ServerMainModule;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.facebook.presto.testing.TestingAccessControlManager;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
+import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.Scopes;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.discovery.client.Announcer;
@@ -78,6 +83,7 @@ public class TestingPrestoServer
     private final ConnectorManager connectorManager;
     private final TestingHttpServer server;
     private final Metadata metadata;
+    private final TestingAccessControlManager accessControl;
     private final ClusterMemoryManager clusterMemoryManager;
     private final LocalMemoryManager localMemoryManager;
     private final InternalNodeManager nodeManager;
@@ -128,7 +134,16 @@ public class TestingPrestoServer
                 .add(new TestingJmxModule())
                 .add(new EventModule())
                 .add(new TraceTokenModule())
-                .add(new ServerMainModule(new SqlParserOptions()));
+                .add(new ServerMainModule(new SqlParserOptions()))
+                .add(new Module() {
+                    @Override
+                    public void configure(Binder binder)
+                    {
+                        binder.bind(TestingAccessControlManager.class).in(Scopes.SINGLETON);
+                        binder.bind(AccessControlManager.class).to(TestingAccessControlManager.class).in(Scopes.SINGLETON);
+                        binder.bind(AccessControl.class).to(AccessControlManager.class).in(Scopes.SINGLETON);
+                    }
+                });
 
         if (discoveryUri != null) {
             checkNotNull(environment, "environment required when discoveryUri is present");
@@ -167,6 +182,7 @@ public class TestingPrestoServer
 
         server = injector.getInstance(TestingHttpServer.class);
         metadata = injector.getInstance(Metadata.class);
+        accessControl = injector.getInstance(TestingAccessControlManager.class);
         clusterMemoryManager = injector.getInstance(ClusterMemoryManager.class);
         localMemoryManager = injector.getInstance(LocalMemoryManager.class);
         nodeManager = injector.getInstance(InternalNodeManager.class);
@@ -238,6 +254,11 @@ public class TestingPrestoServer
     public Metadata getMetadata()
     {
         return metadata;
+    }
+
+    public TestingAccessControlManager getAccessControl()
+    {
+        return accessControl;
     }
 
     public LocalMemoryManager getLocalMemoryManager()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.analyzer;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.Expression;
@@ -32,15 +33,22 @@ public class Analyzer
 {
     private final Metadata metadata;
     private final SqlParser sqlParser;
+    private final AccessControl accessControl;
     private final Session session;
     private final Optional<QueryExplainer> queryExplainer;
     private final boolean experimentalSyntaxEnabled;
 
-    public Analyzer(Session session, Metadata metadata, SqlParser sqlParser, Optional<QueryExplainer> queryExplainer, boolean experimentalSyntaxEnabled)
+    public Analyzer(Session session,
+            Metadata metadata,
+            SqlParser sqlParser,
+            AccessControl accessControl,
+            Optional<QueryExplainer> queryExplainer,
+            boolean experimentalSyntaxEnabled)
     {
         this.session = checkNotNull(session, "session is null");
         this.metadata = checkNotNull(metadata, "metadata is null");
         this.sqlParser = checkNotNull(sqlParser, "sqlParser is null");
+        this.accessControl = checkNotNull(accessControl, "accessControl is null");
         this.queryExplainer = checkNotNull(queryExplainer, "query explainer is null");
         this.experimentalSyntaxEnabled = experimentalSyntaxEnabled;
     }
@@ -48,7 +56,7 @@ public class Analyzer
     public Analysis analyze(Statement statement)
     {
         Analysis analysis = new Analysis();
-        StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, session, experimentalSyntaxEnabled, queryExplainer);
+        StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, accessControl, session, experimentalSyntaxEnabled, queryExplainer);
         TupleDescriptor outputDescriptor = analyzer.process(statement, new AnalysisContext());
         analysis.setOutputDescriptor(outputDescriptor);
         return analysis;

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.analyzer;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.DataDefinitionTask;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.LogicalPlanner;
 import com.facebook.presto.sql.planner.Plan;
@@ -40,6 +41,7 @@ public class QueryExplainer
 {
     private final List<PlanOptimizer> planOptimizers;
     private final Metadata metadata;
+    private final AccessControl accessControl;
     private final SqlParser sqlParser;
     private final boolean experimentalSyntaxEnabled;
     private final Map<Class<? extends Statement>, DataDefinitionTask<?>> dataDefinitionTask;
@@ -48,12 +50,14 @@ public class QueryExplainer
     public QueryExplainer(
             List<PlanOptimizer> planOptimizers,
             Metadata metadata,
+            AccessControl accessControl,
             SqlParser sqlParser,
             Map<Class<? extends Statement>, DataDefinitionTask<?>> dataDefinitionTask,
             FeaturesConfig featuresConfig)
     {
         this(planOptimizers,
                 metadata,
+                accessControl,
                 sqlParser,
                 dataDefinitionTask,
                 featuresConfig.isExperimentalSyntaxEnabled());
@@ -62,12 +66,14 @@ public class QueryExplainer
     public QueryExplainer(
             List<PlanOptimizer> planOptimizers,
             Metadata metadata,
+            AccessControl accessControl,
             SqlParser sqlParser,
             Map<Class<? extends Statement>, DataDefinitionTask<?>> dataDefinitionTask,
             boolean experimentalSyntaxEnabled)
     {
         this.planOptimizers = checkNotNull(planOptimizers, "planOptimizers is null");
         this.metadata = checkNotNull(metadata, "metadata is null");
+        this.accessControl = checkNotNull(accessControl, "accessControl is null");
         this.sqlParser = checkNotNull(sqlParser, "sqlParser is null");
         this.experimentalSyntaxEnabled = experimentalSyntaxEnabled;
         this.dataDefinitionTask = ImmutableMap.copyOf(checkNotNull(dataDefinitionTask, "dataDefinitionTask is null"));
@@ -129,7 +135,7 @@ public class QueryExplainer
     private Plan getLogicalPlan(Session session, Statement statement)
     {
         // analyze statement
-        Analyzer analyzer = new Analyzer(session, metadata, sqlParser, Optional.of(this), experimentalSyntaxEnabled);
+        Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.of(this), experimentalSyntaxEnabled);
 
         Analysis analysis = analyzer.analyze(statement);
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
@@ -142,7 +148,7 @@ public class QueryExplainer
     private SubPlan getDistributedPlan(Session session, Statement statement)
     {
         // analyze statement
-        Analyzer analyzer = new Analyzer(session, metadata, sqlParser, Optional.of(this), experimentalSyntaxEnabled);
+        Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.of(this), experimentalSyntaxEnabled);
 
         Analysis analysis = analyzer.analyze(statement);
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();

--- a/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
@@ -36,6 +36,8 @@ public interface QueryRunner
 
     Metadata getMetadata();
 
+    TestingAccessControlManager getAccessControl();
+
     MaterializedResult execute(@Language("SQL") String sql);
 
     MaterializedResult execute(Session session, @Language("SQL") String sql);

--- a/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
@@ -22,6 +22,7 @@ import org.intellij.lang.annotations.Language;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
 
 public interface QueryRunner
         extends Closeable
@@ -46,4 +47,6 @@ public interface QueryRunner
     void installPlugin(Plugin plugin);
 
     void createCatalog(String catalogName, String connectorName, Map<String, String> properties);
+
+    Lock getExclusiveLock();
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testing;
+
+import com.facebook.presto.metadata.QualifiedTableName;
+import com.facebook.presto.security.AccessControlManager;
+import com.facebook.presto.spi.security.Identity;
+import com.google.common.base.MoreObjects;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDeleteTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyInsertTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySetSystemSessionProperty;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySetUser;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.CREATE_TABLE;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.CREATE_VIEW;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.DELETE_TABLE;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.DROP_TABLE;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.DROP_VIEW;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.INSERT_TABLE;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.RENAME_TABLE;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_TABLE;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_VIEW;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SET_SESSION;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SET_USER;
+import static java.util.Objects.requireNonNull;
+
+public class TestingAccessControlManager
+        extends AccessControlManager
+{
+    private final Set<TestingPrivilege> denyPrivileges = new HashSet<>();
+
+    public static TestingPrivilege privilege(String name, TestingPrivilegeType type)
+    {
+        return new TestingPrivilege(name, type);
+    }
+
+    public void deny(TestingPrivilege... deniedPrivileges)
+    {
+        Collections.addAll(this.denyPrivileges, deniedPrivileges);
+    }
+
+    public void reset()
+    {
+        denyPrivileges.clear();
+    }
+
+    @Override
+    public void checkCanSetUser(Principal principal, String userName)
+    {
+        if (shouldDenyPrivilege(userName, SET_USER)) {
+            denySetUser(principal, userName);
+        }
+        super.checkCanSetUser(principal, userName);
+    }
+
+    @Override
+    public void checkCanCreateTable(Identity identity, QualifiedTableName tableName)
+    {
+        if (shouldDenyPrivilege(tableName.getTableName(), CREATE_TABLE)) {
+            denyCreateTable(tableName.toString());
+        }
+        super.checkCanCreateTable(identity, tableName);
+    }
+
+    @Override
+    public void checkCanDropTable(Identity identity, QualifiedTableName tableName)
+    {
+        if (shouldDenyPrivilege(tableName.getTableName(), DROP_TABLE)) {
+            denyDropTable(tableName.toString());
+        }
+        super.checkCanDropTable(identity, tableName);
+    }
+
+    @Override
+    public void checkCanRenameTable(Identity identity, QualifiedTableName tableName, QualifiedTableName newTableName)
+    {
+        if (shouldDenyPrivilege(tableName.getTableName(), RENAME_TABLE)) {
+            denyRenameTable(tableName.toString(), newTableName.toString());
+        }
+        super.checkCanRenameTable(identity, tableName, newTableName);
+    }
+
+    @Override
+    public void checkCanSelectFromTable(Identity identity, QualifiedTableName tableName)
+    {
+        if (shouldDenyPrivilege(tableName.getTableName(), SELECT_TABLE)) {
+            denySelectTable(tableName.toString());
+        }
+        super.checkCanSelectFromTable(identity, tableName);
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(Identity identity, QualifiedTableName tableName)
+    {
+        if (shouldDenyPrivilege(tableName.getTableName(), INSERT_TABLE)) {
+            denyInsertTable(tableName.toString());
+        }
+        super.checkCanInsertIntoTable(identity, tableName);
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(Identity identity, QualifiedTableName tableName)
+    {
+        if (shouldDenyPrivilege(tableName.getTableName(), DELETE_TABLE)) {
+            denyDeleteTable(tableName.toString());
+        }
+        super.checkCanDeleteFromTable(identity, tableName);
+    }
+
+    @Override
+    public void checkCanCreateView(Identity identity, QualifiedTableName viewName)
+    {
+        if (shouldDenyPrivilege(viewName.getTableName(), CREATE_VIEW)) {
+            denyCreateView(viewName.toString());
+        }
+        super.checkCanCreateView(identity, viewName);
+    }
+
+    @Override
+    public void checkCanDropView(Identity identity, QualifiedTableName viewName)
+    {
+        if (shouldDenyPrivilege(viewName.getTableName(), DROP_VIEW)) {
+            denyDropView(viewName.toString());
+        }
+        super.checkCanDropView(identity, viewName);
+    }
+
+    @Override
+    public void checkCanSelectFromView(Identity identity, QualifiedTableName viewName)
+    {
+        if (shouldDenyPrivilege(viewName.getTableName(), SELECT_VIEW)) {
+            denySelectView(viewName.toString());
+        }
+        super.checkCanSelectFromView(identity, viewName);
+    }
+
+    @Override
+    public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
+    {
+        if (shouldDenyPrivilege(propertyName, SET_SESSION)) {
+            denySetSystemSessionProperty(propertyName);
+        }
+        super.checkCanSetSystemSessionProperty(identity, propertyName);
+    }
+
+    @Override
+    public void checkCanSetCatalogSessionProperty(Identity identity, String catalogName, String propertyName)
+    {
+        if (shouldDenyPrivilege(catalogName + "." + propertyName, SET_SESSION)) {
+            denySetCatalogSessionProperty(catalogName, propertyName);
+        }
+        super.checkCanSetCatalogSessionProperty(identity, catalogName, propertyName);
+    }
+
+    private boolean shouldDenyPrivilege(String entityName, TestingPrivilegeType type)
+    {
+        return denyPrivileges.contains(privilege(entityName, type));
+    }
+
+    public enum TestingPrivilegeType
+    {
+        SET_USER,
+        CREATE_TABLE, DROP_TABLE, RENAME_TABLE, SELECT_TABLE, INSERT_TABLE, DELETE_TABLE,
+        CREATE_VIEW, DROP_VIEW, SELECT_VIEW,
+        SET_SESSION
+    }
+
+    public static class TestingPrivilege
+    {
+        private final String name;
+        private final TestingPrivilegeType type;
+
+        private TestingPrivilege(String name, TestingPrivilegeType type)
+        {
+            this.name = requireNonNull(name, "name is null");
+            this.type = requireNonNull(type, "type is null");
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TestingPrivilege that = (TestingPrivilege) o;
+            return Objects.equals(name, that.name) &&
+                    Objects.equals(type, that.type);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(name, type);
+        }
+
+        @Override
+        public String toString()
+        {
+            return MoreObjects.toStringHelper(this)
+                    .add("name", name)
+                    .add("type", type)
+                    .toString();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -15,6 +15,7 @@ package com.facebook.presto.testing;
 
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.type.TimeZoneKey;
 import com.google.common.base.MoreObjects;
@@ -24,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
@@ -41,7 +43,7 @@ public class TestingConnectorSession
             ImmutableList.of(),
             ImmutableMap.of());
 
-    private final String user;
+    private final Identity identity;
     private final TimeZoneKey timeZoneKey;
     private final Locale locale;
     private final long startTime;
@@ -56,7 +58,7 @@ public class TestingConnectorSession
             List<PropertyMetadata<?>> propertyMetadatas,
             Map<String, Object> propertyValues)
     {
-        this.user = requireNonNull(user, "user is null");
+        this.identity = new Identity(requireNonNull(user, "user is null"), Optional.empty());
         this.timeZoneKey = requireNonNull(timeZoneKey, "timeZoneKey is null");
         this.locale = requireNonNull(locale, "locale is null");
         this.startTime = startTime;
@@ -70,9 +72,9 @@ public class TestingConnectorSession
     }
 
     @Override
-    public String getUser()
+    public Identity getIdentity()
     {
-        return user;
+        return identity;
     }
 
     @Override
@@ -111,7 +113,7 @@ public class TestingConnectorSession
     public String toString()
     {
         return MoreObjects.toStringHelper(this)
-                .add("user", user)
+                .add("user", getUser())
                 .add("timeZoneKey", timeZoneKey)
                 .add("locale", locale)
                 .add("startTime", startTime)

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingSession.java
@@ -16,6 +16,9 @@ package com.facebook.presto.testing;
 import com.facebook.presto.Session;
 import com.facebook.presto.Session.SessionBuilder;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.spi.security.Identity;
+
+import java.util.Optional;
 
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
 import static java.util.Locale.ENGLISH;
@@ -27,7 +30,7 @@ public final class TestingSession
     public static SessionBuilder testSessionBuilder()
     {
         return Session.builder(new SessionPropertyManager())
-                .setUser("user")
+                .setIdentity(new Identity("user", Optional.empty()))
                 .setSource("test")
                 .setCatalog("catalog")
                 .setSchema("schema")

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryQueueDefinition.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryQueueDefinition.java
@@ -14,8 +14,11 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.testing.TestingSession;
 import org.testng.annotations.Test;
+
+import java.util.Optional;
 
 import static org.testng.Assert.assertEquals;
 
@@ -25,7 +28,7 @@ public class TestQueryQueueDefinition
     public void testNameExpansion()
     {
         Session session = TestingSession.testSessionBuilder()
-                .setUser("bob")
+                .setIdentity(new Identity("bob", Optional.empty()))
                 .setSource("the-internet")
                 .build();
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestResetSessionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestResetSessionTask.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.ResetSession;
 import com.google.common.collect.ImmutableList;
@@ -65,7 +66,7 @@ public class TestResetSessionTask
         Session session = TEST_SESSION.withSystemProperty("foo", "bar").withCatalogProperty("catalog", "baz", "blah");
 
         QueryStateMachine stateMachine = new QueryStateMachine(new QueryId("query"), "reset foo", session, URI.create("fake://uri"), executor);
-        new ResetSessionTask().execute(new ResetSession(QualifiedName.of("catalog", "baz")), session, metadata, stateMachine);
+        new ResetSessionTask().execute(new ResetSession(QualifiedName.of("catalog", "baz")), session, metadata, new AllowAllAccessControl(), stateMachine);
 
         Set<String> sessionProperties = stateMachine.getResetSessionProperties();
         assertEquals(sessionProperties, ImmutableSet.of("catalog.baz"));

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSetSessionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSetSessionTask.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -75,7 +76,7 @@ public class TestSetSessionTask
             throws Exception
     {
         QueryStateMachine stateMachine = new QueryStateMachine(new QueryId("query"), "set foo.bar = 'baz'", TEST_SESSION, URI.create("fake://uri"), executor);
-        new SetSessionTask().execute(new SetSession(QualifiedName.of("foo", "bar"), expression), TEST_SESSION, metadata, stateMachine);
+        new SetSessionTask().execute(new SetSession(QualifiedName.of("foo", "bar"), expression), TEST_SESSION, metadata, new AllowAllAccessControl(), stateMachine);
 
         Map<String, String> sessionProperties = stateMachine.getSetSessionProperties();
         assertEquals(sessionProperties, ImmutableMap.of("foo.bar", expectedValue));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -529,7 +529,8 @@ public final class FunctionAssertions
         filter = ExpressionTreeRewriter.rewriteWith(new SymbolToInputRewriter(INPUT_MAPPING), filter);
         projection = ExpressionTreeRewriter.rewriteWith(new SymbolToInputRewriter(INPUT_MAPPING), projection);
 
-        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(TEST_SESSION, metadata, SQL_PARSER, INPUT_TYPES, ImmutableList.of(filter, projection));
+        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(TEST_SESSION, metadata,
+                SQL_PARSER, INPUT_TYPES, ImmutableList.of(filter, projection));
 
         try {
             List<RowExpression> projections = ImmutableList.of(toRowExpression(projection, expressionTypes));
@@ -550,7 +551,8 @@ public final class FunctionAssertions
         filter = ExpressionTreeRewriter.rewriteWith(new SymbolToInputRewriter(INPUT_MAPPING), filter);
         projection = ExpressionTreeRewriter.rewriteWith(new SymbolToInputRewriter(INPUT_MAPPING), projection);
 
-        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(TEST_SESSION, metadata, SQL_PARSER, INPUT_TYPES, ImmutableList.of(filter, projection));
+        IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypesFromInput(TEST_SESSION, metadata,
+                SQL_PARSER, INPUT_TYPES, ImmutableList.of(filter, projection));
 
         try {
             CursorProcessor cursorProcessor = compiler.compileCursorProcessor(

--- a/presto-main/src/test/java/com/facebook/presto/server/MockHttpServletRequest.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/MockHttpServletRequest.java
@@ -149,7 +149,7 @@ public class MockHttpServletRequest
     @Override
     public Principal getUserPrincipal()
     {
-        throw new UnsupportedOperationException();
+        return null;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/server/TestResourceUtil.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestResourceUtil.java
@@ -15,6 +15,7 @@ package com.facebook.presto.server;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.security.AllowAllAccessControl;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
@@ -56,7 +57,7 @@ public class TestResourceUtil
                         .build(),
                 "testRemote");
 
-        Session session = createSessionForRequest(request, new SessionPropertyManager());
+        Session session = createSessionForRequest(request, new AllowAllAccessControl(), new SessionPropertyManager());
 
         assertEquals(session.getUser(), "testUser");
         assertEquals(session.getSource().get(), "testSource");

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.sql.analyzer;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.QualifiedTableName;
@@ -792,6 +794,7 @@ public class TestAnalyzer
         metadata.addConnectorMetadata("tpch", "tpch", new TestingMetadata());
         metadata.addConnectorMetadata("c2", "c2", new TestingMetadata());
         metadata.addConnectorMetadata("c3", "c3", new TestingMetadata());
+        AccessControl accessControl = new AllowAllAccessControl();
 
         SchemaTableName table1 = new SchemaTableName("default", "t1");
         metadata.createTable(SESSION, "tpch", new TableMetadata("tpch", new ConnectorTableMetadata(table1,
@@ -852,6 +855,7 @@ public class TestAnalyzer
                         .build(),
                 metadata,
                 SQL_PARSER,
+                accessControl,
                 Optional.empty(),
                 true);
 
@@ -862,6 +866,7 @@ public class TestAnalyzer
                         .build(),
                 metadata,
                 SQL_PARSER,
+                accessControl,
                 Optional.empty(),
                 false);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Connector.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Connector.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi;
 
+import com.facebook.presto.spi.security.ConnectorAccessControl;
 import com.facebook.presto.spi.session.PropertyMetadata;
 
 import java.util.List;
@@ -91,6 +92,14 @@ public interface Connector
     default List<PropertyMetadata<?>> getTableProperties()
     {
         return emptyList();
+    }
+
+    /**
+     * @throws UnsupportedOperationException if this connector does not have an access control
+     */
+    default ConnectorAccessControl getAccessControl()
+    {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.security;
+
+import com.facebook.presto.spi.PrestoException;
+
+import java.security.Principal;
+
+import static com.facebook.presto.spi.StandardErrorCode.PERMISSION_DENIED;
+import static java.lang.String.format;
+
+public class AccessDeniedException
+        extends PrestoException
+{
+    public AccessDeniedException(String message)
+    {
+        super(PERMISSION_DENIED, "Access Denied: " + message);
+    }
+
+    public static void denySetUser(Principal principal, String userName)
+    {
+        denySetUser(principal, userName, null);
+    }
+
+    public static void denySetUser(Principal principal, String userName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Principal %s cannot become user %s%s", principal, userName, formatExtraInfo(extraInfo)));
+    }
+
+    public static void denyCreateTable(String tableName)
+    {
+        denyCreateTable(tableName, null);
+    }
+
+    public static void denyCreateTable(String tableName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot create table %s%s", tableName, formatExtraInfo(extraInfo)));
+    }
+
+    public static void denyDropTable(String tableName)
+    {
+        denyDropTable(tableName, null);
+    }
+
+    public static void denyDropTable(String tableName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot drop table %s%s", tableName, formatExtraInfo(extraInfo)));
+    }
+
+    public static void denyRenameTable(String tableName, String newTableName)
+    {
+        denyRenameTable(tableName, newTableName, null);
+    }
+
+    public static void denyRenameTable(String tableName, String newTableName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot rename table from %s to %s%s", tableName, newTableName, formatExtraInfo(extraInfo)));
+    }
+
+    public static void denySelectTable(String tableName)
+    {
+        denySelectTable(tableName, null);
+    }
+
+    public static void denySelectTable(String tableName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot select from table %s%s", tableName, formatExtraInfo(extraInfo)));
+    }
+
+    public static void denyInsertTable(String tableName)
+    {
+        denyInsertTable(tableName, null);
+    }
+
+    public static void denyInsertTable(String tableName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot insert into table %s%s", tableName, formatExtraInfo(extraInfo)));
+    }
+
+    public static void denyDeleteTable(String tableName)
+    {
+        denyDeleteTable(tableName, null);
+    }
+
+    public static void denyDeleteTable(String tableName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot delete from table %s%s", tableName, formatExtraInfo(extraInfo)));
+    }
+
+    public static void denyCreateView(String viewName)
+    {
+        denyCreateView(viewName, null);
+    }
+
+    public static void denyCreateView(String viewName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot create view %s%s", viewName, formatExtraInfo(extraInfo)));
+    }
+
+    public static void denyDropView(String viewName)
+    {
+        denyDropView(viewName, null);
+    }
+
+    public static void denyDropView(String viewName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot drop view %s%s", viewName, formatExtraInfo(extraInfo)));
+    }
+
+    public static void denySelectView(String viewName)
+    {
+        denySelectView(viewName, null);
+    }
+
+    public static void denySelectView(String viewName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot select from view %s%s", viewName, formatExtraInfo(extraInfo)));
+    }
+
+    public static void denySetSystemSessionProperty(String propertyName)
+    {
+        denySetSystemSessionProperty(propertyName, null);
+    }
+
+    public static void denySetSystemSessionProperty(String propertyName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot set system session property %s%s", propertyName, formatExtraInfo(extraInfo)));
+    }
+
+    public static void denySetCatalogSessionProperty(String catalogName, String propertyName)
+    {
+        denySetCatalogSessionProperty(catalogName, propertyName, null);
+    }
+
+    public static void denySetCatalogSessionProperty(String catalogName, String propertyName, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot set catalog session property %s.%s%s", catalogName, propertyName, formatExtraInfo(extraInfo)));
+    }
+
+    private static Object formatExtraInfo(String extraInfo)
+    {
+        if (extraInfo == null || extraInfo.isEmpty()) {
+            return "";
+        }
+        return ": " + extraInfo;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/ConnectorAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/ConnectorAccessControl.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.security;
+
+import com.facebook.presto.spi.SchemaTableName;
+
+public interface ConnectorAccessControl
+{
+    /**
+     * Check if identity is allowed to create the specified table in this catalog.
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanCreateTable(Identity identity, SchemaTableName tableName);
+
+    /**
+     * Check if identity is allowed to drop the specified table in this catalog.
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanDropTable(Identity identity, SchemaTableName tableName);
+
+    /**
+     * Check if identity is allowed to rename the specified table in this catalog.
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanRenameTable(Identity identity, SchemaTableName tableName, SchemaTableName newTableName);
+
+    /**
+     * Check if identity is allowed to select from the specified table in this catalog.
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanSelectFromTable(Identity identity, SchemaTableName tableName);
+
+    /**
+     * Check if identity is allowed to insert into the specified table in this catalog.
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanInsertIntoTable(Identity identity, SchemaTableName tableName);
+
+    /**
+     * Check if identity is allowed to delete from the specified table in this catalog.
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanDeleteFromTable(Identity identity, SchemaTableName tableName);
+
+    /**
+     * Check if identity is allowed to create the specified view in this catalog.
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanCreateView(Identity identity, SchemaTableName viewName);
+
+    /**
+     * Check if identity is allowed to drop the specified view in this catalog.
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanDropView(Identity identity, SchemaTableName viewName);
+
+    /**
+     * Check if identity is allowed to select from the specified view in this catalog.
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanSelectFromView(Identity identity, SchemaTableName viewName);
+
+    /**
+     * Check if identity is allowed to set the specified property in this catalog.
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanSetCatalogSessionProperty(Identity identity, String propertyName);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/Identity.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/Identity.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.security;
+
+import java.security.Principal;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class Identity
+{
+    private final String user;
+    private final Optional<Principal> principal;
+
+    public Identity(String user, Optional<Principal> principal)
+    {
+        this.user = requireNonNull(user, "user is null");
+        this.principal = requireNonNull(principal, "principal is null");
+    }
+
+    public String getUser()
+    {
+        return user;
+    }
+
+    public Optional<Principal> getPrincipal()
+    {
+        return principal;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Identity identity = (Identity) o;
+        return Objects.equals(user, identity.user);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(user);
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder("Identity{");
+        sb.append("user='").append(user).append('\'');
+        if (principal.isPresent()) {
+            sb.append(", principal=").append(principal.get());
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -11,27 +11,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.spi;
+package com.facebook.presto.spi.security;
 
-import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.type.TimeZoneKey;
+import java.security.Principal;
 
-import java.util.Locale;
-
-public interface ConnectorSession
+public interface SystemAccessControl
 {
-    default String getUser()
-    {
-        return getIdentity().getUser();
-    }
+    /**
+     * Check if the principal is allowed to be the specified user.
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanSetUser(Principal principal, String userName);
 
-    Identity getIdentity();
-
-    TimeZoneKey getTimeZoneKey();
-
-    Locale getLocale();
-
-    long getStartTime();
-
-    <T> T getProperty(String name, Class<T> type);
+    /**
+     * Check if identity is allowed to set the specified system property.
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanSetSystemSessionProperty(Identity identity, String propertyName);
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.block;
 
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.DynamicSliceOutput;
@@ -23,6 +24,7 @@ import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
@@ -36,9 +38,9 @@ public class TestDictionaryBlockEncoding
     private static final ConnectorSession SESSION = new ConnectorSession()
     {
         @Override
-        public String getUser()
+        public Identity getIdentity()
         {
-            return "user";
+            return new Identity("user", Optional.empty());
         }
 
         @Override

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockEncoding.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockEncoding.java
@@ -15,12 +15,14 @@ package com.facebook.presto.spi.block;
 
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.DynamicSliceOutput;
 import org.testng.annotations.Test;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
@@ -33,9 +35,9 @@ public class TestVariableWidthBlockEncoding
     private static final ConnectorSession SESSION = new ConnectorSession()
     {
         @Override
-        public String getUser()
+        public Identity getIdentity()
         {
-            return "user";
+            return new Identity("user", Optional.empty());
         }
 
         @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.testing.TestingAccessControlManager;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -178,6 +179,12 @@ public class DistributedQueryRunner
     public Metadata getMetadata()
     {
         return coordinator.getMetadata();
+    }
+
+    @Override
+    public TestingAccessControlManager getAccessControl()
+    {
+        return coordinator.getAccessControl();
     }
 
     public TestingPrestoServer getCoordinator()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.testing.TestingAccessControlManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Module;
@@ -121,6 +122,12 @@ public final class StandaloneQueryRunner
     public Metadata getMetadata()
     {
         return server.getMetadata();
+    }
+
+    @Override
+    public TestingAccessControlManager getAccessControl()
+    {
+        return server.getAccessControl();
     }
 
     public TestingPrestoServer getServer()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -32,6 +32,9 @@ import org.intellij.lang.annotations.Language;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -42,6 +45,8 @@ public final class StandaloneQueryRunner
     private final TestingPrestoServer server;
 
     private final TestingPrestoClient prestoClient;
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     public StandaloneQueryRunner(Session defaultSession)
             throws Exception
@@ -70,13 +75,27 @@ public final class StandaloneQueryRunner
     @Override
     public MaterializedResult execute(@Language("SQL") String sql)
     {
-        return prestoClient.execute(sql);
+        lock.readLock().lock();
+        try {
+            return prestoClient.execute(sql);
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+
     }
 
     @Override
     public MaterializedResult execute(Session session, @Language("SQL") String sql)
     {
-        return prestoClient.execute(session, sql);
+        lock.readLock().lock();
+        try {
+            return prestoClient.execute(session, sql);
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+
     }
 
     @Override
@@ -163,13 +182,33 @@ public final class StandaloneQueryRunner
     @Override
     public List<QualifiedTableName> listTables(Session session, String catalog, String schema)
     {
-        return prestoClient.listTables(session, catalog, schema);
+        lock.readLock().lock();
+        try {
+            return prestoClient.listTables(session, catalog, schema);
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+
     }
 
     @Override
     public boolean tableExists(Session session, String table)
     {
-        return prestoClient.tableExists(session, table);
+        lock.readLock().lock();
+        try {
+            return prestoClient.tableExists(session, table);
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+
+    }
+
+    @Override
+    public Lock getExclusiveLock()
+    {
+        return lock.writeLock();
     }
 
     private static TestingPrestoServer createTestingPrestoServer()


### PR DESCRIPTION
The design and implementation of this is very much a work in progress, so please let me know if you have any feedback.

This adds basic authorization checks to Presto.  During analysis of a statement we check if the identity attached to the session is authorized to perform the specified actions.  For statements that skip analysis, the checks are performed directly in the task execution.  The implementation allows for plugins to provide a system wide access control implementation or a specific access control for connector instance.