### PR TITLE
Fix ArrayType.equalTo to work with non-orderable types

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -20,6 +20,7 @@ import com.facebook.presto.operator.aggregation.ApproximateCountColumnAggregatio
 import com.facebook.presto.operator.aggregation.ApproximateCountDistinctAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateDoublePercentileAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateLongPercentileAggregations;
+import com.facebook.presto.operator.aggregation.ApproximateLongPercentileArrayAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateSetAggregation;
 import com.facebook.presto.operator.aggregation.ApproximateSumAggregations;
 import com.facebook.presto.operator.aggregation.AverageAggregations;
@@ -250,6 +251,7 @@ public class FunctionRegistry
                 .aggregate(CountAggregation.class)
                 .aggregate(VarianceAggregation.class)
                 .aggregate(ApproximateLongPercentileAggregations.class)
+                .aggregate(ApproximateLongPercentileArrayAggregations.class)
                 .aggregate(ApproximateDoublePercentileAggregations.class)
                 .aggregate(CountIfAggregation.class)
                 .aggregate(BooleanAndAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.DigestAndPercentileArrayState;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.SqlType;
+import com.google.common.collect.ImmutableList;
+import io.airlift.stats.QuantileDigest;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static com.google.common.base.Preconditions.checkState;
+
+@AggregationFunction("approx_percentile")
+public final class ApproximateDoublePercentileArrayAggregations
+{
+    public static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = new AggregationCompiler().generateAggregationFunction(ApproximateDoublePercentileArrayAggregations.class, new ArrayType(DOUBLE), ImmutableList.<Type>of(DOUBLE, new ArrayType(DOUBLE)));
+
+    private ApproximateDoublePercentileArrayAggregations() {}
+
+    @InputFunction
+    public static void arrayInput(DigestAndPercentileArrayState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType("array<double>") Block quantilesArrayBlock)
+    {
+       ApproximateLongPercentileArrayAggregations.arrayInput(state, doubleToSortableLong(value), quantilesArrayBlock);
+    }
+
+    @CombineFunction
+    public static void combine(DigestAndPercentileArrayState state, DigestAndPercentileArrayState otherState)
+    {
+        ApproximateLongPercentileArrayAggregations.combine(state, otherState);
+    }
+
+    @OutputFunction("array<double>")
+    public static void output(DigestAndPercentileArrayState state, BlockBuilder out)
+    {
+        QuantileDigest digest = state.getDigest();
+        List<Double> percentiles = state.getPercentiles();
+
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), percentiles.size());
+        for (int i = 0; i < percentiles.size(); i++) {
+            Double percentile = percentiles.get(i);
+            checkState(percentile != -1.0, "Percentile is missing");
+            checkCondition(0 <= percentile && percentile <= 1, INVALID_FUNCTION_ARGUMENT, "Percentile must be between 0 and 1");
+            try {
+                DOUBLE.writeDouble(blockBuilder, longToDouble(digest.getQuantile(percentile)));
+            }
+            catch (NullPointerException e) {
+                // no-op
+            }
+        }
+
+        new ArrayType(DOUBLE).writeObject(out, blockBuilder.build());
+    }
+
+    // TODO: raghavsethi: copied code.. what's the best way to re-use what's in ApproximateDoublePercentileAggregations?
+    private static double longToDouble(long value)
+    {
+        if (value < 0) {
+            value ^= 0x7fffffffffffffffL;
+        }
+
+        return Double.longBitsToDouble(value);
+    }
+
+    private static long doubleToSortableLong(double value)
+    {
+        long result = Double.doubleToRawLongBits(value);
+
+        if (result < 0) {
+            result ^= 0x7fffffffffffffffL;
+        }
+
+        return result;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileArrayAggregations.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.DigestAndPercentileArrayState;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.SqlType;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import io.airlift.stats.QuantileDigest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.spi.StandardErrorCode.INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static com.google.common.base.Preconditions.checkState;
+
+@AggregationFunction("approx_percentile")
+public final class ApproximateLongPercentileArrayAggregations
+{
+    public static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = new AggregationCompiler().generateAggregationFunction(ApproximateLongPercentileArrayAggregations.class, new ArrayType(BIGINT), ImmutableList.<Type>of(BIGINT, new ArrayType(DOUBLE)));
+
+    private ApproximateLongPercentileArrayAggregations() {}
+
+    @InputFunction
+    public static void arrayInput(DigestAndPercentileArrayState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType("array<double>") Block quantilesArrayBlock)
+    {
+        QuantileDigest digest = state.getDigest();
+
+        if (digest == null) {
+            digest = new QuantileDigest(0.01);
+            state.setDigest(digest);
+            state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+        }
+
+        state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
+        digest.add(value);
+        state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+
+        List<Double> percentiles = new ArrayList<>(quantilesArrayBlock.getPositionCount());
+
+        for (int i = 0; i < quantilesArrayBlock.getPositionCount(); i++) {
+            if (quantilesArrayBlock.isNull(i)) {
+                continue;
+            }
+            try {
+                percentiles.add(DOUBLE.getDouble(quantilesArrayBlock, i));
+            }
+            catch (Throwable t) {
+                Throwables.propagateIfInstanceOf(t, Error.class);
+                Throwables.propagateIfInstanceOf(t, PrestoException.class);
+
+                throw new PrestoException(INTERNAL_ERROR, t);
+            }
+        }
+
+        state.setPercentiles(percentiles);
+    }
+
+    @CombineFunction
+    public static void combine(DigestAndPercentileArrayState state, DigestAndPercentileArrayState otherState)
+    {
+        QuantileDigest input = otherState.getDigest();
+
+        QuantileDigest previous = state.getDigest();
+        if (previous == null) {
+            state.setDigest(input);
+            state.addMemoryUsage(input.estimatedInMemorySizeInBytes());
+        }
+        else {
+            state.addMemoryUsage(-previous.estimatedInMemorySizeInBytes());
+            previous.merge(input);
+            state.addMemoryUsage(previous.estimatedInMemorySizeInBytes());
+        }
+        state.setPercentiles(otherState.getPercentiles());
+    }
+
+    @OutputFunction("array<bigint>")
+    public static void output(DigestAndPercentileArrayState state, BlockBuilder out)
+    {
+        QuantileDigest digest = state.getDigest();
+        List<Double> percentiles = state.getPercentiles();
+
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), percentiles.size());
+        for (int i = 0; i < percentiles.size(); i++) {
+            Double percentile = percentiles.get(i);
+            checkState(percentile != -1.0, "Percentile is missing");
+            checkCondition(0 <= percentile && percentile <= 1, INVALID_FUNCTION_ARGUMENT, "Percentile must be between 0 and 1");
+            try {
+                BIGINT.writeLong(blockBuilder, digest.getQuantile(percentile));
+            }
+            catch (NullPointerException e) {
+                // no-op
+            }
+        }
+
+        new ArrayType(BIGINT).writeObject(out, blockBuilder.build());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayState.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import io.airlift.stats.QuantileDigest;
+
+import java.util.List;
+
+@AccumulatorStateMetadata(stateSerializerClass = DigestAndPercentileArrayStateSerializer.class, stateFactoryClass = DigestAndPercentileArrayStateFactory.class)
+public interface DigestAndPercentileArrayState
+        extends AccumulatorState
+{
+    QuantileDigest getDigest();
+
+    void setDigest(QuantileDigest digest);
+
+    void setPercentiles(List<Double> percentiles);
+
+    List<Double> getPercentiles();
+
+    void addMemoryUsage(int value);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayStateFactory.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.util.array.ObjectBigArray;
+import io.airlift.stats.QuantileDigest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+
+public class DigestAndPercentileArrayStateFactory
+        implements AccumulatorStateFactory<DigestAndPercentileArrayState>
+{
+    @Override
+    public DigestAndPercentileArrayState createSingleState()
+    {
+        return new SingleDigestAndPercentileArrayState();
+    }
+
+    @Override
+    public Class<? extends DigestAndPercentileArrayState> getSingleStateClass()
+    {
+        return SingleDigestAndPercentileArrayState.class;
+    }
+
+    @Override
+    public DigestAndPercentileArrayState createGroupedState()
+    {
+        return new GroupedDigestAndPercentileArrayState();
+    }
+
+    @Override
+    public Class<? extends DigestAndPercentileArrayState> getGroupedStateClass()
+    {
+        return GroupedDigestAndPercentileArrayState.class;
+    }
+
+    public static class GroupedDigestAndPercentileArrayState
+            extends AbstractGroupedAccumulatorState
+            implements DigestAndPercentileArrayState
+    {
+        private final ObjectBigArray<QuantileDigest> digests = new ObjectBigArray<>();
+        private final ObjectBigArray<List<Double>> percentilesArray = new ObjectBigArray<>(new ArrayList<>());
+        private long size;
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            digests.ensureCapacity(size);
+            percentilesArray.ensureCapacity(size);
+        }
+
+        @Override
+        public QuantileDigest getDigest()
+        {
+            return digests.get(getGroupId());
+        }
+
+        @Override
+        public void setDigest(QuantileDigest digest)
+        {
+            checkNotNull(digest, "value is null");
+            digests.set(getGroupId(), digest);
+        }
+
+        @Override
+        public List<Double> getPercentiles()
+        {
+            return percentilesArray.get(getGroupId());
+        }
+
+        @Override
+        public void setPercentiles(List<Double> percentiles)
+        {
+            percentilesArray.set(getGroupId(), percentiles);
+        }
+
+        @Override
+        public void addMemoryUsage(int value)
+        {
+            size += value;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + digests.sizeOf() + percentilesArray.sizeOf();
+        }
+    }
+
+    public static class SingleDigestAndPercentileArrayState
+            implements DigestAndPercentileArrayState
+    {
+        private QuantileDigest digest;
+        private List<Double> percentiles = new ArrayList<>();
+
+        @Override
+        public QuantileDigest getDigest()
+        {
+            return digest;
+        }
+
+        @Override
+        public void setDigest(QuantileDigest digest)
+        {
+            this.digest = digest;
+        }
+
+        @Override
+        public List<Double> getPercentiles()
+        {
+            return percentiles;
+        }
+
+        @Override
+        public void setPercentiles(List<Double> percentiles)
+        {
+            this.percentiles = percentiles;
+        }
+
+        @Override
+        public void addMemoryUsage(int value)
+        {
+            // noop
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            if (digest == null) {
+                return SIZE_OF_DOUBLE;
+            }
+            return digest.estimatedInMemorySizeInBytes() + SIZE_OF_DOUBLE;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayStateSerializer.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import io.airlift.stats.QuantileDigest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+
+public class DigestAndPercentileArrayStateSerializer
+        implements AccumulatorStateSerializer<DigestAndPercentileArrayState>
+{
+    @Override
+    public Type getSerializedType()
+    {
+        return VARCHAR;
+    }
+
+    @Override
+    public void serialize(DigestAndPercentileArrayState state, BlockBuilder out)
+    {
+        if (state.getDigest() == null) {
+            out.appendNull();
+        }
+        else {
+            DynamicSliceOutput sliceOutput = new DynamicSliceOutput(state.getDigest().estimatedSerializedSizeInBytes() + SIZE_OF_DOUBLE);
+            // write digest
+            state.getDigest().serialize(sliceOutput);
+            // write percentiles
+            List<Double> percentiles = state.getPercentiles();
+            sliceOutput.appendLong(percentiles.size());
+            for (Double percentile : percentiles) {
+                sliceOutput.appendDouble(percentile);
+            }
+
+            Slice slice = sliceOutput.slice();
+            VARCHAR.writeSlice(out, slice);
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, DigestAndPercentileArrayState state)
+    {
+        if (!block.isNull(index)) {
+            SliceInput input = VARCHAR.getSlice(block, index).getInput();
+
+            // read digest
+            state.setDigest(QuantileDigest.deserialize(input));
+            state.addMemoryUsage(state.getDigest().estimatedInMemorySizeInBytes());
+
+            // read number of percentiles
+            Long numPercentiles = input.readLong();
+
+            List<Double> percentiles = new ArrayList<Double>(numPercentiles.intValue());
+            for (int i = 0; i < numPercentiles; i++) {
+                percentiles.add(input.readDouble());
+            }
+            state.setPercentiles(percentiles);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/ArrayType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/ArrayType.java
@@ -65,10 +65,6 @@ public class ArrayType
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        if (isOrderable()) {
-            return compareTo(leftBlock, leftPosition, rightBlock, rightPosition) == 0;
-        }
-
         Block leftArray = leftBlock.getObject(leftPosition, Block.class);
         Block rightArray = rightBlock.getObject(rightPosition, Block.class);
 

--- a/presto-main/src/main/java/com/facebook/presto/type/ArrayType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/ArrayType.java
@@ -72,16 +72,12 @@ public class ArrayType
             return false;
         }
 
-        int len = Math.min(leftArray.getPositionCount(), rightArray.getPositionCount());
-        int index = 0;
-        while (index < len) {
-            checkElementNotNull(leftArray.isNull(index), ARRAY_NULL_ELEMENT_MSG);
-            checkElementNotNull(rightArray.isNull(index), ARRAY_NULL_ELEMENT_MSG);
-            boolean isEqual = elementType.equalTo(leftArray, index, rightArray, index);
-            if (!isEqual) {
+        for (int i = 0; i < leftArray.getPositionCount(); i++) {
+            checkElementNotNull(leftArray.isNull(i), ARRAY_NULL_ELEMENT_MSG);
+            checkElementNotNull(rightArray.isNull(i), ARRAY_NULL_ELEMENT_MSG);
+            if (!elementType.equalTo(leftArray, i, rightArray, i)) {
                 return false;
             }
-            index++;
         }
 
         return true;

--- a/presto-main/src/main/java/com/facebook/presto/type/ArrayType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/ArrayType.java
@@ -65,7 +65,30 @@ public class ArrayType
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        return compareTo(leftBlock, leftPosition, rightBlock, rightPosition) == 0;
+        if (isOrderable()) {
+            return compareTo(leftBlock, leftPosition, rightBlock, rightPosition) == 0;
+        }
+
+        Block leftArray = leftBlock.getObject(leftPosition, Block.class);
+        Block rightArray = rightBlock.getObject(rightPosition, Block.class);
+
+        if (leftArray.getPositionCount() != rightArray.getPositionCount()) {
+            return false;
+        }
+
+        int len = Math.min(leftArray.getPositionCount(), rightArray.getPositionCount());
+        int index = 0;
+        while (index < len) {
+            checkElementNotNull(leftArray.isNull(index), ARRAY_NULL_ELEMENT_MSG);
+            checkElementNotNull(rightArray.isNull(index), ARRAY_NULL_ELEMENT_MSG);
+            boolean isEqual = elementType.equalTo(leftArray, index, rightArray, index);
+            if (!isEqual) {
+                return false;
+            }
+            index++;
+        }
+
+        return true;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
@@ -17,17 +17,21 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.type.ArrayType;
 import com.facebook.presto.testing.RunLengthEncodedBlock;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
 import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
 import static com.facebook.presto.operator.aggregation.ApproximateDoublePercentileAggregations.DOUBLE_APPROXIMATE_PERCENTILE_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.ApproximateDoublePercentileArrayAggregations.DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.ApproximateDoublePercentileAggregations.DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.ApproximateLongPercentileAggregations.LONG_APPROXIMATE_PERCENTILE_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.ApproximateLongPercentileAggregations.LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.ApproximateLongPercentileArrayAggregations.LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 
@@ -94,6 +98,70 @@ public class TestApproximatePercentileAggregation
                 createPage(
                         new Long[] {2L, 2L, null, 3L, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L},
                         0.5));
+
+        // array of approx_percentile
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(),
+                createPage(
+                        new Long[] {null},
+                        new Double[] {0.5, 0.99}),
+                createPage(
+                        new Long[] {null},
+                        new Double[] {0.5, 0.99}));
+
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1L, 1L),
+                createPage(
+                        new Long[] {null},
+                        new Double[] {0.5, 0.99}),
+                createPage(
+                        new Long[] {1L},
+                        new Double[] {0.5, 0.99}));
+
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(2L, 3L),
+                createPage(
+                        new Long[] {null},
+                        new Double[] {0.5, 0.99}),
+                createPage(
+                        new Long[] {1L, 2L, 3L},
+                        new Double[] {0.5, 0.99}));
+
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(2L, 2L),
+                createPage(
+                        new Long[] {1L},
+                        new Double[] {0.5, 0.5}),
+                createPage(
+                        new Long[] {2L, 3L},
+                        new Double[] {0.5, 0.5}));
+
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1L, 2L, 2L),
+                createPage(
+                        new Long[] {1L, null, 2L, null, 2L, null},
+                        new Double[] {0.2, 0.5, 0.8}));
+
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(2L, 3L, 5L),
+                createPage(
+                        new Long[] {1L, null, 2L, null, 2L, null},
+                        new Double[] {0.2, 0.5, 0.8}),
+                createPage(
+                        new Long[] {2L, null, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L},
+                        new Double[] {0.2, 0.5, 0.8}));
 
         // weighted approx_percentile
         assertAggregation(
@@ -221,6 +289,63 @@ public class TestApproximatePercentileAggregation
                         new Double[] {2.0, 2.0, null, 3.0, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0},
                         0.5));
 
