### PR TITLE
Update to Resolver 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
             <dependency>
                 <groupId>io.airlift.resolver</groupId>
                 <artifactId>resolver</artifactId>
-                <version>1.1</version>
+                <version>1.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This fixes incorrect dependencies being resolved when loading
plugins directly from POMs in development mode.