### PR TITLE
Use shard size from database when recovering shards

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/BackupStore.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/BackupStore.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.raptor.backup;
 
 import java.io.File;
-import java.util.OptionalLong;
 import java.util.UUID;
 
 public interface BackupStore
@@ -36,11 +35,10 @@ public interface BackupStore
     void restoreShard(UUID uuid, File target);
 
     /**
-     * Get the size of a shard in the backup store, if it exists.
-     * This method can be used to check for size and/or existence.
+     * Check if a shard exists in the backup store.
      *
      * @param uuid shard UUID
-     * @return the length of the shard in bytes
+     * @return if the shard exists
      */
-    OptionalLong shardSize(UUID uuid);
+    boolean shardExists(UUID uuid);
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/FileBackupStore.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/FileBackupStore.java
@@ -24,14 +24,10 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.OptionalLong;
 import java.util.UUID;
 
 import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_ERROR;
 import static com.facebook.presto.raptor.storage.FileStorageService.getFileSystemPath;
-import static java.nio.file.Files.readAttributes;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
@@ -83,19 +79,9 @@ public class FileBackupStore
     }
 
     @Override
-    public OptionalLong shardSize(UUID uuid)
+    public boolean shardExists(UUID uuid)
     {
-        Path path = getBackupFile(uuid).toPath();
-        try {
-            BasicFileAttributes attributes = readAttributes(path, BasicFileAttributes.class);
-            if (!attributes.isRegularFile()) {
-                return OptionalLong.empty();
-            }
-            return OptionalLong.of(attributes.size());
-        }
-        catch (IOException e) {
-            return OptionalLong.empty();
-        }
+        return getBackupFile(uuid).isFile();
     }
 
     @VisibleForTesting

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/TimeoutBackupStore.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/TimeoutBackupStore.java
@@ -22,7 +22,6 @@ import io.airlift.units.Duration;
 import javax.annotation.PreDestroy;
 
 import java.io.File;
-import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 
@@ -76,10 +75,10 @@ public class TimeoutBackupStore
     }
 
     @Override
