### PR TITLE
Added ability to query for array of percentiles

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -137,19 +137,34 @@ Approximate Aggregate Functions
     for any specific input set. The current implementation of this function
     requires that ``e`` be in the range: [0.01150, 0.26000].
 
-.. function:: approx_percentile(x, p) -> [same as input]
+.. function:: approx_percentile(x, percentage) -> [same as x]
 
     Returns the approximate percentile for all input values of ``x`` at the
-    percentage ``p``. The value of ``p`` must be between zero and one and
-    must be constant for all input rows.
+    given ''percentage''. The value of ``percentage`` must be between zero and
+    one and must be constant for all input rows.
 
-.. function:: approx_percentile(x, w, p) -> [same as input]
+.. function:: approx_percentile(x, percentages) -> array<[same as x]>
+
+    Returns the approximate percentile for all input values of ``x`` at each of
+    the percentages specified in the array. Each element of the array must be 
+    between zero and one, and the array must be constant for all input rows.
+
+.. function:: approx_percentile(x, w, percentage) -> [same as x]
 
     Returns the approximate weighed percentile for all input values of ``x``
     using the per-item weight ``w`` at the percentage ``p``. The weight must be
     an integer value of at least one. It is effectively a replication count for
     the value ``x`` in the percentile set. The value of ``p`` must be between
     zero and one and must be constant for all input rows.
+
+.. function:: approx_percentile(x, w, percentages) -> array<[same as x]>
+
+    Returns the approximate weighed percentile for all input values of ``x``
+    using the per-item weight ``w`` at each of the given percentages specified
+    in the array. The weight must be an integer value of at least one. It is
+    effectively a replication count for the value ``x`` in the percentile set.
+    Each element of the array must be between zero and one, and the array must
+    be constant for all input rows.
 
 .. function:: numeric_histogram(buckets, value, weight) -> map<double, double>
 

--- a/presto-docs/src/main/sphinx/release/release-0.124.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.124.rst
@@ -1,0 +1,8 @@
+=============
+Release 0.123
+=============
+
+General Changes
+---------------
+
+* The :func:`approx_percentile` aggregation now also accepts an array of percentages

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -20,6 +20,7 @@ import com.facebook.presto.operator.aggregation.ApproximateCountColumnAggregatio
 import com.facebook.presto.operator.aggregation.ApproximateCountDistinctAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateDoublePercentileAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateLongPercentileAggregations;
+import com.facebook.presto.operator.aggregation.ApproximateLongPercentileArrayAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateSetAggregation;
 import com.facebook.presto.operator.aggregation.ApproximateSumAggregations;
 import com.facebook.presto.operator.aggregation.AverageAggregations;
@@ -265,6 +266,7 @@ public class FunctionRegistry
                 .aggregate(CountAggregation.class)
                 .aggregate(VarianceAggregation.class)
                 .aggregate(ApproximateLongPercentileAggregations.class)
