### PR TITLE
Support for CTAS with no data

### DIFF
--- a/presto-docs/src/main/sphinx/sql/create-table-as.rst
+++ b/presto-docs/src/main/sphinx/sql/create-table-as.rst
@@ -10,6 +10,7 @@ Synopsis
     CREATE TABLE table_name
     [ WITH ( property_name = expression [, ...] ) ]
     AS query
+    [ WITH [ NO ] DATA ]
 
 Description
 -----------
@@ -34,3 +35,10 @@ Create a new table ``orders_by_date`` that summarizes ``orders``::
     SELECT orderdate, sum(totalprice) AS price
     FROM orders
     GROUP BY orderdate
+
+Create a new ``empty_nation`` table with the same schema as ``nation`` and no data::
+
+    CREATE TABLE empty_nation AS
+    SELECT * 
+    FROM nation 
+    WITH NO DATA

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -84,6 +84,7 @@ public class Analysis
     // for create table
     private Optional<QualifiedTableName> createTableDestination = Optional.empty();
     private Map<String, Expression> createTableProperties = ImmutableMap.of();
+    private boolean createTableAsSelectWithData = true;
 
     // for insert
     private Optional<TableHandle> insertTarget = Optional.empty();
@@ -109,6 +110,16 @@ public class Analysis
     public void setUpdateType(String updateType)
     {
         this.updateType = updateType;
+    }
+
+    public boolean isCreateTableAsSelectWithData()
+    {
+        return createTableAsSelectWithData;
+    }
+
+    public void setCreateTableAsSelectWithData(boolean createTableAsSelectWithData)
+    {
+        this.createTableAsSelectWithData = createTableAsSelectWithData;
     }
 
     public void addResolvedNames(Expression expression, Map<QualifiedName, Integer> mappings)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -500,6 +500,8 @@ class StatementAnalyzer
         }
         accessControl.checkCanCreateTable(session.getIdentity(), targetTable);
 
+        analysis.setCreateTableAsSelectWithData(node.getWithData());
+
         // analyze the query that creates the table
         TupleDescriptor descriptor = process(node.getQuery(), context);
 

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -30,7 +30,9 @@ statement
     : query                                                            #statementDefault
     | USE schema=identifier                                            #use
     | USE catalog=identifier '.' schema=identifier                     #use
-    | CREATE TABLE qualifiedName (WITH tableProperties)? AS query      #createTableAsSelect
+    | CREATE TABLE qualifiedName
+        (WITH tableProperties)? AS query
+        (WITH (NO)? DATA)?                                             #createTableAsSelect
     | CREATE TABLE (IF NOT EXISTS)? qualifiedName
         '(' tableElement (',' tableElement)* ')'
         (WITH tableProperties)?                                        #createTable
@@ -349,6 +351,7 @@ nonReserved
     | IF | NULLIF | COALESCE
     | normalForm
     | POSITION
+    | NO | DATA
     ;
 
 normalForm
@@ -376,6 +379,7 @@ OR: 'OR';
 AND: 'AND';
 IN: 'IN';
 NOT: 'NOT';
+NO: 'NO';
 EXISTS: 'EXISTS';
 BETWEEN: 'BETWEEN';
 LIKE: 'LIKE';
@@ -483,6 +487,7 @@ MAP: 'MAP';
 SET: 'SET';
 RESET: 'RESET';
 SESSION: 'SESSION';
+DATA: 'DATA';
 
 NORMALIZE: 'NORMALIZE';
 NFD : 'NFD';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -151,7 +151,7 @@ class AstBuilder
     @Override
     public Node visitCreateTableAsSelect(SqlBaseParser.CreateTableAsSelectContext context)
     {
-        return new CreateTableAsSelect(getQualifiedName(context.qualifiedName()), (Query) visit(context.query()), processTableProperties(context.tableProperties()));
+        return new CreateTableAsSelect(getQualifiedName(context.qualifiedName()), (Query) visit(context.query()), processTableProperties(context.tableProperties()), context.NO() == null);
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTableAsSelect.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTableAsSelect.java
@@ -27,12 +27,14 @@ public class CreateTableAsSelect
     private final QualifiedName name;
     private final Query query;
     private final Map<String, Expression> properties;
+    private final boolean withData;
 
-    public CreateTableAsSelect(QualifiedName name, Query query, Map<String, Expression> properties)
+    public CreateTableAsSelect(QualifiedName name, Query query, Map<String, Expression> properties, boolean withData)
     {
         this.name = requireNonNull(name, "name is null");
         this.query = requireNonNull(query, "query is null");
         this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
+        this.withData = withData;
     }
 
     public QualifiedName getName()
@@ -48,6 +50,11 @@ public class CreateTableAsSelect
     public Map<String, Expression> getProperties()
     {
         return properties;
+    }
+
+    public boolean getWithData()
+    {
+        return withData;
     }
 
     @Override
@@ -84,6 +91,7 @@ public class CreateTableAsSelect
                 .add("name", name)
                 .add("query", query)
                 .add("properties", properties)
+                .add("withData", withData)
                 .toString();
     }
 }


### PR DESCRIPTION
Support for CTAS with no data

Add support for queries like:
`CREATE TABLE T AS SELECT ... WITH NO DATA`

This code is based on #3213

Task: #3145

Test Plan: running tests