-    public OptionalLong shardSize(UUID uuid)
+    public boolean shardExists(UUID uuid)
     {
         try {
-            return store.shardSize(uuid);
+            return store.shardExists(uuid);
         }
         catch (UncheckedTimeoutException e) {
             throw new PrestoException(RAPTOR_BACKUP_TIMEOUT, "Shard backup size fetch timed out");

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
@@ -269,21 +269,15 @@ public class DatabaseShardManager
     }
 
     @Override
-    public Set<ShardMetadata> getNodeTableShards(String nodeIdentifier, long tableId)
+    public Set<ShardMetadata> getNodeShards(String nodeIdentifier)
     {
-        return dao.getNodeTableShards(nodeIdentifier, tableId);
+        return dao.getNodeShards(nodeIdentifier);
     }
 
     @Override
     public CloseableIterator<ShardNodes> getShardNodes(long tableId, TupleDomain<RaptorColumnHandle> effectivePredicate)
     {
         return new ShardIterator(tableId, effectivePredicate, dbi);
-    }
-
-    @Override
-    public Set<UUID> getNodeShards(String nodeIdentifier)
-    {
-        return dao.getNodeShards(nodeIdentifier);
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
@@ -56,9 +56,6 @@ public interface MetadataDao
             ")")
     void createTableViews();
 
-    @SqlQuery("SELECT table_id FROM tables")
-    List<Long> listTableIds();
-
     @SqlQuery("SELECT table_id FROM tables\n" +
             "WHERE schema_name = :schemaName\n" +
             "  AND table_name = :tableName")

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
@@ -46,19 +46,14 @@ public interface ShardManager
     void replaceShardUuids(long tableId, List<ColumnInfo> columns, Set<UUID> oldShardUuids, Collection<ShardInfo> newShards);
 
     /**
-     * Get shard metadata for table shards on a given node.
+     * Get shard metadata for shards on a given node.
      */
-    Set<ShardMetadata> getNodeTableShards(String nodeIdentifier, long tableId);
+    Set<ShardMetadata> getNodeShards(String nodeIdentifier);
 
     /**
      * Return the shard nodes a given table.
      */
     CloseableIterator<ShardNodes> getShardNodes(long tableId, TupleDomain<RaptorColumnHandle> effectivePredicate);
-
-    /**
-     * Return the shards for a given node
-     */
-    Set<UUID> getNodeShards(String nodeIdentifier);
 
     /**
      * Assign a shard to a node.

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManagerDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManagerDao.java
@@ -101,21 +101,13 @@ public interface ShardManagerDao
     @SqlQuery("SELECT shard_uuid FROM shards WHERE table_id = :tableId")
     List<UUID> getShards(@Bind("tableId") long tableId);
 
-    @SqlQuery("SELECT s.shard_uuid\n" +
+    @SqlQuery("SELECT s.table_id, s.shard_id, s.shard_uuid, s.row_count, s.compressed_size, s.uncompressed_size\n" +
             "FROM shards s\n" +
             "JOIN shard_nodes sn ON (s.shard_id = sn.shard_id)\n" +
             "JOIN nodes n ON (sn.node_id = n.node_id)\n" +
             "WHERE n.node_identifier = :nodeIdentifier")
-    Set<UUID> getNodeShards(@Bind("nodeIdentifier") String nodeIdentifier);
-
-    @SqlQuery("SELECT s.shard_id, s.shard_uuid, s.row_count, s.compressed_size, s.uncompressed_size\n" +
-            "FROM shards s\n" +
-            "JOIN shard_nodes sn ON (s.shard_id = sn.shard_id)\n" +
-            "JOIN nodes n ON (sn.node_id = n.node_id)\n" +
-            "WHERE s.table_id = :tableId\n" +
-            "  AND n.node_identifier = :nodeIdentifier")
     @Mapper(ShardMetadata.Mapper.class)
-    Set<ShardMetadata> getNodeTableShards(@Bind("nodeIdentifier") String nodeIdentifier, @Bind("tableId") long tableId);
+    Set<ShardMetadata> getNodeShards(@Bind("nodeIdentifier") String nodeIdentifier);
 
     @SqlQuery("SELECT s.shard_uuid, n.node_identifier\n" +
             "FROM shards s\n" +

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardMetadata.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardMetadata.java
@@ -32,6 +32,7 @@ import static java.util.Objects.requireNonNull;
 
 public class ShardMetadata
 {
+    private final long tableId;
     private final long shardId;
     private final UUID shardUuid;
     private final long rowCount;
@@ -40,18 +41,20 @@ public class ShardMetadata
     private final OptionalLong rangeStart;
     private final OptionalLong rangeEnd;
 
-    public ShardMetadata(long shardId, UUID shardUuid, long rowCount, long compressedSize, long uncompressedSize)
+    public ShardMetadata(long tableId, long shardId, UUID shardUuid, long rowCount, long compressedSize, long uncompressedSize)
     {
-        this(shardId, shardUuid, rowCount, compressedSize, uncompressedSize, OptionalLong.empty(), OptionalLong.empty());
+        this(tableId, shardId, shardUuid, rowCount, compressedSize, uncompressedSize, OptionalLong.empty(), OptionalLong.empty());
     }
 
-    public ShardMetadata(long shardId, UUID shardUuid, long rowCount, long compressedSize, long uncompressedSize, OptionalLong rangeStart, OptionalLong rangeEnd)
+    public ShardMetadata(long tableId, long shardId, UUID shardUuid, long rowCount, long compressedSize, long uncompressedSize, OptionalLong rangeStart, OptionalLong rangeEnd)
     {
+        checkArgument(tableId > 0, "tableId must be > 0");
         checkArgument(shardId > 0, "shardId must be > 0");
         checkArgument(rowCount >= 0, "rowCount must be >= 0");
         checkArgument(compressedSize >= 0, "compressedSize must be >= 0");
         checkArgument(uncompressedSize >= 0, "uncompressedSize must be >= 0");
 
+        this.tableId = tableId;
         this.shardId = shardId;
         this.shardUuid = checkNotNull(shardUuid, "shardUuid is null");
         this.rowCount = rowCount;
@@ -59,6 +62,11 @@ public class ShardMetadata
         this.uncompressedSize = uncompressedSize;
         this.rangeStart = requireNonNull(rangeStart, "rangeStart is null");
         this.rangeEnd = requireNonNull(rangeEnd, "rangeEnd is null");
+    }
+
+    public long getTableId()
+    {
+        return tableId;
     }
 
     public UUID getShardUuid()
@@ -99,7 +107,7 @@ public class ShardMetadata
     public ShardMetadata withTimeRange(long rangeStart, long rangeEnd)
     {
         return new ShardMetadata(
-                shardId,
+                tableId, shardId,
                 shardUuid,
                 rowCount,
                 compressedSize,
@@ -111,6 +119,7 @@ public class ShardMetadata
     public String toString()
     {
         ToStringHelper stringHelper = toStringHelper(this)
+                .add("tableId", "tableId")
                 .add("shardId", shardId)
                 .add("shardUuid", shardUuid)
                 .add("rowCount", rowCount)
@@ -136,7 +145,8 @@ public class ShardMetadata
             return false;
         }
         ShardMetadata that = (ShardMetadata) o;
-        return Objects.equals(shardId, that.shardId) &&
+        return Objects.equals(tableId, that.tableId) &&
+                Objects.equals(shardId, that.shardId) &&
                 Objects.equals(rowCount, that.rowCount) &&
                 Objects.equals(compressedSize, that.compressedSize) &&
                 Objects.equals(uncompressedSize, that.uncompressedSize) &&
@@ -148,7 +158,7 @@ public class ShardMetadata
     @Override
     public int hashCode()
     {
-        return Objects.hash(shardId, shardUuid, rowCount, compressedSize, uncompressedSize, rangeStart, rangeEnd);
+        return Objects.hash(tableId, shardId, shardUuid, rowCount, compressedSize, uncompressedSize, rangeStart, rangeEnd);
     }
 
     public static class Mapper
@@ -159,6 +169,7 @@ public class ShardMetadata
                 throws SQLException
         {
             return new ShardMetadata(
+                    r.getLong("table_id"),
                     r.getLong("shard_id"),
                     uuidFromBytes(r.getBytes("shard_uuid")),
                     r.getLong("row_count"),

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -288,7 +288,7 @@ public class OrcStorageManager
 
     private boolean backupExists(UUID shardUuid)
     {
-        return backupStore.isPresent() && backupStore.get().shardSize(shardUuid).isPresent();
+        return backupStore.isPresent() && backupStore.get().shardExists(shardUuid);
     }
 
     private ShardInfo createShardInfo(UUID shardUuid, File file, Set<String> nodes, long rowCount, long uncompressedSize)

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardRecoveryManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardRecoveryManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.raptor.storage;
 
 import com.facebook.presto.raptor.backup.BackupStore;
 import com.facebook.presto.raptor.metadata.ShardManager;
+import com.facebook.presto.raptor.metadata.ShardMetadata;
 import com.facebook.presto.raptor.util.PrioritizedFifoExecutor;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PrestoException;
@@ -154,6 +155,7 @@ public class ShardRecoveryManager
     private Set<UUID> getMissingShards()
     {
         return shardManager.getNodeShards(nodeIdentifier).stream()
+                .map(ShardMetadata::getShardUuid)
                 .filter(this::shardNeedsRecovery)
                 .collect(toSet());
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardRecoveryManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardRecoveryManager.java
@@ -138,9 +138,9 @@ public class ShardRecoveryManager
         missingShardExecutor.scheduleWithFixedDelay(() -> {
             try {
                 SECONDS.sleep(ThreadLocalRandom.current().nextInt(1, 30));
-                for (UUID shard : getMissingShards()) {
+                for (ShardMetadata shard : getMissingShards()) {
                     stats.incrementBackgroundShardRecovery();
-                    shardQueue.submit(MissingShard.createBackgroundMissingShard(shard));
+                    shardQueue.submit(MissingShard.createBackgroundMissingShard(shard.getShardUuid(), shard.getCompressedSize()));
                 }
             }
             catch (InterruptedException e) {
@@ -152,22 +152,17 @@ public class ShardRecoveryManager
         }, 0, missingShardDiscoveryInterval.toMillis(), TimeUnit.MILLISECONDS);
     }
 
-    private Set<UUID> getMissingShards()
+    private Set<ShardMetadata> getMissingShards()
     {
         return shardManager.getNodeShards(nodeIdentifier).stream()
-                .map(ShardMetadata::getShardUuid)
-                .filter(this::shardNeedsRecovery)
+                .filter(shard -> shardNeedsRecovery(shard.getShardUuid(), shard.getCompressedSize()))
                 .collect(toSet());
     }
 
-    private boolean shardNeedsRecovery(UUID shardUuid)
+    private boolean shardNeedsRecovery(UUID shardUuid, long shardSize)
     {
         File storageFile = storageService.getStorageFile(shardUuid);
-        if (!storageFile.exists()) {
-            return true;
-        }
-        OptionalLong backupLength = backupStore.get().shardSize(shardUuid);
-        return backupLength.isPresent() && (storageFile.length() != backupLength.getAsLong());
+        return !storageFile.exists() || (storageFile.length() != shardSize);
     }
 
     public Future<?> recoverShard(UUID shardUuid)
@@ -179,18 +174,17 @@ public class ShardRecoveryManager
     }
 
     @VisibleForTesting
-    void restoreFromBackup(UUID shardUuid)
+    void restoreFromBackup(UUID shardUuid, OptionalLong shardSize)
     {
         File storageFile = storageService.getStorageFile(shardUuid);
 
-        OptionalLong backupSize = backupStore.get().shardSize(shardUuid);
-        if (!backupSize.isPresent()) {
+        if (!backupStore.get().shardExists(shardUuid)) {
             stats.incrementShardRecoveryBackupNotFound();
             throw new PrestoException(RAPTOR_RECOVERY_ERROR, "No backup file found for shard: " + shardUuid);
         }
 
         if (storageFile.exists()) {
-            if (storageFile.length() == backupSize.getAsLong()) {
+            if (!shardSize.isPresent() || (storageFile.length() == shardSize.getAsLong())) {
                 return;
             }
             log.warn("Local shard file is corrupt. Deleting local file: %s", shardUuid);
@@ -233,7 +227,7 @@ public class ShardRecoveryManager
             throw new PrestoException(RAPTOR_RECOVERY_ERROR, "Failed to move shard: " + shardUuid, e);
         }
 
-        if (!storageFile.exists() || (storageFile.length() != backupSize.getAsLong())) {
+        if (!storageFile.exists() || (shardSize.isPresent() && (storageFile.length() != shardSize.getAsLong()))) {
             stats.incrementShardRecoveryFailure();
             log.info("Files do not match after recovery. Deleting local file: " + shardUuid);
             storageFile.delete();
@@ -267,18 +261,20 @@ public class ShardRecoveryManager
             implements MissingShardRunnable
     {
         private final UUID shardUuid;
+        private final OptionalLong shardSize;
         private final boolean active;
 
-        public MissingShardRecovery(UUID shardUuid, boolean active)
+        public MissingShardRecovery(UUID shardUuid, OptionalLong shardSize, boolean active)
         {
             this.shardUuid = checkNotNull(shardUuid, "shardUuid is null");
+            this.shardSize = checkNotNull(shardSize, "shardSize is null");
             this.active = active;
         }
 
         @Override
         public void run()
         {
-            restoreFromBackup(shardUuid);
+            restoreFromBackup(shardUuid, shardSize);
         }
 
         @Override
@@ -291,27 +287,34 @@ public class ShardRecoveryManager
     private static final class MissingShard
     {
         private final UUID shardUuid;
+        private final OptionalLong shardSize;
         private final boolean active;
 
-        private MissingShard(UUID shardUuid, boolean active)
+        private MissingShard(UUID shardUuid, OptionalLong shardSize, boolean active)
         {
             this.shardUuid = checkNotNull(shardUuid, "shardUuid is null");
+            this.shardSize = checkNotNull(shardSize, "shardSize is null");
             this.active = active;
         }
 
-        public static MissingShard createBackgroundMissingShard(UUID shardUuid)
+        public static MissingShard createBackgroundMissingShard(UUID shardUuid, long shardSize)
         {
-            return new MissingShard(shardUuid, false);
+            return new MissingShard(shardUuid, OptionalLong.of(shardSize), false);
         }
 
         public static MissingShard createActiveMissingShard(UUID shardUuid)
         {
-            return new MissingShard(shardUuid, true);
+            return new MissingShard(shardUuid, OptionalLong.empty(), true);
         }
 
         public UUID getShardUuid()
         {
             return shardUuid;
+        }
+
+        public OptionalLong getShardSize()
+        {
+            return shardSize;
         }
 
         public boolean isActive()
@@ -362,7 +365,10 @@ public class ShardRecoveryManager
                 @Override
                 public Future<?> load(MissingShard missingShard)
                 {
-                    MissingShardRecovery task = new MissingShardRecovery(missingShard.getShardUuid(), missingShard.isActive());
+                    MissingShardRecovery task = new MissingShardRecovery(
+                            missingShard.getShardUuid(),
+                            missingShard.getShardSize(),
+                            missingShard.isActive());
                     ListenableFuture<?> future = shardRecoveryExecutor.submit(task);
                     future.addListener(() -> queuedMissingShards.invalidate(missingShard), directExecutor());
                     return future;

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestBackupManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestBackupManager.java
@@ -71,7 +71,7 @@ public class TestBackupManager
         }
         futures.forEach(CompletableFuture::join);
         for (UUID uuid : uuids) {
-            assertTrue(store.shardSize(uuid).isPresent());
+            assertTrue(store.shardExists(uuid));
         }
     }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestFileBackupStore.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestFileBackupStore.java
@@ -61,20 +61,18 @@ public class TestFileBackupStore
         Files.write("hello world", file1, UTF_8);
         UUID uuid1 = randomUUID();
 
-        assertFalse(store.shardSize(uuid1).isPresent());
+        assertFalse(store.shardExists(uuid1));
         store.backupShard(uuid1, file1);
-        assertTrue(store.shardSize(uuid1).isPresent());
-        assertEquals(store.shardSize(uuid1).getAsLong(), file1.length());
+        assertTrue(store.shardExists(uuid1));
 
         // backup second file
         File file2 = new File(temporary, "file2");
         Files.write("bye bye", file2, UTF_8);
         UUID uuid2 = randomUUID();
 
-        assertFalse(store.shardSize(uuid2).isPresent());
+        assertFalse(store.shardExists(uuid2));
         store.backupShard(uuid2, file2);
-        assertTrue(store.shardSize(uuid2).isPresent());
-        assertEquals(store.shardSize(uuid2).getAsLong(), file2.length());
+        assertTrue(store.shardExists(uuid2));
 
         // verify first file
         File restore1 = new File(temporary, "restore1");
@@ -87,6 +85,6 @@ public class TestFileBackupStore
         assertEquals(readAllBytes(file2.toPath()), readAllBytes(restore2.toPath()));
 
         // verify random UUID does not exist
-        assertFalse(store.shardSize(randomUUID()).isPresent());
+        assertFalse(store.shardExists(randomUUID()));
     }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
@@ -150,7 +150,7 @@ public class TestDatabaseShardManager
         shardManager.commitShards(tableId, columns, inputShards.build(), Optional.empty());
 
         for (String node : nodes) {
-            Set<ShardMetadata> shardMetadata = shardManager.getNodeTableShards(node, tableId);
+            Set<ShardMetadata> shardMetadata = shardManager.getNodeShards(node);
             Set<UUID> expectedUuids = ImmutableSet.copyOf(nodeShardMap.get(node));
             Set<UUID> actualUuids = shardMetadata.stream().map(ShardMetadata::getShardUuid).collect(toSet());
             assertEquals(actualUuids, expectedUuids);
@@ -181,13 +181,13 @@ public class TestDatabaseShardManager
                 .add(shardInfo(expectedUuids.get(1), nodes.get(0)))
                 .build();
 
-        Set<ShardMetadata> shardMetadata = shardManager.getNodeTableShards(nodes.get(0), tableId);
+        Set<ShardMetadata> shardMetadata = shardManager.getNodeShards(nodes.get(0));
         Set<Long> shardIds = shardMetadata.stream().map(ShardMetadata::getShardId).collect(toSet());
         Set<UUID> replacedUuids = shardMetadata.stream().map(ShardMetadata::getShardUuid).collect(toSet());
 
         shardManager.replaceShardIds(tableId, columns, shardIds, newShards);
 
-        shardMetadata = shardManager.getNodeTableShards(nodes.get(0), tableId);
+        shardMetadata = shardManager.getNodeShards(nodes.get(0));
         Set<UUID> actualUuids = shardMetadata.stream().map(ShardMetadata::getShardUuid).collect(toSet());
         assertEquals(actualUuids, ImmutableSet.copyOf(expectedUuids));
 
@@ -236,12 +236,12 @@ public class TestDatabaseShardManager
                 .add(shardInfo(expectedUuids.get(1), nodes.get(0)))
                 .build();
 
-        Set<ShardMetadata> shardMetadata = shardManager.getNodeTableShards(nodes.get(0), tableId);
+        Set<ShardMetadata> shardMetadata = shardManager.getNodeShards(nodes.get(0));
         Set<UUID> replacedUuids = shardMetadata.stream().map(ShardMetadata::getShardUuid).collect(toSet());
 
         shardManager.replaceShardUuids(tableId, columns, replacedUuids, newShards);
 
-        shardMetadata = shardManager.getNodeTableShards(nodes.get(0), tableId);
+        shardMetadata = shardManager.getNodeShards(nodes.get(0));
         Set<UUID> actualUuids = shardMetadata.stream().map(ShardMetadata::getShardUuid).collect(toSet());
         assertEquals(actualUuids, ImmutableSet.copyOf(expectedUuids));
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardManagerDao.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardManagerDao.java
@@ -163,10 +163,10 @@ public class TestShardManagerDao
 
         long tableId = 1;
 
-        long shardId1 = dao.insertShard(shardUuid1, tableId, 0, 0, 0);
-        long shardId2 = dao.insertShard(shardUuid2, tableId, 0, 0, 0);
-        long shardId3 = dao.insertShard(shardUuid3, tableId, 0, 0, 0);
-        long shardId4 = dao.insertShard(shardUuid4, tableId, 0, 0, 0);
+        long shardId1 = dao.insertShard(shardUuid1, tableId, 1, 11, 111);
+        long shardId2 = dao.insertShard(shardUuid2, tableId, 2, 22, 222);
+        long shardId3 = dao.insertShard(shardUuid3, tableId, 3, 33, 333);
+        long shardId4 = dao.insertShard(shardUuid4, tableId, 4, 44, 444);
 
         assertEquals(dao.getShards(tableId), ImmutableList.of(shardUuid1, shardUuid2, shardUuid3, shardUuid4));
 
@@ -180,8 +180,13 @@ public class TestShardManagerDao
         dao.insertShardNode(shardId1, nodeId2);
         dao.insertShardNode(shardId4, nodeId2);
 
-        assertEquals(dao.getNodeShards(nodeName1), ImmutableList.of(shardUuid1, shardUuid2, shardUuid3, shardUuid4));
-        assertEquals(dao.getNodeShards(nodeName2), ImmutableList.of(shardUuid1, shardUuid4));
+        ShardMetadata shard1 = new ShardMetadata(tableId, shardId1, shardUuid1, 1, 11, 111);
+        ShardMetadata shard2 = new ShardMetadata(tableId, shardId2, shardUuid2, 2, 22, 222);
+        ShardMetadata shard3 = new ShardMetadata(tableId, shardId3, shardUuid3, 3, 33, 333);
+        ShardMetadata shard4 = new ShardMetadata(tableId, shardId4, shardUuid4, 4, 44, 444);
+
+        assertEquals(dao.getNodeShards(nodeName1), ImmutableSet.of(shard1, shard2, shard3, shard4));
+        assertEquals(dao.getNodeShards(nodeName2), ImmutableSet.of(shard1, shard4));
 
         dao.dropShardNodes(tableId);
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestCompactionSetCreator.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestCompactionSetCreator.java
@@ -159,6 +159,7 @@ public class TestCompactionSetCreator
     {
         return new ShardMetadata(
                 1,
+                1,
                 UUID.randomUUID(),
                 10,
                 10,
@@ -170,6 +171,7 @@ public class TestCompactionSetCreator
     private static ShardMetadata shardWithRange(long uncompressedSize, long rangeStart, long rangeEnd)
     {
         return new ShardMetadata(
+                1,
                 ThreadLocalRandom.current().nextInt(1, 10),
                 UUID.randomUUID(),
                 10,

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
@@ -60,6 +60,7 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -208,7 +209,7 @@ public class TestOrcStorageManager
         assertTrue(file.getParentFile().delete());
         assertFalse(file.exists());
 
-        recoveryManager.restoreFromBackup(shardUuid);
+        recoveryManager.restoreFromBackup(shardUuid, OptionalLong.empty());
 
         try (OrcDataSource dataSource = manager.openShard(shardUuid)) {
             OrcRecordReader reader = createReader(dataSource, columnIds, columnTypes);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardCompactionDiscovery.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardCompactionDiscovery.java
@@ -120,7 +120,7 @@ public class TestShardCompactionDiscovery
                 10,
                 true);
 
-        Set<ShardMetadata> shardMetadata = shardManager.getNodeTableShards("node1", 1);
+        Set<ShardMetadata> shardMetadata = shardManager.getNodeShards("node1");
         Set<ShardMetadata> temporalMetadata = shardCompactionManager.filterShardsWithTemporalMetadata(shardMetadata, 1, 1);
         assertEquals(temporalMetadata.stream().map(ShardMetadata::getShardUuid).collect(toSet()), timeRangeShards.stream().map(ShardInfo::getShardUuid).collect(toSet()));
     }


### PR DESCRIPTION
This avoids putting excessive load on the backup store.