+        // array of approx_percentile
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(),
+                createPage(
+                        new Double[] {null},
+                        new Double[] {0.5, 0.5}),
+                createPage(
+                        new Double[] {null},
+                        0.5));
+
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1.0, 1.0),
+                createPage(
+                        new Double[] {null},
+                        new Double[] {0.5, 0.5}),
+                createPage(
+                        new Double[] {1.0},
+                        new Double[] {0.5, 0.5}));
+
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1.0, 2.0, 3.0),
+                createPage(
+                        new Double[] {null},
+                        new Double[] {0.2, 0.5, 0.8}),
+                createPage(
+                        new Double[] {1.0, 2.0, 3.0},
+                        new Double[] {0.2, 0.5, 0.8}));
+
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(2.0, 3.0),
+                createPage(
+                        new Double[] {1.0},
+                        new Double[] {0.5, 0.99}),
+                createPage(
+                        new Double[] {2.0, 3.0},
+                        new Double[] {0.5, 0.99}));
+
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1.0, 3.0),
+                createPage(
+                        new Double[] {1.0, null, 2.0, 2.0, null, 2.0, 2.0, null},
+                        new Double[] {0.01, 0.5}),
+                createPage(
+                        new Double[] {2.0, 2.0, null, 3.0, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0},
+                        new Double[] {0.01, 0.5}));
+
+
         // weighted approx_percentile
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
@@ -306,6 +431,24 @@ public class TestApproximatePercentileAggregation
         return new Page(valuesBlock, percentilesBlock);
     }
 