+                .aggregate(ApproximateLongPercentileArrayAggregations.class)
                 .aggregate(ApproximateDoublePercentileAggregations.class)
                 .aggregate(CountIfAggregation.class)
                 .aggregate(BooleanAndAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileAggregations.java
@@ -21,6 +21,8 @@ import com.facebook.presto.type.SqlType;
 import com.google.common.collect.ImmutableList;
 import io.airlift.stats.QuantileDigest;
 
+import static com.facebook.presto.operator.aggregation.LongDoubleConverterUtil.doubleToSortableLong;
+import static com.facebook.presto.operator.aggregation.LongDoubleConverterUtil.sortableLongToDouble;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -64,27 +66,7 @@ public final class ApproximateDoublePercentileAggregations
         else {
             checkState(percentile != -1.0, "Percentile is missing");
             checkCondition(0 <= percentile && percentile <= 1, INVALID_FUNCTION_ARGUMENT, "Percentile must be between 0 and 1");
-            DOUBLE.writeDouble(out, longToDouble(digest.getQuantile(percentile)));
+            DOUBLE.writeDouble(out, sortableLongToDouble(digest.getQuantile(percentile)));
         }
-    }
-
-    private static double longToDouble(long value)
-    {
-        if (value < 0) {
-            value ^= 0x7fffffffffffffffL;
-        }
-
-        return Double.longBitsToDouble(value);
-    }
-
-    private static long doubleToSortableLong(double value)
-    {
-        long result = Double.doubleToRawLongBits(value);
-
-        if (result < 0) {
-            result ^= 0x7fffffffffffffffL;
-        }
-
-        return result;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.DigestAndPercentileArrayState;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.SqlType;
+import com.google.common.collect.ImmutableList;
+import io.airlift.stats.QuantileDigest;
+
+import java.util.List;
+
+import static com.facebook.presto.operator.aggregation.LongDoubleConverterUtil.doubleToSortableLong;
+import static com.facebook.presto.operator.aggregation.LongDoubleConverterUtil.sortableLongToDouble;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+
+@AggregationFunction("approx_percentile")
+public final class ApproximateDoublePercentileArrayAggregations
+{
+    public static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = new AggregationCompiler().generateAggregationFunction(ApproximateDoublePercentileArrayAggregations.class, new ArrayType(DOUBLE), ImmutableList.<Type>of(DOUBLE, new ArrayType(DOUBLE)));
+    public static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = new AggregationCompiler().generateAggregationFunction(ApproximateDoublePercentileArrayAggregations.class, new ArrayType(DOUBLE), ImmutableList.<Type>of(DOUBLE, BIGINT, new ArrayType(DOUBLE)));
+
+    private ApproximateDoublePercentileArrayAggregations() {}
+
+    @InputFunction
+    public static void input(DigestAndPercentileArrayState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType("array<double>") Block percentilesArrayBlock)
+    {
+        ApproximateLongPercentileArrayAggregations.input(state, doubleToSortableLong(value), percentilesArrayBlock);
+    }
+
+    @InputFunction
+    public static void weightedInput(DigestAndPercentileArrayState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType("array<double>") Block percentilesArrayBlock)
+    {
+        ApproximateLongPercentileArrayAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentilesArrayBlock);
+    }
+
+    @CombineFunction
+    public static void combine(DigestAndPercentileArrayState state, DigestAndPercentileArrayState otherState)
+    {
+        ApproximateLongPercentileArrayAggregations.combine(state, otherState);
+    }
+
+    @OutputFunction("array<double>")
+    public static void output(DigestAndPercentileArrayState state, BlockBuilder out)
+    {
+        QuantileDigest digest = state.getDigest();
+        List<Double> percentiles = state.getPercentiles();
+
+        if (percentiles == null || digest == null) {
+            out.appendNull();
+            return;
+        }
+
+        BlockBuilder blockBuilder = out.beginBlockEntry();
+
+        for (int i = 0; i < percentiles.size(); i++) {
+            Double percentile = percentiles.get(i);
+            DOUBLE.writeDouble(blockBuilder, sortableLongToDouble(digest.getQuantile(percentile)));
+        }
+
+        out.closeEntry();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileArrayAggregations.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.DigestAndPercentileArrayState;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.type.ArrayType;
+import com.facebook.presto.type.SqlType;
+import com.google.common.collect.ImmutableList;
+import io.airlift.stats.QuantileDigest;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.util.Failures.checkCondition;
+
+@AggregationFunction("approx_percentile")
+public final class ApproximateLongPercentileArrayAggregations
+{
+    public static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = new AggregationCompiler().generateAggregationFunction(ApproximateLongPercentileArrayAggregations.class, new ArrayType(BIGINT), ImmutableList.<Type>of(BIGINT, new ArrayType(DOUBLE)));
+    public static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = new AggregationCompiler().generateAggregationFunction(ApproximateLongPercentileArrayAggregations.class, new ArrayType(BIGINT), ImmutableList.<Type>of(BIGINT, BIGINT, new ArrayType(DOUBLE)));
+
+    private ApproximateLongPercentileArrayAggregations() {}
+
+    @InputFunction
+    public static void input(DigestAndPercentileArrayState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType("array<double>") Block percentilesArrayBlock)
+    {
+        initializePercentilesArray(state, percentilesArrayBlock);
+        initializeDigest(state);
+
+        QuantileDigest digest = state.getDigest();
+        state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
+        digest.add(value);
+        state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+    }
+
+    @InputFunction
+    public static void weightedInput(DigestAndPercentileArrayState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType("array<double>") Block percentilesArrayBlock)
+    {
+        initializePercentilesArray(state, percentilesArrayBlock);
+        initializeDigest(state);
+
+        QuantileDigest digest = state.getDigest();
+        state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
+        digest.add(value, weight);
+        state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+    }
+
+    @CombineFunction
+    public static void combine(DigestAndPercentileArrayState state, DigestAndPercentileArrayState otherState)
+    {
+        QuantileDigest otherDigest = otherState.getDigest();
+        QuantileDigest digest = state.getDigest();
+
+        if (digest == null) {
+            state.setDigest(otherDigest);
+            state.addMemoryUsage(otherDigest.estimatedInMemorySizeInBytes());
+        }
+        else {
+            state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
+            digest.merge(otherDigest);
+            state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+        }
+
+        state.setPercentiles(otherState.getPercentiles());
+    }
+
+    @OutputFunction("array<bigint>")
+    public static void output(DigestAndPercentileArrayState state, BlockBuilder out)
+    {
+        QuantileDigest digest = state.getDigest();
+        List<Double> percentiles = state.getPercentiles();
+
+        if (percentiles == null || digest == null) {
+            out.appendNull();
+            return;
+        }
+
+        BlockBuilder blockBuilder = out.beginBlockEntry();
+
+        for (int i = 0; i < percentiles.size(); i++) {
+            Double percentile = percentiles.get(i);
+            BIGINT.writeLong(blockBuilder, digest.getQuantile(percentile));
+        }
+
+        out.closeEntry();
+    }
+
+    private static void initializePercentilesArray(DigestAndPercentileArrayState state, Block percentilesArrayBlock)
+    {
+        if (state.getPercentiles() == null) {
+            ImmutableList.Builder<Double> percentilesListBuilder = ImmutableList.builder();
+
+            for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
+                checkCondition(!percentilesArrayBlock.isNull(i), INVALID_FUNCTION_ARGUMENT, "Percentile cannot be null");
+                double percentile = DOUBLE.getDouble(percentilesArrayBlock, i);
+                checkCondition(0 <= percentile && percentile <= 1, INVALID_FUNCTION_ARGUMENT, "Percentile must be between 0 and 1");
+                percentilesListBuilder.add(percentile);
+            }
+
+            state.setPercentiles(percentilesListBuilder.build());
+        }
+    }
+
+    private static void initializeDigest(DigestAndPercentileArrayState state)
+    {
+        QuantileDigest digest = state.getDigest();
+        if (digest == null) {
+            digest = new QuantileDigest(0.01);
+            state.setDigest(digest);
+            state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/LongDoubleConverterUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/LongDoubleConverterUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+final class LongDoubleConverterUtil
+{
+    private LongDoubleConverterUtil() {}
+
+    /**
+     * Converts a double value to a sortable long. The value is converted by getting their IEEE 754
+     * floating-point bit layout. Some bits are swapped to be able to compare the result as long.
+     */
+    public static double sortableLongToDouble(long value)
+    {
+        value = value ^ (value >> 63) & Long.MAX_VALUE;
+        return Double.longBitsToDouble(value);
+    }
+
+    /**
+     * Converts a sortable long to double.
+     *
+     * @see #sortableLongToDouble(long)
+     */
+    public static long doubleToSortableLong(double value)
+    {
+        long bits = Double.doubleToRawLongBits(value);
+        return bits ^ (bits >> 63) & Long.MAX_VALUE;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayState.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import io.airlift.stats.QuantileDigest;
+
+import java.util.List;
+
+@AccumulatorStateMetadata(stateSerializerClass = DigestAndPercentileArrayStateSerializer.class, stateFactoryClass = DigestAndPercentileArrayStateFactory.class)
+public interface DigestAndPercentileArrayState
+        extends AccumulatorState
+{
+    QuantileDigest getDigest();
+
+    void setDigest(QuantileDigest digest);
+
+    void setPercentiles(List<Double> percentiles);
+
+    List<Double> getPercentiles();
+
+    void addMemoryUsage(int value);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayStateFactory.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.util.array.ObjectBigArray;
+import io.airlift.stats.QuantileDigest;
+
+import java.util.List;
+
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+import static java.util.Objects.requireNonNull;
+
+public class DigestAndPercentileArrayStateFactory
+        implements AccumulatorStateFactory<DigestAndPercentileArrayState>
+{
+    @Override
+    public DigestAndPercentileArrayState createSingleState()
+    {
+        return new SingleDigestAndPercentileArrayState();
+    }
+
+    @Override
+    public Class<? extends DigestAndPercentileArrayState> getSingleStateClass()
+    {
+        return SingleDigestAndPercentileArrayState.class;
+    }
+
+    @Override
+    public DigestAndPercentileArrayState createGroupedState()
+    {
+        return new GroupedDigestAndPercentileArrayState();
+    }
+
+    @Override
+    public Class<? extends DigestAndPercentileArrayState> getGroupedStateClass()
+    {
+        return GroupedDigestAndPercentileArrayState.class;
+    }
+
+    public static class GroupedDigestAndPercentileArrayState
+            extends AbstractGroupedAccumulatorState
+            implements DigestAndPercentileArrayState
+    {
+        private final ObjectBigArray<QuantileDigest> digests = new ObjectBigArray<>();
+        private final ObjectBigArray<List<Double>> percentilesArray = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            digests.ensureCapacity(size);
+            percentilesArray.ensureCapacity(size);
+        }
+
+        @Override
+        public QuantileDigest getDigest()
+        {
+            return digests.get(getGroupId());
+        }
+
+        @Override
+        public void setDigest(QuantileDigest digest)
+        {
+            digests.set(getGroupId(), requireNonNull(digest, "digest is null"));
+        }
+
+        @Override
+        public List<Double> getPercentiles()
+        {
+            return percentilesArray.get(getGroupId());
+        }
+
+        @Override
+        public void setPercentiles(List<Double> percentiles)
+        {
+            percentilesArray.set(getGroupId(), requireNonNull(percentiles, "percentiles is null"));
+        }
+
+        @Override
+        public void addMemoryUsage(int value)
+        {
+            size += value;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + digests.sizeOf() + percentilesArray.sizeOf();
+        }
+    }
+
+    public static class SingleDigestAndPercentileArrayState
+            implements DigestAndPercentileArrayState
+    {
+        private QuantileDigest digest;
+        private List<Double> percentiles;
+
+        @Override
+        public QuantileDigest getDigest()
+        {
+            return digest;
+        }
+
+        @Override
+        public void setDigest(QuantileDigest digest)
+        {
+            this.digest = requireNonNull(digest, "digest is null");
+        }
+
+        @Override
+        public List<Double> getPercentiles()
+        {
+            return percentiles;
+        }
+
+        @Override
+        public void setPercentiles(List<Double> percentiles)
+        {
+            this.percentiles = requireNonNull(percentiles, "percentiles is null");
+        }
+
+        @Override
+        public void addMemoryUsage(int value)
+        {
+            // noop
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            if (digest == null) {
+                return SIZE_OF_DOUBLE;
+            }
+            return digest.estimatedInMemorySizeInBytes() + SIZE_OF_DOUBLE;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayStateSerializer.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceInput;
+import io.airlift.stats.QuantileDigest;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+
+public class DigestAndPercentileArrayStateSerializer
+        implements AccumulatorStateSerializer<DigestAndPercentileArrayState>
+{
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(DigestAndPercentileArrayState state, BlockBuilder out)
+    {
+        if (state.getDigest() == null) {
+            out.appendNull();
+        }
+        else {
+            DynamicSliceOutput sliceOutput =
+                    new DynamicSliceOutput(state.getDigest().estimatedSerializedSizeInBytes() + (state.getPercentiles().size() * SIZE_OF_DOUBLE) +  SIZE_OF_LONG);
+            // write digest
+            state.getDigest().serialize(sliceOutput);
+            // write percentiles
+            List<Double> percentiles = state.getPercentiles();
+            sliceOutput.appendLong(percentiles.size());
+            for (Double percentile : percentiles) {
+                sliceOutput.appendDouble(percentile);
+            }
+
+            VARBINARY.writeSlice(out, sliceOutput.slice());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, DigestAndPercentileArrayState state)
+    {
+        if (!block.isNull(index)) {
+            SliceInput input = VARBINARY.getSlice(block, index).getInput();
+
+            // read digest
+            state.setDigest(QuantileDigest.deserialize(input));
+            state.addMemoryUsage(state.getDigest().estimatedInMemorySizeInBytes());
+
+            // read number of percentiles
+            long numPercentiles = input.readLong();
+
+            ImmutableList.Builder<Double> percentilesListBuilder = ImmutableList.builder();
+            for (int i = 0; i < numPercentiles; i++) {
+                percentilesListBuilder.add(input.readDouble());
+            }
+            state.setPercentiles(percentilesListBuilder.build());
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
@@ -13,26 +13,28 @@
  */
 package com.facebook.presto.operator.aggregation;
 
-import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.testing.RunLengthEncodedBlock;
+import com.facebook.presto.type.ArrayType;
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
 import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
-import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
 import static com.facebook.presto.operator.aggregation.ApproximateDoublePercentileAggregations.DOUBLE_APPROXIMATE_PERCENTILE_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.ApproximateDoublePercentileAggregations.DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.ApproximateDoublePercentileArrayAggregations.DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.ApproximateDoublePercentileArrayAggregations.DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.ApproximateLongPercentileAggregations.LONG_APPROXIMATE_PERCENTILE_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.ApproximateLongPercentileAggregations.LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION;
-import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.operator.aggregation.ApproximateLongPercentileArrayAggregations.LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.ApproximateLongPercentileArrayAggregations.LONG_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 
 public class TestApproximatePercentileAggregation
 {
-    private static final Block EMPTY_DOUBLE_BLOCK = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), 0).build();
-    private static final Block EMPTY_LONG_BLOCK = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 0).build();
-
     @Test
     public void testLongPartialStep()
             throws Exception
@@ -71,6 +73,48 @@ public class TestApproximatePercentileAggregation
                 3L,
                 createLongsBlock(1L, null, 2L, 2L, null, 2L, 2L, null, 2L, 2L, null, 3L, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
                 createRLEBlock(0.5, 21));
+
+        // array of approx_percentile
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                null,
+                createLongsBlock(null, null),
+                createRLEBlock(ImmutableList.of(0.5),  2));
+
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                null,
+                createLongsBlock(null, null),
+                createRLEBlock(ImmutableList.of(0.5, 0.99),  2));
+
+        assertAggregation(LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1L, 1L),
+                createLongsBlock(null, 1L),
+                createRLEBlock(ImmutableList.of(0.5, 0.5),  2));
+
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1L, 2L, 3L),
+                createLongsBlock(null, 1L, 2L, 3L),
+                createRLEBlock(ImmutableList.of(0.2, 0.5, 0.8),  4));
+
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(2L, 3L),
+                createLongsBlock(1L, 2L, 3L),
+                createRLEBlock(ImmutableList.of(0.5, 0.99),  3));
+
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1L, 3L),
+                createLongsBlock(1L, null, 2L, 2L, null, 2L, 2L, null, 2L, 2L, null, 3L, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
+                createRLEBlock(ImmutableList.of(0.01, 0.5),  21));
 
         // weighted approx_percentile
         assertAggregation(
@@ -112,6 +156,15 @@ public class TestApproximatePercentileAggregation
                 createLongsBlock(1L, null, 2L, null, 2L, null, 2L, null, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
                 createLongsBlock(1L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L),
                 createRLEBlock(0.5, 17));
+
+        // weighted + array of approx_percentile
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION,
+                1.0,
+                ImmutableList.of(1L, 2L),
+                createLongsBlock(1L, 2L, 3L),
+                createLongsBlock(4L, 2L, 1L),
+                createRLEBlock(ImmutableList.of(0.5, 0.8),  3));
     }
 
     @Test
@@ -154,6 +207,49 @@ public class TestApproximatePercentileAggregation
                 createDoublesBlock(1.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 3.0, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
                 createRLEBlock(0.5, 21));
 
+        // array of approx_percentile
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                null,
+                createDoublesBlock(null, null),
+                createRLEBlock(ImmutableList.of(0.5),  2));
+
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                null,
+                createDoublesBlock(null, null),
+                createRLEBlock(ImmutableList.of(0.5, 0.5),  2));
+
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1.0, 1.0),
+                createDoublesBlock(null, 1.0),
+                createRLEBlock(ImmutableList.of(0.5, 0.5),  2));
+
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1.0, 2.0, 3.0),
+                createDoublesBlock(null, 1.0, 2.0, 3.0),
+                createRLEBlock(ImmutableList.of(0.2, 0.5, 0.8),  4));
+
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(2.0, 3.0),
+                createDoublesBlock(1.0, 2.0, 3.0),
+                createRLEBlock(ImmutableList.of(0.5, 0.99),  3));
+
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+                1.0,
+                ImmutableList.of(1.0, 3.0),
+                createDoublesBlock(1.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 3.0, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
+                createRLEBlock(ImmutableList.of(0.01, 0.5),  21));
+
         // weighted approx_percentile
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
@@ -194,5 +290,35 @@ public class TestApproximatePercentileAggregation
                 createDoublesBlock(1.0, null, 2.0, null, 2.0, null, 2.0, null, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
                 createLongsBlock(1L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L),
                 createRLEBlock(0.5, 17));
