### PR TITLE
Fix and cleanup unit tests for aggregation functions

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -107,6 +107,23 @@ public final class BlockAssertions
         return builder.build();
     }
 
+    public static Block createStringArraysBlock(Iterable<? extends Iterable<String>> values)
+    {
+        ArrayType arrayType = new ArrayType(VARCHAR);
+        BlockBuilder builder = arrayType.createBlockBuilder(new BlockBuilderStatus(), 100);
+
+        for (Iterable<String> value : values) {
+            if (value == null) {
+                builder.appendNull();
+            }
+            else {
+                arrayType.writeObject(builder, createStringsBlock(value));
+            }
+        }
+
+        return builder.build();
+    }
+
     public static Block createBooleansBlock(Boolean... values)
     {
         requireNonNull(values, "varargs 'values' is null");

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
@@ -146,6 +146,6 @@ public abstract class AbstractTestAggregationFunction
 
     protected void testAggregation(Object expectedValue, Block... blocks)
     {
-        assertAggregation(getFunction(), getConfidence(), expectedValue, blocks[0].getPositionCount(), blocks);
+        assertAggregation(getFunction(), getConfidence(), expectedValue, blocks);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
@@ -41,10 +41,14 @@ public final class AggregationTestUtils
     {
     }
 
-    public static void assertAggregation(InternalAggregationFunction function, double confidence, Object expectedValue, int positions, Block... blocks)
+    public static void assertAggregation(InternalAggregationFunction function, double confidence, Object expectedValue, Block... blocks)
     {
+        int positions = blocks[0].getPositionCount();
+        for (int i = 1; i < blocks.length; i++) {
+            assertEquals(positions, blocks[i].getPositionCount(), "input blocks provided are not equal in position count");
+        }
         if (positions == 0) {
-            assertAggregation(function, confidence, expectedValue);
+            assertAggregation(function, confidence, expectedValue, new Page[]{});
         }
         else if (positions == 1) {
             assertAggregation(function, confidence, expectedValue, new Page(positions, blocks));
@@ -159,8 +163,10 @@ public final class AggregationTestUtils
         return Math.abs(expected - actual) <= error && !Double.isInfinite(error);
     }
 
-    public static void assertAggregation(InternalAggregationFunction function, double confidence, Object expectedValue, Page... pages)
+    private static void assertAggregation(InternalAggregationFunction function, double confidence, Object expectedValue, Page... pages)
     {
+        // This assertAggregation does not try to split up the page to test the correctness of combine function.
+        // Do not use this directly. Always use the other assertAggregation.
         assertEquals(aggregation(function, confidence, pages), expectedValue);
         assertEquals(partialAggregation(function, confidence, pages), expectedValue);
         if (pages.length > 0) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
@@ -13,12 +13,10 @@
  */
 package com.facebook.presto.operator.aggregation;
 
-import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.testing.RunLengthEncodedBlock;
-import com.google.common.base.Preconditions;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
@@ -45,120 +43,76 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE_AGGREGATION,
                 1.0,
                 null,
-                createPage(
-                        new Long[] {null},
-                        0.5),
-                createPage(
-                        new Long[] {null},
-                        0.5));
+                createLongsBlock(null, null),
+                createRLEBlock(0.5, 2));
 
         assertAggregation(LONG_APPROXIMATE_PERCENTILE_AGGREGATION,
                 1.0,
                 1L,
-                createPage(
-                        new Long[] {null},
-                        0.5),
-                createPage(
-                        new Long[] {1L},
-                        0.5));
+                createLongsBlock(null, 1L),
+                createRLEBlock(0.5, 2));
 
         assertAggregation(
                 LONG_APPROXIMATE_PERCENTILE_AGGREGATION,
                 1.0,
                 2L,
-                createPage(
-                        new Long[] {null},
-                        0.5),
-                createPage(
-                        new Long[] {1L, 2L, 3L},
-                        0.5));
+                createLongsBlock(null, 1L, 2L, 3L),
+                createRLEBlock(0.5, 4));
 
         assertAggregation(
                 LONG_APPROXIMATE_PERCENTILE_AGGREGATION,
                 1.0,
                 2L,
-                createPage(
-                        new Long[] {1L},
-                        0.5),
-                createPage(
-                        new Long[] {2L, 3L},
-                        0.5));
+                createLongsBlock(1L, 2L, 3L),
+                createRLEBlock(0.5, 3));
 
         assertAggregation(
                 LONG_APPROXIMATE_PERCENTILE_AGGREGATION,
                 1.0,
                 3L,
-                createPage(
-                        new Long[] {1L, null, 2L, 2L, null, 2L, 2L, null},
-                        0.5),
-                createPage(
-                        new Long[] {2L, 2L, null, 3L, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L},
-                        0.5));
+                createLongsBlock(1L, null, 2L, 2L, null, 2L, 2L, null, 2L, 2L, null, 3L, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
+                createRLEBlock(0.5, 21));
 
         // weighted approx_percentile
         assertAggregation(
                 LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 1.0,
                 null,
-                createPage(
-                        new Long[] {null},
-                        new Long[] {1L},
-                        0.5),
-                createPage(
-                        new Long[] {null},
-                        new Long[] {1L},
-                        0.5));
+                createLongsBlock(null, null),
+                createLongsBlock(1L, 1L),
+                createRLEBlock(0.5, 2));
 
         assertAggregation(
                 LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 1.0,
                 1L,
-                createPage(
-                        new Long[] {null},
-                        new Long[] {1L},
-                        0.5),
-                createPage(
-                        new Long[] {1L},
-                        new Long[] {1L},
-                        0.5));
+                createLongsBlock(null, 1L),
+                createLongsBlock(1L, 1L),
+                createRLEBlock(0.5, 2));
 
         assertAggregation(
                 LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 1.0,
                 2L,
-                createPage(
-                        new Long[] {null},
-                        new Long[] {1L}, 0.5),
-                createPage(
-                        new Long[] {1L, 2L, 3L},
-                        new Long[] {1L, 1L, 1L},
-                        0.5));
+                createLongsBlock(null, 1L, 2L, 3L),
+                createLongsBlock(1L, 1L, 1L, 1L),
+                createRLEBlock(0.5, 4));
 
         assertAggregation(
                 LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 1.0,
                 2L,
-                createPage(
-                        new Long[] {1L},
-                        new Long[] {1L},
-                        0.5),
-                createPage(
-                        new Long[] {2L, 3L},
-                        new Long[] {1L, 1L},
-                        0.5));
+                createLongsBlock(1L, 2L, 3L),
+                createLongsBlock(1L, 1L, 1L),
+                createRLEBlock(0.5, 3));
 
         assertAggregation(
                 LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 1.0,
                 3L,
-                createPage(
-                        new Long[] {1L, null, 2L, null, 2L, null},
-                        new Long[] {1L, 1L, 2L, 1L, 2L, 1L},
-                        0.5),
-                createPage(
-                        new Long[] {2L, null, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L},
-                        new Long[] {2L, 1L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L},
-                        0.5));
+                createLongsBlock(1L, null, 2L, null, 2L, null, 2L, null, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
+                createLongsBlock(1L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L),
+                createRLEBlock(0.5, 17));
     }
 
     @Test
