### PR TITLE
Fix race condition in query queues

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueuedExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueuedExecution.java
@@ -70,9 +70,7 @@ public class QueuedExecution
             });
         }
         else {
-            if (!nextQueues.get(0).enqueue(new QueuedExecution(queryExecution, nextQueues.subList(1, nextQueues.size()), executor, stats, listenableFuture))) {
-                queryExecution.fail(new IllegalStateException("Entering secondary queue failed"));
-            }
+            nextQueues.get(0).enqueue(new QueuedExecution(queryExecution, nextQueues.subList(1, nextQueues.size()), executor, stats, listenableFuture));
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryQueueManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryQueueManager.java
@@ -162,7 +162,8 @@ public class SqlQueryQueueManager
             }
         }
 
-        return queues.get(0).enqueue(createQueuedExecution(queryExecution, queues.subList(1, queues.size()), executor, stats));
+        queues.get(0).enqueue(createQueuedExecution(queryExecution, queues.subList(1, queues.size()), executor, stats));
+        return true;
     }
 
     // Queues returned have already been created and added queryQueues


### PR DESCRIPTION
Lets consider an example from #3637:
 "user.${USER}": {
 "maxConcurrent": 2,
 "maxQueued": 2
 },
 "dashboard.${USER}": {
 "maxConcurrent": 1,
 "maxQueued": 1
 },
When two queries are scheduled at the same time, both of them get permit
and most likely both of them will try to get enqueued.
This situation lead to an error that one of them was not able
to enqueue - "Entering secondary queue failed".
In order to solve that, I removed the check of the of size of queued queries.
It is not needed as it is already covered by checking the permits in reserve method.
Once query got permit it is assumed that it can be enqueued. As a side effect query queue can
for the moment hold more queries in state QUEUED than it is set in configuration.

Task: #3637

Test Plan: Running unit tests