+
+        // weighted + array of approx_percentile
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION,
+                1.0,
+                ImmutableList.of(1.0, 2.0),
+                createDoublesBlock(1.0, 2.0, 3.0),
+                createLongsBlock(4L, 2L, 1L),
+                createRLEBlock(ImmutableList.of(0.5, 0.8),  3));
+    }
+
+    private static RunLengthEncodedBlock createRLEBlock(double percentile, int positionCount)
+    {
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), 1);
+        DOUBLE.writeDouble(blockBuilder, percentile);
+        return new RunLengthEncodedBlock(blockBuilder.build(), positionCount);
+    }
+
+    private static RunLengthEncodedBlock createRLEBlock(Iterable<Double> percentiles, int positionCount)
+    {
+        BlockBuilder rleBlockBuilder = new ArrayType(DOUBLE).createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder arrayBlockBuilder = rleBlockBuilder.beginBlockEntry();
+
+        for (double percentile : percentiles) {
+            DOUBLE.writeDouble(arrayBlockBuilder, percentile);
+        }
+
+        rleBlockBuilder.closeEntry();
+
+        return new RunLengthEncodedBlock(rleBlockBuilder.build(), positionCount);
     }
 }


### PR DESCRIPTION
Adds functionality described in #2452 (Create approx_percentile function that returns multiple percentiles). Still need to add in alternative forms of query, but this PR was already 600+ lines, so figured I'd get some feedback first. This will also require documentation changes.