@@ -170,201 +124,77 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE_AGGREGATION,
                 1.0,
                 null,
-                createPage(
-                        new Double[] {null},
-                        0.5),
-                createPage(
-                        new Double[] {null},
-                        0.5));
+                createDoublesBlock(null, null),
+                createRLEBlock(0.5, 2));
 
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_AGGREGATION,
                 1.0,
                 1.0,
-                createPage(
-                        new Double[] {null},
-                        0.5),
-                createPage(
-                        new Double[] {1.0},
-                        0.5));
+                createDoublesBlock(null, 1.0),
+                createRLEBlock(0.5, 2));
 
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_AGGREGATION,
                 1.0,
                 2.0,
-                createPage(
-                        new Double[] {null},
-                        0.5),
-                createPage(
-                        new Double[] {1.0, 2.0, 3.0},
-                        0.5));
+                createDoublesBlock(null, 1.0, 2.0, 3.0),
+                createRLEBlock(0.5, 4));
 
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_AGGREGATION,
                 1.0,
                 2.0,
-                createPage(
-                        new Double[] {1.0},
-                        0.5),
-                createPage(
-                        new Double[] {2.0, 3.0},
-                        0.5));
+                createDoublesBlock(1.0, 2.0, 3.0),
+                createRLEBlock(0.5, 3));
 
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_AGGREGATION,
                 1.0,
                 3.0,
