### PR TITLE
Create a new dictionary when we read a row group

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
@@ -184,7 +184,7 @@ public class SliceDictionaryStreamReader
         else {
             int[] ids = Arrays.copyOfRange(dataVector, 0, nextBatchSize);
             boolean[] isNullVector = Arrays.copyOfRange(this.isNullVector, 0, nextBatchSize);
-            Slice[] values = Arrays.copyOf(dictionary, dictionary.length);
+            Slice[] values = dictionary;
             sliceVector.setDictionary(values, ids, isNullVector);
         }
 
@@ -197,11 +197,9 @@ public class SliceDictionaryStreamReader
     {
         // read the dictionary
         if (!dictionaryOpen && dictionarySize > 0) {
-            // resize the dictionary array if necessary
-            if (dictionary.length < dictionarySize) {
-                dictionary = new Slice[dictionarySize];
-                dictionaryLength = new int[dictionarySize];
-            }
+            // create a new dictionary array
+            dictionary = new Slice[dictionarySize];
+            dictionaryLength = new int[dictionarySize];
 
             // read the lengths
             LongStream lengthStream = dictionaryLengthStreamSource.openStream();


### PR DESCRIPTION
We try to reuse the already allocated dictionary (if possible) for
multiple reads. This forces us to make a copy of the dictionary for
every batch. Allocate a new dictionary for every read, to avoid copying
the dictionary each time.