### PR TITLE
Simplify updateAssignments in ClusterMemoryManager

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
@@ -150,10 +150,8 @@ public class ClusterMemoryManager
                         maxMemory = bytesUsed;
                     }
                 }
-                for (QueryExecution queryExecution : queries) {
-                    if (queryExecution.getQueryId().equals(biggestQuery.getQueryId())) {
-                        queryExecution.setMemoryPool(new VersionedMemoryPoolId(RESERVED_POOL, version));
-                    }
+                if (biggestQuery != null) {
+                    biggestQuery.setMemoryPool(new VersionedMemoryPoolId(RESERVED_POOL, version));
                 }
             }
         }


### PR DESCRIPTION
We already find the `biggestQuery`, there is not need to find it again in `queries`