-                createPage(
-                        new Double[] {1.0, null, 2.0, 2.0, null, 2.0, 2.0, null},
-                        0.5),
-                createPage(
-                        new Double[] {2.0, 2.0, null, 3.0, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0},
-                        0.5));
+                createDoublesBlock(1.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 3.0, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
+                createRLEBlock(0.5, 21));
 
         // weighted approx_percentile
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 1.0,
                 null,
-                createPage(
-                        new Double[] {null},
-                        new Long[] {1L},
-                        0.5),
-                createPage(
-                        new Double[] {null},
-                        new Long[] {1L},
-                        0.5));
+                createDoublesBlock(null, null),
+                createLongsBlock(1L, 1L),
+                createRLEBlock(0.5, 2));
 
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 1.0,
                 1.0,
-                createPage(
-                        new Double[] {null},
-                        new Long[] {1L},
-                        0.5),
-                createPage(
-                        new Double[] {1.0},
-                        new Long[] {1L},
-                        0.5));
+                createDoublesBlock(null, 1.0),
+                createLongsBlock(1L, 1L),
+                createRLEBlock(0.5, 2));
 
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 1.0,
                 2.0,
-                createPage(
-                        new Double[] {null},
-                        new Long[] {1L},
-                        0.5),
-                createPage(
-                        new Double[] {1.0, 2.0, 3.0},
-                        new Long[] {1L, 1L, 1L},
-                        0.5));
+                createDoublesBlock(null, 1.0, 2.0, 3.0),
+                createLongsBlock(1L, 1L, 1L, 1L),
+                createRLEBlock(0.5, 4));
 
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 1.0,
                 2.0,
-                createPage(
-                        new Double[] {1.0},
-                        new Long[] {1L},
-                        0.5),
-                createPage(
-                        new Double[] {2.0, 3.0},
-                        new Long[] {1L, 1L},
-                        0.5));
+                createDoublesBlock(1.0, 2.0, 3.0),
+                createLongsBlock(1L, 1L, 1L),
+                createRLEBlock(0.5, 3));
 
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 1.0,
                 3.0,
