### PR TITLE
Fix bug in BigintGroupByHash

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.117.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.117.rst
@@ -8,3 +8,5 @@ General Changes
 * Add back casts between JSON and VARCHAR to provide an easier migration path
   to :func:`json_parse` and :func:`json_format`. These will be removed in a
   future release.
+* Fix bug in semi joins and group bys on a single ``BIGINT`` column where
+  0 could match ``NULL``.

--- a/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
@@ -105,6 +105,7 @@ public class BigintGroupByHash
     @Override
     public void appendValuesTo(int groupId, PageBuilder pageBuilder, int outputChannelOffset)
     {
+        checkArgument(groupId >= 0, "groupId is negative");
         BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(outputChannelOffset);
         if (groupId == nullGroupId) {
             blockBuilder.appendNull();
@@ -270,6 +271,9 @@ public class BigintGroupByHash
         newGroupIds.ensureCapacity(newSize);
 
         for (int groupId = 0; groupId < nextGroupId; groupId++) {
+            if (groupId == nullGroupId) {
+                continue;
+            }
             long value = valuesByGroupId.get(groupId);
 
             // find an empty slot for the address


### PR DESCRIPTION
When set is rehash'ed and contains a null, the value zero will appear to
be contained in the set in addition to null