### PR TITLE
Adding additional test for contains(), when search value is NULL

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -223,6 +223,7 @@ public class TestArrayOperators
         assertFunction("CONTAINS(ARRAY [1, 2, 3], 5)", BOOLEAN, false);
         assertFunction("CONTAINS(ARRAY [1, NULL, 3], 1)", BOOLEAN, true);
         assertFunction("CONTAINS(ARRAY [NULL, 2, 3], 1)", BOOLEAN, null);
+        assertFunction("CONTAINS(ARRAY [NULL, 2, 3], NULL)", BOOLEAN, null);
         assertFunction("CONTAINS(ARRAY [1, 2.0, 3], 3.0)", BOOLEAN, true);
         assertFunction("CONTAINS(ARRAY [1.0, 2.5, 3.0], 2.2)", BOOLEAN, false);
         assertFunction("CONTAINS(ARRAY ['puppies', 'kittens'], 'kittens')", BOOLEAN, true);


### PR DESCRIPTION
Adding additional test for testArrayContains(), when search value is NULL. Relevant - https://github.com/facebook/presto/commit/ad904644f9ae694326c79fb6c4bca70ca23bb5e8