-                createPage(
-                        new Double[] {1.0, null, 2.0, null, 2.0, null},
-                        new Long[] {1L, 1L, 2L, 1L, 2L, 1L},
-                        0.5),
-                createPage(
-                        new Double[] {2.0, null, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0},
-                        new Long[] {2L, 1L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L},
-                        0.5));
-    }
-
-    private static Page createPage(Double[] values, double percentile)
-    {
-        Block valuesBlock;
-        Block percentilesBlock;
-
-        if (values.length == 0) {
-            valuesBlock = EMPTY_DOUBLE_BLOCK;
-            percentilesBlock = EMPTY_DOUBLE_BLOCK;
-        }
-        else {
-            valuesBlock = createDoublesBlock(values);
-            int positionCount = values.length;
-            percentilesBlock = createRLEBlock(percentile, positionCount);
-        }
-
-        return new Page(valuesBlock, percentilesBlock);
-    }
-
-    private static Page createPage(Long[] values, double percentile)
-    {
-        Block valuesBlock;
-        Block percentilesBlock;
-
-        if (values.length == 0) {
-            valuesBlock = EMPTY_LONG_BLOCK;
-            percentilesBlock = EMPTY_DOUBLE_BLOCK;
-        }
-        else {
-            valuesBlock = createLongsBlock(values);
-            percentilesBlock = createRLEBlock(percentile, values.length);
-        }
-
-        return new Page(valuesBlock, percentilesBlock);
-    }
-
-    private static Page createPage(Long[] values, Long[] weights, double percentile)
-    {
-        Preconditions.checkArgument(values.length == weights.length, "values.length must match weights.length");
-
-        Block valuesBlock;
-        Block weightsBlock;
-        Block percentilesBlock;
-
-        if (values.length == 0) {
-            valuesBlock = EMPTY_LONG_BLOCK;
-            weightsBlock = EMPTY_LONG_BLOCK;
-            percentilesBlock = EMPTY_DOUBLE_BLOCK;
-        }
-        else {
-            valuesBlock = createLongsBlock(values);
-            weightsBlock = createLongsBlock(weights);
-            percentilesBlock = createRLEBlock(percentile, values.length);
-        }
-
-        return new Page(valuesBlock, weightsBlock, percentilesBlock);
-    }
-
-    private static Page createPage(Double[] values, Long[] weights, double percentile)
-    {
-        Preconditions.checkArgument(values.length == weights.length, "values.length must match weights.length");
-
-        Block valuesBlock;
-        Block weightsBlock;
-        Block percentilesBlock;
-
-        if (values.length == 0) {
-            valuesBlock = EMPTY_DOUBLE_BLOCK;
-            weightsBlock = EMPTY_LONG_BLOCK;
-            percentilesBlock = EMPTY_DOUBLE_BLOCK;
-        }
-        else {
-            valuesBlock = createDoublesBlock(values);
-            weightsBlock = createLongsBlock(weights);
-            percentilesBlock = createRLEBlock(percentile, values.length);
-        }
-
-        return new Page(valuesBlock, weightsBlock, percentilesBlock);
+                createDoublesBlock(1.0, null, 2.0, null, 2.0, null, 2.0, null, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
+                createLongsBlock(1L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L),
+                createRLEBlock(0.5, 17));
     }
 
     private static RunLengthEncodedBlock createRLEBlock(double percentile, int positionCount)

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArbitraryAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArbitraryAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
-import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -56,8 +55,7 @@ public class TestArbitraryAggregation
                 booleanAgg,
                 1.0,
                 null,
-                createPage(
-                        new Boolean[] {null}));
+                createBooleansBlock((Boolean) null));
     }
 
     @Test
@@ -69,8 +67,7 @@ public class TestArbitraryAggregation
                 booleanAgg,
                 1.0,
                 true,
-                createPage(
-                        new Boolean[] {true, true}));
+                createBooleansBlock(true, true));
     }
 
     @Test
@@ -82,8 +79,7 @@ public class TestArbitraryAggregation
                 longAgg,
                 1.0,
                 null,
-                createPage(
-                        new Long[] {null, null}));
+                createLongsBlock(null, null));
     }
 
     @Test
@@ -95,8 +91,7 @@ public class TestArbitraryAggregation
                 longAgg,
                 1.0,
                 1L,
-                createPage(
-                        new Long[] {1L , null}));
+                createLongsBlock(1L , null));
     }
 
     @Test
@@ -108,8 +103,7 @@ public class TestArbitraryAggregation
                 doubleAgg,
                 1.0,
                 null,
-                createPage(
-                        new Double[] {null, null}));
+                createDoublesBlock(null, null));
     }
 
     @Test
@@ -121,8 +115,7 @@ public class TestArbitraryAggregation
                 doubleAgg,
                 1.0,
                 2.0,
-                createPage(
-                        new Double[] {null, 2.0}));
+                createDoublesBlock(null, 2.0));
     }
 
     @Test
@@ -134,8 +127,7 @@ public class TestArbitraryAggregation
                 stringAgg,
                 1.0,
                 null,
-                createPage(
-                        new String[] {null, null}));
+                createStringsBlock(null, null));
     }
 
     @Test