+    private static Page createPage(Double[] values, Double[] percentiles)
+    {
+        Block valuesBlock;
+        Block percentilesBlock;
+
+        if (values.length == 0) {
+            valuesBlock = EMPTY_DOUBLE_BLOCK;
+            percentilesBlock = EMPTY_DOUBLE_BLOCK;
+        }
+        else {
+            valuesBlock = createDoublesBlock(values);
+            int positionCount = values.length;
+            percentilesBlock = createRLEBlock(percentiles, positionCount);
+        }
+
+        return new Page(valuesBlock, percentilesBlock);
+    }
+
     private static Page createPage(Long[] values, double percentile)
     {
         Block valuesBlock;
@@ -318,6 +461,24 @@ public class TestApproximatePercentileAggregation
         else {
             valuesBlock = createLongsBlock(values);
             percentilesBlock = createRLEBlock(percentile, values.length);
+        }
+
+        return new Page(valuesBlock, percentilesBlock);
+    }
+
+    private static Page createPage(Long[] values, Double[] percentiles)
+    {
+        Block valuesBlock;
+        Block percentilesBlock;
+
+        if (values.length == 0) {
+            valuesBlock = EMPTY_DOUBLE_BLOCK;
+            percentilesBlock = EMPTY_DOUBLE_BLOCK;
+        }
+        else {
+            valuesBlock = createLongsBlock(values);
+            int positionCount = values.length;
+            percentilesBlock = createRLEBlock(percentiles, positionCount);
         }
 
         return new Page(valuesBlock, percentilesBlock);
@@ -372,5 +533,20 @@ public class TestApproximatePercentileAggregation
         BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), 1);
         DOUBLE.writeDouble(blockBuilder, percentile);
         return new RunLengthEncodedBlock(blockBuilder.build(), positionCount);
+    }
+
+    private static RunLengthEncodedBlock createRLEBlock(Double[] percentiles, int positionCount)
+    {
+        BlockBuilder rleBlockBuilder = new ArrayType(DOUBLE).createBlockBuilder(new BlockBuilderStatus(), 1);
+
+        BlockBuilder arrayBlockBuilder = rleBlockBuilder.beginBlockEntry();
+
+        for (double percentile : percentiles) {
+            DOUBLE.writeDouble(arrayBlockBuilder, percentile);
+        }
+
+        rleBlockBuilder.closeEntry();
+
+        return new RunLengthEncodedBlock(rleBlockBuilder.build(), positionCount);
     }
 }


### PR DESCRIPTION
I'm not completely sure how orderable and comparable are different from each other, but AbstractType says it isn't either of those, so it seems like the only way to do it is iterate through the elements.