### PR TITLE
Fix ArrayType.equalTo to work with comparable non-orderable types

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/ArrayType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/ArrayType.java
@@ -65,7 +65,22 @@ public class ArrayType
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        return compareTo(leftBlock, leftPosition, rightBlock, rightPosition) == 0;
+        Block leftArray = leftBlock.getObject(leftPosition, Block.class);
+        Block rightArray = rightBlock.getObject(rightPosition, Block.class);
+
+        if (leftArray.getPositionCount() != rightArray.getPositionCount()) {
+            return false;
+        }
+
+        for (int i = 0; i < leftArray.getPositionCount(); i++) {
+            checkElementNotNull(leftArray.isNull(i), ARRAY_NULL_ELEMENT_MSG);
+            checkElementNotNull(rightArray.isNull(i), ARRAY_NULL_ELEMENT_MSG);
+            if (!elementType.equalTo(leftArray, i, rightArray, i)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     @Override
@@ -83,6 +98,10 @@ public class ArrayType
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
+        if (!elementType.isOrderable()) {
+            throw new UnsupportedOperationException(getTypeSignature() + " type is not orderable");
+        }
+
         Block leftArray = leftBlock.getObject(leftPosition, Block.class);
         Block rightArray = rightBlock.getObject(rightPosition, Block.class);
 

--- a/presto-main/src/test/java/com/facebook/presto/type/TestColorArrayType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestColorArrayType.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.List;
+
+import static com.facebook.presto.type.ColorType.COLOR;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.StructuralTestUtil.arrayBlockOf;
+
+public class TestColorArrayType
+        extends AbstractTestType
+{
+    public TestColorArrayType()
+    {
+        super(new TypeRegistry().getType(parseTypeSignature("array<color>")), List.class, createTestBlock(new TypeRegistry().getType(parseTypeSignature("array<color>"))));
+    }
+
+    public static Block createTestBlock(Type arrayType)
+    {
+        BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), 4);
+        arrayType.writeObject(blockBuilder, arrayBlockOf(COLOR, 1, 2));
+        arrayType.writeObject(blockBuilder, arrayBlockOf(COLOR, 1, 2, 3));
+        arrayType.writeObject(blockBuilder, arrayBlockOf(COLOR, 1, 2, 3));
+        arrayType.writeObject(blockBuilder, arrayBlockOf(COLOR, 100, 200, 300));
+        return blockBuilder.build();
+    }
+
+    @Override
+    protected Object getGreaterValue(Object value)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractType.java
@@ -84,7 +84,7 @@ public abstract class AbstractType
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        throw new UnsupportedOperationException(getTypeSignature() + " type is not ordered");
+        throw new UnsupportedOperationException(getTypeSignature() + " type is not orderable");
     }
 
     @Override


### PR DESCRIPTION
Attempt to fix #3542. Still having some trouble passing the new test, because it's not clear how comparable non-orderable types should be handled at lower layers.