### PR TITLE
Print error to stderr

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -284,7 +284,7 @@ public class Console
             }
         }
         catch (RuntimeException e) {
-            System.out.println("Error running command: " + e.getMessage());
+            System.err.println("Error running command: " + e.getMessage());
             if (queryRunner.getSession().isDebug()) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
This error is being output to stdout, which makes it difficult to detect when invoked programatically.