### PR TITLE
Add test queries for UNION with hidden columns.

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3657,6 +3657,15 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testUnionWithFilterNotInSelect()
+            throws Exception
+    {
+        assertQuery("SELECT orderkey, orderdate FROM orders WHERE custkey < 1000 UNION ALL SELECT orderkey, shipdate FROM lineitem WHERE linenumber < 2000");
+        assertQuery("SELECT orderkey, orderdate FROM orders UNION ALL SELECT orderkey, shipdate FROM lineitem WHERE linenumber < 2000");
+        assertQuery("SELECT orderkey, orderdate FROM orders WHERE custkey < 1000 UNION ALL SELECT orderkey, shipdate FROM lineitem");
+    }
+
+    @Test
     public void testSelectOnlyUnion()
             throws Exception
     {


### PR DESCRIPTION
We have added a new test function for UNION queries with hidden columns. This was done to create test cases for hidden columns. Relevant: https://github.com/facebook/presto/commit/522d0562405e990608c07dc848392dcd49e11a70

Edit: We updated the commit with the name change and removed "hidden column" reference from commit message. Should we create a new pull request ? 

Since the comments from @martint went away. I am posting @martint comments here: 

What does "hidden columns" mean in this context? There's a specific notion of hidden columns in Presto (columns that are not automatically included in SELECT * queries), but this doesn't seem to be it.

I had replied with the following: 

I think we misunderstood the meaning of "hidden columns" now that you mention it. This definitely does not test the hidden columns in Presto. Regardless, the test covers queries (union over select+filter) that are not present in the current test cases. Therefore, we will appropriately rename the test function to denote that test scenario.

Our original purpose was to create test case for the change added to release 0.101 named "Fix analysis of UNION queries for tables with hidden columns." (https://prestodb.io/docs/current/release/release-0.101.html) After doing some quick search, we found some description about hidden columns that can be created using Kafka connector by using column definition in JSON (https://prestodb.io/docs/current/connector/kafka.html). But, could not find other ways to create tables with hidden columns. Let us know if you have suggestions on how to test the fix added to 0.101.
