### PR TITLE
presto-hive: add posibility to specify storage format using hive storage handler class name

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -558,15 +558,32 @@ public class HiveMetadata
         if (serdeInfo == null) {
             throw new PrestoException(HIVE_INVALID_METADATA, "Table storage descriptor is missing SerDe info");
         }
-        String outputFormat = descriptor.getOutputFormat();
-        String serializationLib = serdeInfo.getSerializationLib();
 
-        for (HiveStorageFormat format : HiveStorageFormat.values()) {
+        String serializationLib = serdeInfo.getSerializationLib();
+        String inputFormat = descriptor.getInputFormat();
+        String outputFormat = descriptor.getOutputFormat();
+
+        for (HiveStorageFormat format : HiveStorageFormat.predefinedFormats()) {
             if (format.getOutputFormat().equals(outputFormat) && format.getSerDe().equals(serializationLib)) {
                 return format;
             }
         }
-        throw new PrestoException(HIVE_UNSUPPORTED_FORMAT, format("Output format %s with SerDe %s is not supported", outputFormat, serializationLib));
+
+        return tryLoadCustomStorageFormat(serializationLib, inputFormat, outputFormat);
+    }
+
+    private static HiveStorageFormat tryLoadCustomStorageFormat(String serializationLib, String inputFormat, String outputFormat)
+    {
+        try {
+            return new HiveStorageFormat(
+                    Class.forName(serializationLib).getName(),
+                    Class.forName(inputFormat).getName(),
+                    Class.forName(outputFormat).getName()
+            );
+        }
+        catch (ClassNotFoundException e) {
+            throw new PrestoException(HIVE_UNSUPPORTED_FORMAT, format("Output format %s with SerDe %s is not supported", outputFormat, serializationLib));
+        }
     }
 
     private boolean pathExists(Path path)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveStorageFormat.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveStorageFormat.java
@@ -13,6 +13,12 @@
  */
 package com.facebook.presto.hive;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat;
 import org.apache.hadoop.hive.ql.io.RCFileInputFormat;
@@ -23,61 +29,165 @@ import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
 import org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe;
 import org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
 import org.apache.hadoop.mapred.SequenceFileInputFormat;
 import org.apache.hadoop.mapred.TextInputFormat;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Collection;
 