@@ -147,8 +139,7 @@ public class TestArbitraryAggregation
                 stringAgg,
                 1.0,
                 "a",
-                createPage(
-                        new String[] {"a", "a"}));
+                createStringsBlock("a", "a"));
     }
 
     @Test
@@ -160,8 +151,7 @@ public class TestArbitraryAggregation
                 arrayAgg,
                 1.0,
                 null,
-                createPage(
-                        Arrays.asList(null, null, null, null)));
+                createArrayBigintBlock(Arrays.asList(null, null, null, null)));
     }
 
     @Test
@@ -173,32 +163,6 @@ public class TestArbitraryAggregation
                 arrayAgg,
                 1.0,
                 ImmutableList.of(23L, 45L),
-                createPage(
-                        ImmutableList.of(ImmutableList.of(23L, 45L), ImmutableList.of(23L, 45L), ImmutableList.of(23L, 45L), ImmutableList.of(23L, 45L))));
-    }
-
-    private static Page createPage(Boolean[] values)
-    {
-        return new Page(createBooleansBlock(values));
-    }
-
-    private static Page createPage(Long[] values)
-    {
-        return new Page(createLongsBlock(values));
-    }
-
-    private static Page createPage(Double[] values)
-    {
-        return new Page(createDoublesBlock(values));
-    }
-
-    private static Page createPage(String[] values)
-    {
-        return new Page(createStringsBlock(values));
-    }
-
-    private static Page createPage(Iterable<? extends Iterable<Long>> values)
-    {
-        return new Page(createArrayBigintBlock(values));
+                createArrayBigintBlock(ImmutableList.of(ImmutableList.of(23L, 45L), ImmutableList.of(23L, 45L), ImmutableList.of(23L, 45L), ImmutableList.of(23L, 45L))));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayAggregation.java
@@ -15,22 +15,17 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
-import com.facebook.presto.spi.Page;
-import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import com.facebook.presto.spi.type.SqlDate;
-import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.type.ArrayType;
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
 
+import static com.facebook.presto.block.BlockAssertions.createArrayBigintBlock;
 import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
 import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
 import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
-import static com.facebook.presto.spi.type.BigintType.BIGINT;
 
 public class TestArrayAggregation
 {
@@ -45,7 +40,7 @@ public class TestArrayAggregation
                 bigIntAgg,
                 1.0,
                 null,
-                new Page(createLongsBlock(new Long[] {})));
+                createLongsBlock(new Long[] {}));
     }
 
     @Test
@@ -57,7 +52,7 @@ public class TestArrayAggregation
                 bigIntAgg,
                 1.0,
                 null,
-                new Page(createLongsBlock(new Long[] {null, null, null})));
+                createLongsBlock(new Long[] {null, null, null}));
     }
 
     @Test
@@ -69,7 +64,7 @@ public class TestArrayAggregation
                 bigIntAgg,
                 1.0,
                 Arrays.asList(2L, 3L),
-                new Page(createLongsBlock(new Long[] {null, 2L, null, 3L, null})));
+                createLongsBlock(new Long[] {null, 2L, null, 3L, null}));
     }
 
     @Test
@@ -81,7 +76,7 @@ public class TestArrayAggregation
                 booleanAgg,
                 1.0,
                 Arrays.asList(true, false),
-                new Page(createBooleansBlock(new Boolean[] {true, false})));
+                createBooleansBlock(new Boolean[] {true, false}));
     }
 
     @Test
@@ -93,7 +88,7 @@ public class TestArrayAggregation
                 bigIntAgg,
                 1.0,
                 Arrays.asList(2L, 1L, 2L),
-                new Page(createLongsBlock(new Long[] {2L, 1L, 2L})));
+                createLongsBlock(new Long[] {2L, 1L, 2L}));
     }
 
     @Test
@@ -105,7 +100,7 @@ public class TestArrayAggregation
                 varcharAgg,
                 1.0,
                 Arrays.asList("hello", "world"),
