### PR TITLE
Fix condition for SharedBuffer completion

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -30,6 +30,7 @@ public final class PrestoHeaders
     public static final String PRESTO_MAX_SIZE = "X-Presto-Max-Size";
     public static final String PRESTO_PAGE_TOKEN = "X-Presto-Page-Sequence-Id";
     public static final String PRESTO_PAGE_NEXT_TOKEN = "X-Presto-Page-End-Sequence-Id";
+    public static final String PRESTO_BUFFER_COMPLETE = "X-Presto-Buffer-Complete";
 
     private PrestoHeaders() {}
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/BufferResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/BufferResult.java
@@ -24,21 +24,21 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class BufferResult
 {
-    public static BufferResult emptyResults(long token, boolean bufferClosed)
+    public static BufferResult emptyResults(long token, boolean bufferComplete)
     {
-        return new BufferResult(token, token, bufferClosed, ImmutableList.<Page>of());
+        return new BufferResult(token, token, bufferComplete, ImmutableList.<Page>of());
     }
 
     private final long token;
     private final long nextToken;
-    private final boolean bufferClosed;
+    private final boolean bufferComplete;
     private final List<Page> pages;
 
-    public BufferResult(long token, long nextToken, boolean bufferClosed, List<Page> pages)
+    public BufferResult(long token, long nextToken, boolean bufferComplete, List<Page> pages)
     {
         this.token = token;
         this.nextToken = nextToken;
-        this.bufferClosed = bufferClosed;
+        this.bufferComplete = bufferComplete;
         this.pages = ImmutableList.copyOf(checkNotNull(pages, "pages is null"));
     }
 
@@ -52,9 +52,9 @@ public class BufferResult
         return nextToken;
     }
 
-    public boolean isBufferClosed()
+    public boolean isBufferComplete()
     {
-        return bufferClosed;
+        return bufferComplete;
     }
 
     public List<Page> getPages()
@@ -84,14 +84,14 @@ public class BufferResult
         BufferResult that = (BufferResult) o;
         return Objects.equals(token, that.token) &&
                 Objects.equals(nextToken, that.nextToken) &&
-                Objects.equals(bufferClosed, that.bufferClosed) &&
+                Objects.equals(bufferComplete, that.bufferComplete) &&
                 Objects.equals(pages, that.pages);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(token, nextToken, bufferClosed, pages);
+        return Objects.hash(token, nextToken, bufferComplete, pages);
     }
 
     @Override
@@ -100,7 +100,7 @@ public class BufferResult
         return toStringHelper(this)
                 .add("token", token)
                 .add("nextToken", nextToken)
-                .add("bufferClosed", bufferClosed)
+                .add("bufferComplete", bufferComplete)
                 .add("pages", pages)
                 .toString();
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/PartitionBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/PartitionBuffer.java
@@ -81,6 +81,9 @@ public class PartitionBuffer
         updateMemoryUsage(bytesAdded);
     }
 
+    /**
+     * @return at least one page if we have pages in buffer, empty list otherwise
+     */
     public synchronized List<Page> getPages(DataSize maxSize, long sequenceId)
     {
         long maxBytes = maxSize.toBytes();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -117,13 +117,17 @@ public class TestSqlTaskManager
             assertEquals(taskInfo.getState(), TaskState.RUNNING);
 
             BufferResult results = sqlTaskManager.getTaskResults(taskId, OUT, 0, new DataSize(1, Unit.MEGABYTE)).get();
-            assertEquals(results.isBufferClosed(), false);
+            assertEquals(results.isBufferComplete(), false);
             assertEquals(results.getPages().size(), 1);
             assertEquals(results.getPages().get(0).getPositionCount(), 1);
 
             results = sqlTaskManager.getTaskResults(taskId, OUT, results.getToken() + results.getPages().size(), new DataSize(1, Unit.MEGABYTE)).get();
-            assertEquals(results.isBufferClosed(), true);
+            assertEquals(results.isBufferComplete(), true);
             assertEquals(results.getPages().size(), 0);
+
+            // complete the task by calling abort on it
+            TaskInfo info = sqlTaskManager.abortTaskResults(taskId, OUT);
+            assertEquals(info.getOutputBuffers().getState(), SharedBuffer.BufferState.FINISHED);
 
             taskInfo = sqlTaskManager.getTaskInfo(taskId, taskInfo.getState()).get(1, TimeUnit.SECONDS);
             assertEquals(taskInfo.getState(), TaskState.FINISHED);

--- a/presto-main/src/test/java/com/facebook/presto/operator/MockExchangeRequestProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/MockExchangeRequestProcessor.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.facebook.presto.PrestoMediaTypes.PRESTO_PAGES;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_BUFFER_COMPLETE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_PAGE_NEXT_TOKEN;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_PAGE_TOKEN;
 import static com.google.common.base.Preconditions.checkState;
@@ -103,9 +104,6 @@ public class MockExchangeRequestProcessor
             bytes = sliceOutput.slice().getBytes();
             status = HttpStatus.OK;
         }
