### PR TITLE
blackhole: remove synchronization of tables in BlackHoleMetadata

### DIFF
--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
@@ -128,10 +128,8 @@ public class BlackHoleMetadata
                 newTableName.getTableName(),
                 oldTableHandle.getColumnHandles()
         );
-        synchronized (tables) {
-            tables.remove(oldTableHandle.getTableName());
-            tables.put(newTableName.getTableName(), newTableHandle);
-        }
+        tables.remove(oldTableHandle.getTableName());
+        tables.put(newTableName.getTableName(), newTableHandle);
     }
 
     @Override


### PR DESCRIPTION
blackhole: remove synchronization of tables in BlackHoleMetadata

Synchronization (atomic remove and put into concurrent hash map of
tables) is not needed, it does not guarantee that concurrent operations
on metadata can be run safely (e.g. rename table with drop table).

Simple approach of fixing that would be to try implement transaction-like
metadata storage with using ConnectorSession.getStartTime() as transaction id (txid)
Then session with higher txid would need to wait for all
operations with lower txid to finish.

Ticket: #3647

Test Plan: none