-                new Page(createStringsBlock(new String[] {"hello", "world"})));
+                createStringsBlock(new String[] {"hello", "world"}));
     }
 
     @Test
@@ -117,7 +112,7 @@ public class TestArrayAggregation
                 varcharAgg,
                 1.0,
                 Arrays.asList(new SqlDate(1), new SqlDate(2), new SqlDate(4)),
-                new Page(createLongsBlock(new Long[] {1L, 2L, 4L})));
+                createLongsBlock(new Long[] {1L, 2L, 4L}));
     }
 
     @Test
@@ -126,28 +121,10 @@ public class TestArrayAggregation
     {
         InternalAggregationFunction varcharAgg = metadata.getExactFunction(new Signature("array_agg", "array<array<bigint>>", "array<bigint>")).getAggregationFunction();
 
-        Type arrayType = new ArrayType(BIGINT);
-        BlockBuilder builder = arrayType.createBlockBuilder(new BlockBuilderStatus(), 100);
-
-        BlockBuilder variableWidthBlockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), 100);
-        BIGINT.writeLong(variableWidthBlockBuilder, 1);
-        arrayType.writeObject(builder, variableWidthBlockBuilder);
-
-        variableWidthBlockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), 100);
-        BIGINT.writeLong(variableWidthBlockBuilder, 1);
-        BIGINT.writeLong(variableWidthBlockBuilder, 2);
-        arrayType.writeObject(builder, variableWidthBlockBuilder);
-
-        variableWidthBlockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), 100);
-        BIGINT.writeLong(variableWidthBlockBuilder, 1);
-        BIGINT.writeLong(variableWidthBlockBuilder, 2);
-        BIGINT.writeLong(variableWidthBlockBuilder, 3);
-        arrayType.writeObject(builder, variableWidthBlockBuilder);
-
         assertAggregation(
                 varcharAgg,
                 1.0,
                 Arrays.asList(Arrays.asList(1L), Arrays.asList(1L, 2L), Arrays.asList(1L, 2L, 3L)),
-                new Page(builder.build()));
+                createArrayBigintBlock(ImmutableList.of(ImmutableList.of(1L), ImmutableList.of(1L, 2L), ImmutableList.of(1L, 2L, 3L))));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMinMaxByAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMinMaxByAggregation.java
@@ -19,7 +19,6 @@ import com.facebook.presto.operator.aggregation.state.MaxOrMinByState;
 import com.facebook.presto.operator.aggregation.state.MaxOrMinByStateFactory;
 import com.facebook.presto.operator.aggregation.state.MaxOrMinByStateSerializer;
 import com.facebook.presto.spi.ConnectorSession;
-import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -79,9 +78,8 @@ public class TestMinMaxByAggregation
                 function,
                 1.0,
                 1.0,
-                createPage(
-                        new Double[] {1.0, null},
-                        new Double[] {1.0, 2.0}));
+                createDoublesBlock(1.0, null),
+                createDoublesBlock(1.0, 2.0));
     }
 
     @Test
@@ -92,9 +90,8 @@ public class TestMinMaxByAggregation
                 function,
                 1.0,
                 null,
-                createPage(
-                        new Double[] {1.0, null},
-                        new Double[] {1.0, 2.0}));
+                createDoublesBlock(1.0, null),
+                createDoublesBlock(1.0, 2.0));
     }
 
     @Test
@@ -106,23 +103,15 @@ public class TestMinMaxByAggregation
                 function,
                 1.0,
                 null,
-                createPage(
-                        new Double[] {null},
-                        new Double[] {null}),
-                createPage(
-                        new Double[] {null},
-                        new Double[] {null}));
+                createDoublesBlock(null, null),
+                createDoublesBlock(null, null));
 
         assertAggregation(
                 function,
                 1.0,
                 3.0,
-                createPage(
-                        new Double[] {3.0, 2.0},
-                        new Double[] {1.0, 1.5}),
-                createPage(
-                        new Double[] {5.0, 3.0},
-                        new Double[] {2.0, 4.0}));
+                createDoublesBlock(3.0, 2.0, 5.0, 3.0),
+                createDoublesBlock(1.0, 1.5, 2.0, 4.0));
     }
 
     @Test
