### PR TITLE
Fix DayOfWeek function documentation

### DIFF
--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -187,7 +187,7 @@ Specifier Description
 ``%V``    Week (``01`` .. ``53``), where Sunday is the first day of the week; used with ``%X``
 ``%v``    Week (``01`` .. ``53``), where Monday is the first day of the week; used with ``%x``
 ``%W``    Weekday name (``Sunday`` .. ``Saturday``)
-``%w``    Day of the week (``0`` .. ``6``), where Sunday is the first day of the week
+``%w``    Day of the week (``1`` .. ``7``), where Monday is the first day of the week
 ``%X``    Year for the week where Sunday is the first day of the week, numeric, four digits; used with ``%V``
 ``%x``    Year for the week, where Monday is the first day of the week, numeric, four digits; used with ``%v``
 ``%Y``    Year, numeric, four digits


### PR DESCRIPTION
Joda is using ISO standard, the first day of the week is Monday:
http://joda-time.sourceforge.net/apidocs/org/joda/time/DateTimeConstants.html#SUNDAY
http://joda-time.sourceforge.net/apidocs/org/joda/time/DateTimeConstants.html#MONDAY

Presto is working as:
```
presto:default> select date_format(date_parse('20150920', '%Y%m%d'),'%W');
 _col0
--------
 Sunday
(1 row)

presto:default> select date_format(date_parse('20150920', '%Y%m%d'),'%w');
 _col0
-------
 7
(1 row)
```
Presto's datetime function documentation needs to be fixed.