-        else if (result.isBufferClosed()) {
-            status = HttpStatus.GONE;
-        }
         else {
             status = HttpStatus.NO_CONTENT;
         }
@@ -115,7 +113,8 @@ public class MockExchangeRequestProcessor
                 ImmutableListMultimap.of(
                         CONTENT_TYPE, PRESTO_PAGES,
                         PRESTO_PAGE_TOKEN, String.valueOf(result.getToken()),
-                        PRESTO_PAGE_NEXT_TOKEN, String.valueOf(result.getNextToken())
+                        PRESTO_PAGE_NEXT_TOKEN, String.valueOf(result.getNextToken()),
+                        PRESTO_BUFFER_COMPLETE, String.valueOf(result.isBufferComplete())
                 ),
                 bytes);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
@@ -96,7 +96,7 @@ public class TestExchangeClient
         assertTrue(exchangeClient.getStatus().getBufferedBytes() == 0);
 
         // client should have sent only 2 requests: one to get all pages and once to get the done signal
-        assertStatus(exchangeClient.getStatus().getPageBufferClientStatuses().get(0), location, "closed", 3, 2, 2, "not scheduled");
+        assertStatus(exchangeClient.getStatus().getPageBufferClientStatuses().get(0), location, "closed", 3, 3, 3, "not scheduled");
     }
 
     @Test(timeOut = 10000)
@@ -151,8 +151,8 @@ public class TestExchangeClient
         }
 
         ImmutableMap<URI, PageBufferClientStatus> statuses = uniqueIndex(exchangeClient.getStatus().getPageBufferClientStatuses(), PageBufferClientStatus::getUri);
-        assertStatus(statuses.get(location1), location1, "closed", 3, 2, 2, "not scheduled");
-        assertStatus(statuses.get(location2), location2, "closed", 3, 2, 2, "not scheduled");
+        assertStatus(statuses.get(location1), location1, "closed", 3, 3, 3, "not scheduled");
+        assertStatus(statuses.get(location2), location2, "closed", 3, 3, 3, "not scheduled");
     }
 
     @Test
@@ -228,7 +228,7 @@ public class TestExchangeClient
         assertEquals(exchangeClient.getStatus().getBufferedPages(), 0);
         assertTrue(exchangeClient.getStatus().getBufferedBytes() == 0);
         assertEquals(exchangeClient.isClosed(), true);
-        assertStatus(exchangeClient.getStatus().getPageBufferClientStatuses().get(0), location, "closed", 3, 4, 4, "not scheduled");
+        assertStatus(exchangeClient.getStatus().getPageBufferClientStatuses().get(0), location, "closed", 3, 5, 5, "not scheduled");
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
@@ -150,11 +150,21 @@ public class TestHttpPageBufferClient
         client.scheduleRequest();
         requestComplete.await(10, TimeUnit.SECONDS);
 
+        // get the buffer complete signal
+        assertEquals(callback.getPages().size(), 0);
+        assertEquals(callback.getCompletedRequests(), 1);
+
+        // schedule the delete call to the buffer
+        callback.resetStats();
+        client.scheduleRequest();
+        requestComplete.await(10, TimeUnit.SECONDS);
+        assertEquals(callback.getFinishedBuffers(), 1);
+
         assertEquals(callback.getPages().size(), 0);
         assertEquals(callback.getCompletedRequests(), 0);
-        assertEquals(callback.getFinishedBuffers(), 1);
         assertEquals(callback.getFailedBuffers(), 0);
-        assertStatus(client, location, "closed", 3, 4, 4, 0, "not scheduled");
+
+        assertStatus(client, location, "closed", 3, 5, 5, 0, "not scheduled");
     }
 
     @Test


### PR DESCRIPTION
SharedBuffer should be marked complete when both conditions are satisfied:
- client has acknowledged all the pages
- client knows that there will be no more pages

Once the client sees all the pages and the no more pages signal,
explicitly send a delete to the SharedBuffer to indicate completion.