@@ -133,23 +122,15 @@ public class TestMinMaxByAggregation
                 function,
                 1.0,
                 null,
-                createPage(
-                        new Double[] {null},
-                        new Double[] {null}),
-                createPage(
-                        new Double[] {null},
-                        new Double[] {null}));
+                createDoublesBlock(null, null),
+                createDoublesBlock(null, null));
 
         assertAggregation(
                 function,
                 1.0,
                 2.0,
-                createPage(
-                        new Double[] {3.0, 2.0},
-                        new Double[] {1.0, 1.5}),
-                createPage(
-                        new Double[] {null},
-                        new Double[] {null}));
+                createDoublesBlock(3.0, 2.0, null),
+                createDoublesBlock(1.0, 1.5, null));
     }
 
     @Test
@@ -160,23 +141,15 @@ public class TestMinMaxByAggregation
                 function,
                 1.0,
                 "z",
-                createPage(
-                        new String[] {"z", "a"},
-                        new Double[] {1.0, 2.0}),
-                createPage(
-                        new String[] {"x", "b"},
-                        new Double[] {2.0, 3.0}));
+                createStringsBlock("z", "a", "x", "b"),
+                createDoublesBlock(1.0, 2.0, 2.0, 3.0));
 
         assertAggregation(
                 function,
                 1.0,
                 "a",
-                createPage(
-                        new String[] {"zz", "hi"},
-                        new Double[] {0.0, 1.0}),
-                createPage(
-                        new String[] {"bb", "a"},
-                        new Double[] {2.0, -1.0}));
+                createStringsBlock("zz", "hi", "bb", "a"),
+                createDoublesBlock(0.0, 1.0, 2.0, -1.0));
     }
 
     @Test
@@ -187,23 +160,15 @@ public class TestMinMaxByAggregation
                 function,
                 1.0,
                 "a",
-                createPage(
-                        new String[] {"z", "a"},
-                        new Double[] {1.0, 2.0}),
-                createPage(
-                        new String[] {null},
-                        new Double[] {null}));
+                createStringsBlock("z", "a", null),
+                createDoublesBlock(1.0, 2.0, null));
 
         assertAggregation(
                 function,
                 1.0,
                 "hi",
-                createPage(
-                        new String[] {"zz", "hi"},
-                        new Double[] {0.0, 1.0}),
-                createPage(
-                        new String[] {null, "a"},
-                        new Double[] {null, -1.0}));
+                createStringsBlock("zz", "hi", null, "a"),
+                createDoublesBlock(0.0, 1.0, null, -1.0));
     }
 
     @Test
@@ -236,16 +201,6 @@ public class TestMinMaxByAggregation
         result.setKey(createStringsBlock(key));
         result.setValue(createDoublesBlock(value));
         return result;
-    }
-
-    private static Page createPage(Double[] values, Double[] keys)
-    {
-        return new Page(createDoublesBlock(values), createDoublesBlock(keys));
-    }
-
-    private static Page createPage(String[] values, Double[] keys)
-    {
-        return new Page(createStringsBlock(values), createDoublesBlock(keys));
     }
 
     private static class CustomDoubleType

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMultimapAggAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMultimapAggAggregation.java
@@ -133,6 +133,6 @@ public class TestMultimapAggAggregation
             builder.row(expectedKeys.get(i), expectedValues.get(i));
         }
 
-        assertAggregation(aggFunc, 1.0, map.isEmpty() ? null : map, builder.build());
+        assertAggregation(aggFunc, 1.0, map.isEmpty() ? null : map, builder.build().getBlocks());
     }
 }


### PR DESCRIPTION
There were 2 assertAggregation functions. One of them can do automatic splitting up to exercise and verify the correctness of combine functions. The other can't. This commit removes all external calls to the latter.