### PR TITLE
Fix race condition in HttpPageBufferClient

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
@@ -314,8 +314,8 @@ public final class HttpPageBufferClient
                     lastUpdate = DateTime.now();
 
                 }
-                clientCallback.requestComplete(HttpPageBufferClient.this);
                 requestsCompleted.incrementAndGet();
+                clientCallback.requestComplete(HttpPageBufferClient.this);
             }
 
             @Override
@@ -351,8 +351,8 @@ public final class HttpPageBufferClient
                     future = null;
                     lastUpdate = DateTime.now();
                 }
-                clientCallback.clientFinished(HttpPageBufferClient.this);
                 requestsCompleted.incrementAndGet();
+                clientCallback.clientFinished(HttpPageBufferClient.this);
             }
 
             @Override


### PR DESCRIPTION
* TestHttpPageBufferClient#testHappyPath was failing intermittently,
because the client's requestsCompleted flag was not up-to-date
when the client callback informed the client that the operation
was complete