### PR TITLE
Test correct number of buckets in NumericHistogramAggregation

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestNumericHistogramAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestNumericHistogramAggregation.java
@@ -17,6 +17,7 @@ import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.type.MapType;
@@ -48,19 +49,7 @@ public class TestNumericHistogramAggregation
         InternalAggregationFunction function = functionRegistry.resolveFunction(QualifiedName.of("numeric_histogram"), ImmutableList.of(BIGINT.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()), false).getAggregationFunction();
         factory = function.bind(ImmutableList.of(0, 1, 2), Optional.empty(), Optional.empty(), 1.0);
 
-        int numberOfBuckets = 10;
-
-        PageBuilder builder = new PageBuilder(ImmutableList.of(BIGINT, DOUBLE, DOUBLE));
-
-        for (int i = 0; i < 100; i++) {
-            builder.declarePosition();
-
-            BIGINT.writeLong(builder.getBlockBuilder(0), numberOfBuckets);
-            DOUBLE.writeDouble(builder.getBlockBuilder(1), i); // value
-            DOUBLE.writeDouble(builder.getBlockBuilder(2), 1); // weight
-        }
-
-        input = builder.build();
+        input = makeInput(10);
     }
 
     @Test
@@ -116,10 +105,33 @@ public class TestNumericHistogramAggregation
         assertTrue(result.isNull(0));
     }
 
+    @Test(expectedExceptions = {PrestoException.class})
+    public void testBadNumberOfBuckets()
+    {
+        Accumulator singleStep = factory.createAccumulator();
+        singleStep.addInput(makeInput(0));
+        getFinalBlock(singleStep);
+    }
+
     private static Map<Double, Double> extractSingleValue(Block block)
             throws IOException
     {
         MapType mapType = new MapType(DOUBLE, DOUBLE);
         return (Map<Double, Double>) mapType.getObjectValue(null, block, 0);
+    }
+
+    private Page makeInput(int numberOfBuckets)
+    {
+        PageBuilder builder = new PageBuilder(ImmutableList.of(BIGINT, DOUBLE, DOUBLE));
+
+        for (int i = 0; i < 100; i++) {
+            builder.declarePosition();
+
+            BIGINT.writeLong(builder.getBlockBuilder(0), numberOfBuckets);
+            DOUBLE.writeDouble(builder.getBlockBuilder(1), i); // value
+            DOUBLE.writeDouble(builder.getBlockBuilder(2), 1); // weight
+        }
+
+        return builder.build();
     }
 }


### PR DESCRIPTION
* Add a test to ensure that the NumericHistogramAggregation function
throws an exception if it is given a number of buckets less than 1.

Testing: ran test in isolation and clean build