-public enum HiveStorageFormat
+import static com.facebook.presto.hive.util.Types.checkType;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.Class.forName;
+import static java.util.Locale.ENGLISH;
+
+public class HiveStorageFormat
 {
-    ORC(OrcSerde.class.getName(),
+    private static final Logger LOG = Logger.get(HiveMetadata.class);
+
+    public static final HiveStorageFormat ORC = new HiveStorageFormat(OrcSerde.class.getName(),
             OrcInputFormat.class.getName(),
-            OrcOutputFormat.class.getName()),
-    DWRF(com.facebook.hive.orc.OrcSerde.class.getName(),
+            OrcOutputFormat.class.getName());
+    public static final HiveStorageFormat DWRF = new HiveStorageFormat(com.facebook.hive.orc.OrcSerde.class.getName(),
             com.facebook.hive.orc.OrcInputFormat.class.getName(),
-            com.facebook.hive.orc.OrcOutputFormat.class.getName()),
-    PARQUET(ParquetHiveSerDe.class.getName(),
+            com.facebook.hive.orc.OrcOutputFormat.class.getName());
+    public static final HiveStorageFormat PARQUET = new HiveStorageFormat(ParquetHiveSerDe.class.getName(),
             MapredParquetInputFormat.class.getName(),
-            MapredParquetOutputFormat.class.getName()),
-    RCBINARY(LazyBinaryColumnarSerDe.class.getName(),
+            MapredParquetOutputFormat.class.getName());
+    public static final HiveStorageFormat RCBINARY = new HiveStorageFormat(LazyBinaryColumnarSerDe.class.getName(),
             RCFileInputFormat.class.getName(),
-            RCFileOutputFormat.class.getName()),
-    RCTEXT(ColumnarSerDe.class.getName(),
+            RCFileOutputFormat.class.getName());
+    public static final HiveStorageFormat RCTEXT = new HiveStorageFormat(ColumnarSerDe.class.getName(),
             RCFileInputFormat.class.getName(),
-            RCFileOutputFormat.class.getName()),
-    SEQUENCEFILE(LazySimpleSerDe.class.getName(),
+            RCFileOutputFormat.class.getName());
+    public static final HiveStorageFormat SEQUENCEFILE = new HiveStorageFormat(LazySimpleSerDe.class.getName(),
             SequenceFileInputFormat.class.getName(),
-            HiveSequenceFileOutputFormat.class.getName()),
-    TEXTFILE(LazySimpleSerDe.class.getName(),
+            HiveSequenceFileOutputFormat.class.getName());
+    public static final HiveStorageFormat TEXTFILE = new HiveStorageFormat(LazySimpleSerDe.class.getName(),
             TextInputFormat.class.getName(),
             HiveIgnoreKeyTextOutputFormat.class.getName());
 
-    private final String serde;
+    private final String serDe;
     private final String inputFormat;
     private final String outputFormat;
 
-    HiveStorageFormat(String serde, String inputFormat, String outputFormat)
+    @JsonCreator
+    public HiveStorageFormat(
+            @JsonProperty("serDe") String serDe,
+            @JsonProperty("inputFormat") String inputFormat,
+            @JsonProperty("outputFormat") String outputFormat)
     {
-        this.serde = checkNotNull(serde, "serde is null");
+        this.serDe = checkNotNull(serDe, "serDe is null");
         this.inputFormat = checkNotNull(inputFormat, "inputFormat is null");
         this.outputFormat = checkNotNull(outputFormat, "outputFormat is null");
     }
 
+    @JsonProperty
     public String getSerDe()
     {
-        return serde;
+        return serDe;
     }
 
+    @JsonProperty
     public String getInputFormat()
     {
         return inputFormat;
     }
 
+    @JsonProperty
     public String getOutputFormat()
     {
         return outputFormat;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        HiveStorageFormat that = (HiveStorageFormat) o;
+
+        return Objects.equal(this.serDe, that.serDe) &&
+                Objects.equal(this.inputFormat, that.inputFormat) &&
+                Objects.equal(this.outputFormat, that.outputFormat);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(serDe, inputFormat, outputFormat);
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("serDe", serDe)
+                .add("inputFormat", inputFormat)
+                .add("outputFormat", outputFormat)
+                .toString();
+    }
+
+    public static HiveStorageFormat valueOf(String format)
+    {
+        HiveStorageFormat predefinedFormat = getByName(format);
+        HiveStorageFormat customFormat = getBySerdeClass(format);
+        HiveStorageFormat hiveStorageFormat = predefinedFormat != null ? predefinedFormat : customFormat;
+        checkArgument(hiveStorageFormat != null, "Format %s not found", format);
+        return hiveStorageFormat;
+    }
+
+    public static Collection<HiveStorageFormat> predefinedFormats()
+    {
+        return ImmutableList.of(ORC, DWRF, PARQUET, RCBINARY, RCTEXT, SEQUENCEFILE, TEXTFILE);
+    }
+
+    private static HiveStorageFormat getByName(String format)
+    {
+        switch (format.toUpperCase(ENGLISH)) {
+            case "ORC":
+                return ORC;
+            case "DWRF":
+                return DWRF;
+            case "PARQUET":
+                return PARQUET;
+            case "RCBINARY":
+                return RCBINARY;
+            case "RCTEXT":
+                return RCTEXT;
+            case "SEQUENCEFILE":
+                return SEQUENCEFILE;
+            case "TEXTFILE":
+                return TEXTFILE;
+            default:
+                return null;
+        }
+    }
+
+    private static HiveStorageFormat getBySerdeClass(String className)
+    {
+        try {
+            Class<?> clazz = forName(className);
+            HiveStorageHandler storageHandler = checkType(
+                    clazz.newInstance(), HiveStorageHandler.class, "Handler class should implement " + HiveStorageHandler.class.getName()
+            );
+            return new HiveStorageFormat(
+                    storageHandler.getSerDeClass().getName(),
+                    storageHandler.getInputFormatClass().getName(),
+                    storageHandler.getOutputFormatClass().getName()
+            );
+        }
+        catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            LOG.debug("Exception happens during loading serde class", e);
+            return null;
+        }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static java.util.Locale.ENGLISH;
 
 public class HiveTableProperties
 {
@@ -42,7 +41,7 @@ public class HiveTableProperties
                         HiveStorageFormat.class,
                         config.getHiveStorageFormat(),
                         false,
-                        value -> HiveStorageFormat.valueOf(((String) value).toUpperCase(ENGLISH))));
+                        value -> HiveStorageFormat.valueOf(((String) value))));
     }
 
     public List<PropertyMetadata<?>> getTableProperties()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -139,7 +139,10 @@ public abstract class AbstractTestHiveClient
     protected static final String INVALID_TABLE = "totally_invalid_table_name";
     protected static final String INVALID_COLUMN = "totally_invalid_column_name";
 
