### PR TITLE
Free DriverContext reserved when OperatorContext fails to reserve

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -269,6 +269,7 @@ public class OperatorContext
         long newReservation = memoryReservation.addAndGet(bytes);
         if (newReservation > maxMemoryReservation) {
             memoryReservation.getAndAdd(-bytes);
+            driverContext.freeMemory(bytes);
             return false;
         }
         return true;


### PR DESCRIPTION
We found a case that `memoryReservation` kept increasing at the `PARTIAL` aggregation operator.