-    protected Set<HiveStorageFormat> createTableFormats = ImmutableSet.copyOf(HiveStorageFormat.values());
+    protected Set<HiveStorageFormat> createTableFormats = ImmutableSet.<HiveStorageFormat>builder()
+            .addAll(HiveStorageFormat.predefinedFormats())
+            .add(HiveStorageFormat.valueOf(TestHiveStorageHandler.class.getName()))
+            .build();
 
     protected String database;
     protected SchemaTableName tablePartitionFormat;
@@ -1725,41 +1728,43 @@ public abstract class AbstractTestHiveClient
     protected static void assertPageSourceType(ConnectorPageSource pageSource, HiveStorageFormat hiveStorageFormat)
     {
         if (pageSource instanceof RecordPageSource) {
-            assertInstanceOf(((RecordPageSource) pageSource).getCursor(), recordCursorType(hiveStorageFormat), hiveStorageFormat.name());
+            assertInstanceOf(((RecordPageSource) pageSource).getCursor(), recordCursorType(hiveStorageFormat), hiveStorageFormat.toString());
         }
         else {
-            assertInstanceOf(pageSource, pageSourceType(hiveStorageFormat), hiveStorageFormat.name());
+            assertInstanceOf(pageSource, pageSourceType(hiveStorageFormat), hiveStorageFormat.toString());
         }
     }
 
     private static Class<? extends HiveRecordCursor> recordCursorType(HiveStorageFormat hiveStorageFormat)
     {
-        switch (hiveStorageFormat) {
-            case RCTEXT:
-                return ColumnarTextHiveRecordCursor.class;
-            case RCBINARY:
-                return ColumnarBinaryHiveRecordCursor.class;
-            case ORC:
-                return OrcHiveRecordCursor.class;
-            case PARQUET:
-                return ParquetHiveRecordCursor.class;
-            case DWRF:
-                return DwrfHiveRecordCursor.class;
+        if (HiveStorageFormat.RCTEXT.equals(hiveStorageFormat)) {
+            return ColumnarTextHiveRecordCursor.class;
+        }
+        else if (HiveStorageFormat.RCBINARY.equals(hiveStorageFormat)) {
+            return ColumnarBinaryHiveRecordCursor.class;
+        }
+        else if (HiveStorageFormat.ORC.equals(hiveStorageFormat)) {
+            return OrcHiveRecordCursor.class;
+        }
+        else if (HiveStorageFormat.PARQUET.equals(hiveStorageFormat)) {
+            return ParquetHiveRecordCursor.class;
+        }
+        else if (HiveStorageFormat.DWRF.equals(hiveStorageFormat)) {
+            return DwrfHiveRecordCursor.class;
         }
         return GenericHiveRecordCursor.class;
     }
 
     private static Class<? extends ConnectorPageSource> pageSourceType(HiveStorageFormat hiveStorageFormat)
     {
-        switch (hiveStorageFormat) {
-            case RCTEXT:
-            case RCBINARY:
-                return RcFilePageSource.class;
-            case ORC:
-            case DWRF:
-                return OrcPageSource.class;
-            default:
-                throw new AssertionError("Filed type " + hiveStorageFormat + " does not use a page source");
+        if (HiveStorageFormat.RCTEXT.equals(hiveStorageFormat) || HiveStorageFormat.RCBINARY.equals(hiveStorageFormat)) {
+            return RcFilePageSource.class;
+        }
+        else if (HiveStorageFormat.ORC.equals(hiveStorageFormat) || HiveStorageFormat.DWRF.equals(hiveStorageFormat)) {
+            return OrcPageSource.class;
+        }
+        else {
+            throw new AssertionError("Filed type " + hiveStorageFormat + " does not use a page source");
         }
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -35,6 +35,7 @@ import com.facebook.presto.type.TypeRegistry;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 import io.airlift.slice.Slice;
 import org.apache.hadoop.fs.FileSystem;
@@ -50,6 +51,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 
@@ -269,7 +271,12 @@ public abstract class AbstractTestHiveClientS3
     public void testTableCreation()
             throws Exception
     {
-        for (HiveStorageFormat storageFormat : HiveStorageFormat.values()) {
+        Set<HiveStorageFormat> createTableFormats = ImmutableSet.<HiveStorageFormat>builder()
+                .addAll(HiveStorageFormat.predefinedFormats())
+                .add(HiveStorageFormat.valueOf(TestHiveStorageHandler.class.getName()))
+                .build();
+
+        for (HiveStorageFormat storageFormat : createTableFormats) {
             try {
                 doCreateTable(temporaryCreateTable, storageFormat, "presto_test");
             }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveStorageFormatTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveStorageFormatTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import io.airlift.json.JsonCodec;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class HiveStorageFormatTest
+{
+    private final JsonCodec<HiveStorageFormat> codec = JsonCodec.jsonCodec(HiveStorageFormat.class);
+
+    @Test
+    public void testPredefinedStorageFormatRoundTrip()
+    {
+        HiveStorageFormat expected = HiveStorageFormat.valueOf("ORC");
+
+        String json = codec.toJson(expected);
+        HiveStorageFormat actual = codec.fromJson(json);
+
+        assertEquals(actual.getSerDe(), expected.getSerDe());
+        assertEquals(actual.getInputFormat(), expected.getInputFormat());
+        assertEquals(actual.getOutputFormat(), expected.getOutputFormat());
+    }
+
+    @Test
+    public void testCustomStorageFormatRoundTrip()
+    {
+        HiveStorageFormat expected = HiveStorageFormat.valueOf(TestHiveStorageHandler.class.getName());
+
+        String json = codec.toJson(expected);
+        HiveStorageFormat actual = codec.fromJson(json);
+
+        TestHiveStorageHandler defaultStorageHandler = new TestHiveStorageHandler();
+        assertEquals(actual.getSerDe(), defaultStorageHandler.getSerDeClass().getName());
+        assertEquals(actual.getInputFormat(), defaultStorageHandler.getInputFormatClass().getName());
+        assertEquals(actual.getOutputFormat(), defaultStorageHandler.getOutputFormatClass().getName());
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -63,6 +63,10 @@ public final class HiveTestUtils
             .add(new GenericHiveRecordCursorProvider())
             .build();
 
+    public static final ImmutableSet<String> SUPPORTED_STORAGE_FORMAT_NAMES = ImmutableSet.of(
+            "ORC", "DWRF", "PARQUET", "RCBINARY", "RCTEXT", "SEQUENCEFILE", "TEXTFILE", TestHiveStorageHandler.class.getName()
+    );
+
     public static List<Type> getTypes(List<? extends ColumnHandle> columnHandles)
     {
         ImmutableList.Builder<Type> types = ImmutableList.builder();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -35,6 +35,7 @@ import static com.facebook.presto.hive.HiveQueryRunner.TPCH_SCHEMA;
 import static com.facebook.presto.hive.HiveQueryRunner.createQueryRunner;
 import static com.facebook.presto.hive.HiveQueryRunner.createSampledSession;
 import static com.facebook.presto.hive.HiveTableProperties.STORAGE_FORMAT_PROPERTY;
+import static com.facebook.presto.hive.HiveTestUtils.SUPPORTED_STORAGE_FORMAT_NAMES;
 import static io.airlift.tpch.TpchTable.ORDERS;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.joda.time.DateTimeZone.UTC;
@@ -122,12 +123,12 @@ public class TestHiveIntegrationSmokeTest
     public void createTableAs()
             throws Exception
     {
-        for (HiveStorageFormat storageFormat : HiveStorageFormat.values()) {
+        for (String storageFormat : SUPPORTED_STORAGE_FORMAT_NAMES) {
             createTableAs(storageFormat);
         }
     }
 
-    public void createTableAs(HiveStorageFormat storageFormat)
+    public void createTableAs(String storageFormat)
             throws Exception
     {
         String select = "SELECT" +
@@ -141,7 +142,7 @@ public class TestHiveIntegrationSmokeTest
         assertQuery(createTableAs, "SELECT 1");
 
         TableMetadata tableMetadata = getTableMetadata("test_format_table");
-        assertEquals(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY), storageFormat);
+        assertEquals(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY), HiveStorageFormat.valueOf(storageFormat));
 
         assertQuery("SELECT * from test_format_table", select);
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveStorageHandler.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveStorageHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive;
+
+import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
+import org.apache.hadoop.hive.ql.metadata.DefaultStorageHandler;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
+import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
+import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.OutputFormat;
+import org.apache.hadoop.mapred.TextInputFormat;
+
+public class TestHiveStorageHandler
+        extends DefaultStorageHandler
+{
+    @Override
+    public Class<? extends InputFormat> getInputFormatClass()
+    {
+        return TextInputFormat.class;
+    }
+
+    @Override
+    public Class<? extends OutputFormat> getOutputFormatClass()
+    {
+        return HiveIgnoreKeyTextOutputFormat.class;
+    }
+
+    @Override
+    public Class<? extends AbstractSerDe> getSerDeClass()
+    {
+        return LazySimpleSerDe.class;
+    }
+}


### PR DESCRIPTION
`format` table property accepts predefined literals, like 'ORC', 'TEXTFILE', etc..
Now that property also accepts fully specified storage handler class name.
Specified class must implement `org.apache.hadoop.hive.ql.metadata.HiveStorageHandler`.
In order to use it you have to put the jar with custom storage handler classes into hive-connector class-path.

Testing: unit tests, integration tests