### PR TITLE
Optimize ORC reading when file contains many tiny stripes

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
@@ -149,7 +149,7 @@ public class OrcPageSourceFactory
         OrcPredicate predicate = new TupleDomainOrcPredicate<>(effectivePredicate, columnReferences.build());
 
         try {
-            OrcReader reader = new OrcReader(orcDataSource, metadataReader);
+            OrcReader reader = new OrcReader(orcDataSource, metadataReader, maxMergeDistance, maxBufferSize);
             OrcRecordReader recordReader = reader.createRecordReader(
                     includedColumns.build(),
                     predicate,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/CachingOrcDataSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/CachingOrcDataSource.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Ints;
+import io.airlift.slice.FixedLengthSliceInput;
+import io.airlift.slice.Slices;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class CachingOrcDataSource
+        implements OrcDataSource
+{
+    private final OrcDataSource dataSource;
+    private final RegionFinder regionFinder;
+
+    private long cachePosition;
+    private int cacheLength;
+    private byte[] cache;
+
+    public CachingOrcDataSource(OrcDataSource dataSource, RegionFinder regionFinder)
+    {
+        this.dataSource = requireNonNull(dataSource, "dataSource is null");
+        this.regionFinder = requireNonNull(regionFinder, "regionFinder is null");
+        this.cache = new byte[0];
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return dataSource.getReadTimeNanos();
+    }
+
+    @Override
+    public long getSize()
+    {
+        return dataSource.getSize();
+    }
+
+    @VisibleForTesting
+    void readCacheAt(long offset)
+            throws IOException
+    {
+        DiskRange newCacheRange = regionFinder.getRangeFor(offset);
+        cachePosition = newCacheRange.getOffset();
+        cacheLength = newCacheRange.getLength();
+        if (cache.length < cacheLength) {
+            cache = new byte[cacheLength];
+        }
+        dataSource.readFully(newCacheRange.getOffset(), cache, 0, cacheLength);
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer)
+            throws IOException
+    {
+        readFully(position, buffer, 0, buffer.length);
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer, int bufferOffset, int length)
+            throws IOException
+    {
+        if (position < cachePosition) {
+            throw new IllegalArgumentException(String.format("read request (offset %d length %d) is before cache (offset %d length %d)", position, length, cachePosition, cacheLength));
+        }
+        if (position >= cachePosition + cacheLength) {
+            readCacheAt(position);
+        }
+        if (position + length > cachePosition + cacheLength) {
+            throw new IllegalArgumentException(String.format("read request (offset %d length %d) partially overlaps cache (offset %d length %d)", position, length, cachePosition, cacheLength));
+        }
+        System.arraycopy(cache, Ints.checkedCast(position - cachePosition), buffer, bufferOffset, length);
+    }
+
+    @Override
+    public <K> Map<K, FixedLengthSliceInput> readFully(Map<K, DiskRange> diskRanges)
+            throws IOException
+    {
+        ImmutableMap.Builder<K, FixedLengthSliceInput> builder = ImmutableMap.builder();
+
+        // Assumption here: all disk ranges are in the same region. Therefore, serving them in arbitrary order
+        // will not result in eviction of cache that otherwise could have served any of the DiskRanges provided.
+        for (Map.Entry<K, DiskRange> entry : diskRanges.entrySet()) {
+            DiskRange diskRange = entry.getValue();
+            byte[] buffer = new byte[diskRange.getLength()];
+            readFully(diskRange.getOffset(), buffer);
+            builder.put(entry.getKey(), Slices.wrappedBuffer(buffer).getInput());
+        }
+        return builder.build();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        dataSource.close();
+    }
+
+    public interface RegionFinder
+    {
+        DiskRange getRangeFor(long desiredOffset);
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -25,6 +25,7 @@ import com.google.common.primitives.Ints;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
@@ -49,17 +50,21 @@ public class OrcReader
 
     private final OrcDataSource orcDataSource;
     private final MetadataReader metadataReader;
+    private final DataSize maxMergeDistance;
+    private final DataSize maxReadSize;
     private final CompressionKind compressionKind;
     private final int bufferSize;
     private final Footer footer;
     private final Metadata metadata;
 
     // This is based on the Apache Hive ORC code
-    public OrcReader(OrcDataSource orcDataSource, MetadataReader metadataReader)
+    public OrcReader(OrcDataSource orcDataSource, MetadataReader metadataReader, DataSize maxMergeDistance, DataSize maxReadSize)
             throws IOException
     {
         this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
         this.metadataReader = requireNonNull(metadataReader, "metadataReader is null");
+        this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
+        this.maxReadSize = requireNonNull(maxReadSize, "maxReadSize is null");
 
         //
         // Read the file tail:
@@ -185,7 +190,9 @@ public class OrcReader
                 bufferSize,
                 footer.getRowsInRowGroup(),
                 requireNonNull(hiveStorageTimeZone, "hiveStorageTimeZone is null"),
-                metadataReader);
+                metadataReader,
+                maxMergeDistance,
+                maxReadSize);
     }
 
     /**

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReader.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
+import io.airlift.units.DataSize;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
@@ -85,7 +86,9 @@ public class OrcRecordReader
             int bufferSize,
             int rowsInRowGroup,
             DateTimeZone hiveStorageTimeZone,
-            MetadataReader metadataReader)
+            MetadataReader metadataReader,
+            DataSize maxMergeDistance,
+            DataSize maxReadSize)
             throws IOException
     {
         requireNonNull(includedColumns, "includedColumns is null");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/StripeInformation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/StripeInformation.java
@@ -57,6 +57,11 @@ public class StripeInformation
         return footerLength;
     }
 
+    public long getTotalLength()
+    {
+        return indexLength + dataLength + footerLength;
+    }
+
     @Override
     public String toString()
     {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -393,7 +393,7 @@ public class OrcTester
         return orcReader.createRecordReader(ImmutableMap.of(0, type), predicate, HIVE_STORAGE_TIME_ZONE);
     }
 
-    private static DataSize writeOrcColumn(File outputFile, Format format, Compression compression, ObjectInspector columnObjectInspector, Iterator<?> values)
+    static DataSize writeOrcColumn(File outputFile, Format format, Compression compression, ObjectInspector columnObjectInspector, Iterator<?> values)
             throws Exception
     {
         RecordWriter recordWriter;
@@ -403,7 +403,12 @@ public class OrcTester
         else {
             recordWriter = createOrcRecordWriter(outputFile, format, compression, columnObjectInspector);
         }
+        return writeOrcColumn(outputFile, format, recordWriter, columnObjectInspector, values);
+    }
 
+    static DataSize writeOrcColumn(File outputFile, Format format, RecordWriter recordWriter, ObjectInspector columnObjectInspector, Iterator<?> values)
+            throws Exception
+    {
         SettableStructObjectInspector objectInspector = createSettableStructObjectInspector("test", columnObjectInspector);
         Object row = objectInspector.create();
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -385,7 +385,7 @@ public class OrcTester
             throws IOException
     {
         OrcDataSource orcDataSource = new FileOrcDataSource(tempFile.getFile(), new DataSize(1, Unit.MEGABYTE), new DataSize(1, Unit.MEGABYTE), new DataSize(1, Unit.MEGABYTE));
-        OrcReader orcReader = new OrcReader(orcDataSource, metadataReader);
+        OrcReader orcReader = new OrcReader(orcDataSource, metadataReader, new DataSize(1, Unit.MEGABYTE), new DataSize(1, Unit.MEGABYTE));
 
         assertEquals(orcReader.getColumnNames(), ImmutableList.of("test"));
         assertEquals(orcReader.getFooter().getRowsInRowGroup(), 10_000);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.OrcTester.Compression;
+import com.facebook.presto.orc.OrcTester.Format;
+import com.facebook.presto.orc.OrcTester.TempFile;
+import com.facebook.presto.orc.metadata.OrcMetadataReader;
+import com.facebook.presto.orc.metadata.StripeInformation;
+import com.facebook.presto.spi.block.Block;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.FixedLengthSliceInput;
+import io.airlift.units.DataSize;
+import io.airlift.units.DataSize.Unit;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
+import org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat;
+import org.apache.hadoop.hive.serde2.ReaderWriterProfiler;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.JobConf;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.orc.OrcRecordReader.LinearProbeRangeFinder.createTinyStripesRangeFinder;
+import static com.facebook.presto.orc.OrcRecordReader.wrapWithCacheIfTinyStripes;
+import static com.facebook.presto.orc.OrcTester.Compression.NONE;
+import static com.facebook.presto.orc.OrcTester.Compression.ZLIB;
+import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
+import static com.facebook.presto.orc.OrcTester.HIVE_STORAGE_TIME_ZONE;
+import static com.facebook.presto.orc.OrcTester.writeOrcColumn;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
+import static io.airlift.testing.Assertions.assertInstanceOf;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+public class TestCachingOrcDataSource
+{
+    private static final int POSITION_COUNT = 50000;
+
+    private TempFile tempFile;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        tempFile = new TempFile("presto_test_cods", "orc");
+        Random random = new Random();
+        Iterator<String> iterator = Stream.generate(() -> Long.toHexString(random.nextLong())).limit(POSITION_COUNT).iterator();
+        writeOrcColumn(tempFile.getFile(), ORC_12, createOrcRecordWriter(tempFile.getFile(), ORC_12, ZLIB, javaStringObjectInspector), javaStringObjectInspector, iterator);
+    }
+
+    @AfterClass
+    public void tearDown()
+            throws Exception
+    {
+        tempFile.close();
+    }
+
+    @Test
+    public void testWrapWithCacheIfTinyStripes()
+            throws IOException
+    {
+        DataSize maxMergeDistance = new DataSize(1, Unit.MEGABYTE);
+        DataSize maxReadSize = new DataSize(8, Unit.MEGABYTE);
+
+        OrcDataSource actual = wrapWithCacheIfTinyStripes(
+                FakeOrcDataSource.INSTANCE,
+                ImmutableList.of(new StripeInformation(123, 3, 10, 10, 10)),
+                maxMergeDistance,
+                maxReadSize);
+        assertInstanceOf(actual, CachingOrcDataSource.class);
+
+        actual = wrapWithCacheIfTinyStripes(
+                FakeOrcDataSource.INSTANCE,
+                ImmutableList.of(new StripeInformation(123, 3, 10, 10, 10), new StripeInformation(123, 33, 10, 10, 10), new StripeInformation(123, 63, 10, 10, 10)),
+                maxMergeDistance,
+                maxReadSize);
+        assertInstanceOf(actual, CachingOrcDataSource.class);
+
+        actual = wrapWithCacheIfTinyStripes(
+                FakeOrcDataSource.INSTANCE,
+                ImmutableList.of(new StripeInformation(123, 3, 10, 10, 10), new StripeInformation(123, 33, 10, 10, 10), new StripeInformation(123, 63, 1048576 * 8 - 20, 10, 10)),
+                maxMergeDistance,
+                maxReadSize);
+        assertInstanceOf(actual, CachingOrcDataSource.class);
+
+        actual = wrapWithCacheIfTinyStripes(
+                FakeOrcDataSource.INSTANCE,
+                ImmutableList.of(new StripeInformation(123, 3, 10, 10, 10), new StripeInformation(123, 33, 10, 10, 10), new StripeInformation(123, 63, 1048576 * 8 - 20 + 1, 10, 10)),
+                maxMergeDistance,
+                maxReadSize);
+        assertNotInstanceOf(actual, CachingOrcDataSource.class);
+    }
+
+    @Test
+    public void testTinyStripesReadCacheAt()
+            throws IOException
+    {
+        DataSize maxMergeDistance = new DataSize(1, Unit.MEGABYTE);
+        DataSize maxReadSize = new DataSize(8, Unit.MEGABYTE);
+
+        TestingOrcDataSource testingOrcDataSource = new TestingOrcDataSource(FakeOrcDataSource.INSTANCE);
+        CachingOrcDataSource cachingOrcDataSource = new CachingOrcDataSource(
+                testingOrcDataSource,
+                createTinyStripesRangeFinder(
+                        ImmutableList.of(new StripeInformation(123, 3, 10, 10, 10), new StripeInformation(123, 33, 10, 10, 10), new StripeInformation(123, 63, 1048576 * 8 - 20, 10, 10)),
+                        maxMergeDistance,
+                        maxReadSize));
+        cachingOrcDataSource.readCacheAt(3);
+        assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(3, 60)));
+        cachingOrcDataSource.readCacheAt(63);
+        assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(63, 8 * 1048576)));
+
+        testingOrcDataSource = new TestingOrcDataSource(FakeOrcDataSource.INSTANCE);
+        cachingOrcDataSource = new CachingOrcDataSource(
+                testingOrcDataSource,
+                createTinyStripesRangeFinder(
+                        ImmutableList.of(new StripeInformation(123, 3, 10, 10, 10), new StripeInformation(123, 33, 10, 10, 10), new StripeInformation(123, 63, 1048576 * 8 - 20, 10, 10)),
+                        maxMergeDistance,
+                        maxReadSize));
+        cachingOrcDataSource.readCacheAt(62); // read at the end of a stripe
+        assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(3, 60)));
+        cachingOrcDataSource.readCacheAt(63);
+        assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(63, 8 * 1048576)));
+
+        testingOrcDataSource = new TestingOrcDataSource(FakeOrcDataSource.INSTANCE);
+        cachingOrcDataSource = new CachingOrcDataSource(
+                testingOrcDataSource,
+                createTinyStripesRangeFinder(
+                        ImmutableList.of(new StripeInformation(123, 3, 1, 0, 0), new StripeInformation(123, 4, 1048576, 1048576, 1048576 * 3), new StripeInformation(123, 4 + 1048576 * 5, 1048576, 1048576, 1048576)),
+                        maxMergeDistance,
+                        maxReadSize));
+        cachingOrcDataSource.readCacheAt(3);
+        assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(3, 1 + 1048576 * 5)));
+        cachingOrcDataSource.readCacheAt(4 + 1048576 * 5);
+        assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(4 + 1048576 * 5, 3 * 1048576)));
+    }
+
+    @Test
+    public void testIntegration()
+            throws IOException
+    {
+        // tiny file
+        TestingOrcDataSource orcDataSource = new TestingOrcDataSource(
+                new FileOrcDataSource(tempFile.getFile(), new DataSize(1, Unit.MEGABYTE), new DataSize(1, Unit.MEGABYTE), new DataSize(1, Unit.MEGABYTE)));
+        doIntegration(orcDataSource, new DataSize(1, Unit.MEGABYTE), new DataSize(1, Unit.MEGABYTE));
+        assertEquals(orcDataSource.getReadCount(), 1); // read entire file at once
+
+        // tiny stripes
+        orcDataSource = new TestingOrcDataSource(
+                new FileOrcDataSource(tempFile.getFile(), new DataSize(1, Unit.MEGABYTE), new DataSize(1, Unit.MEGABYTE), new DataSize(1, Unit.MEGABYTE)));
+        doIntegration(orcDataSource, new DataSize(400, Unit.KILOBYTE), new DataSize(400, Unit.KILOBYTE));
+        assertEquals(orcDataSource.getReadCount(), 3); // footer, first few stripes, last few stripes
+    }
+
+    public void doIntegration(TestingOrcDataSource orcDataSource, DataSize maxMergeDistance, DataSize maxReadSize)
+            throws IOException
+    {
+        OrcReader orcReader = new OrcReader(orcDataSource, new OrcMetadataReader(), maxMergeDistance, maxReadSize);
+        // 1 for reading file footer
+        assertEquals(orcDataSource.getReadCount(), 1);
+        List<StripeInformation> stripes = orcReader.getFooter().getStripes();
+        // Sanity check number of stripes. This can be three or higher because of orc writer low memory mode.
+        assertGreaterThanOrEqual(stripes.size(), 3);
+        //verify wrapped by CachingOrcReader
+        assertInstanceOf(wrapWithCacheIfTinyStripes(orcDataSource, stripes, maxMergeDistance, maxReadSize), CachingOrcDataSource.class);
+
+        OrcRecordReader orcRecordReader = orcReader.createRecordReader(ImmutableMap.of(0, VARCHAR), (numberOfRows, statisticsByColumnIndex) -> true, HIVE_STORAGE_TIME_ZONE);
+        int positionCount = 0;
+        while (true) {
+            int batchSize = orcRecordReader.nextBatch();
+            if (batchSize <= 0) {
+                break;
+            }
+            Block block = orcRecordReader.readBlock(VARCHAR, 0);
+            positionCount += block.getPositionCount();
+        }
+        assertEquals(positionCount, POSITION_COUNT);
+    }
+
+    public static <T, U extends T> void assertNotInstanceOf(T actual, Class<U> expectedType)
+    {
+        assertNotNull(actual, "actual is null");
+        assertNotNull(expectedType, "expectedType is null");
+        if (expectedType.isInstance(actual)) {
+            fail(String.format("expected:<%s> to not be an instance of <%s>", actual, expectedType.getName()));
+        }
+    }
+
+    private static FileSinkOperator.RecordWriter createOrcRecordWriter(File outputFile, Format format, Compression compression, ObjectInspector columnObjectInspector)
+            throws IOException
+    {
+        JobConf jobConf = new JobConf();
+        jobConf.set("hive.exec.orc.write.format", format == ORC_12 ? "0.12" : "0.11");
+        jobConf.set("hive.exec.orc.default.compress", compression.name());
+        ReaderWriterProfiler.setProfilerOptions(jobConf);
+
+        Properties tableProperties = new Properties();
+        tableProperties.setProperty("columns", "test");
+        tableProperties.setProperty("columns.types", columnObjectInspector.getTypeName());
+        tableProperties.setProperty("orc.stripe.size", "1200000");
+
+        return new OrcOutputFormat().getHiveRecordWriter(
+                jobConf,
+                new Path(outputFile.toURI()),
+                Text.class,
+                compression != NONE,
+                tableProperties,
+                () -> { });
+    }
+
+    private static class FakeOrcDataSource
+            implements OrcDataSource
+    {
+        public static final FakeOrcDataSource INSTANCE = new FakeOrcDataSource();
+
+        @Override
+        public long getReadTimeNanos()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getSize()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void readFully(long position, byte[] buffer)
+                throws IOException
+        {
+            // do nothing
+        }
+
+        @Override
+        public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
+                throws IOException
+        {
+            // do nothing
+        }
+
+        @Override
+        public <K> Map<K, FixedLengthSliceInput> readFully(Map<K, DiskRange> diskRanges)
+                throws IOException
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcDataSource.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.FixedLengthSliceInput;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+class TestingOrcDataSource
+        implements OrcDataSource
+{
+    private final OrcDataSource delegate;
+
+    private int readCount;
+    private List<DiskRange> lastReadRanges;
+
+    public TestingOrcDataSource(OrcDataSource delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    public int getReadCount()
+    {
+        return readCount;
+    }
+
+    public List<DiskRange> getLastReadRanges()
+    {
+        return lastReadRanges;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return delegate.getReadTimeNanos();
+    }
+
+    @Override
+    public long getSize()
+    {
+        return delegate.getSize();
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer)
+            throws IOException
+    {
+        readCount++;
+        lastReadRanges = ImmutableList.of(new DiskRange(position, buffer.length));
+        delegate.readFully(position, buffer);
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException
+    {
+        readCount++;
+        lastReadRanges = ImmutableList.of(new DiskRange(position, bufferLength));
+        delegate.readFully(position, buffer, bufferOffset, bufferLength);
+    }
+
+    @Override
+    public <K> Map<K, FixedLengthSliceInput> readFully(Map<K, DiskRange> diskRanges)
+            throws IOException
+    {
+        readCount += diskRanges.size();
+        lastReadRanges = ImmutableList.copyOf(diskRanges.values());
+        return delegate.readFully(diskRanges);
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -190,7 +190,7 @@ public class OrcStorageManager
         OrcDataSource dataSource = openShard(shardUuid, readerAttributes);
 
         try {
-            OrcReader reader = new OrcReader(dataSource, new OrcMetadataReader());
+            OrcReader reader = new OrcReader(dataSource, new OrcMetadataReader(), readerAttributes.getMaxMergeDistance(), readerAttributes.getMaxReadSize());
 
             Map<Long, Integer> indexMap = columnIdIndex(reader.getColumnNames());
             ImmutableMap.Builder<Integer, Type> includedColumns = ImmutableMap.builder();
@@ -314,7 +314,7 @@ public class OrcStorageManager
     private List<ColumnStats> computeShardStats(File file)
     {
         try (OrcDataSource dataSource = fileOrcDataSource(defaultReaderAttributes, file)) {
-            OrcReader reader = new OrcReader(dataSource, new OrcMetadataReader());
+            OrcReader reader = new OrcReader(dataSource, new OrcMetadataReader(), defaultReaderAttributes.getMaxMergeDistance(), defaultReaderAttributes.getMaxReadSize());
 
             ImmutableList.Builder<ColumnStats> list = ImmutableList.builder();
             for (ColumnInfo info : getColumnInfo(reader)) {

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
@@ -22,6 +22,7 @@ import com.facebook.presto.orc.metadata.OrcMetadataReader;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
+import io.airlift.units.DataSize.Unit;
 import org.joda.time.DateTimeZone;
 
 import java.io.File;
@@ -48,7 +49,7 @@ final class OrcTestingUtil
     public static OrcRecordReader createReader(OrcDataSource dataSource, List<Long> columnIds, List<Type> types)
             throws IOException
     {
-        OrcReader orcReader = new OrcReader(dataSource, new OrcMetadataReader());
+        OrcReader orcReader = new OrcReader(dataSource, new OrcMetadataReader(), new DataSize(1, Unit.MEGABYTE), new DataSize(1, Unit.MEGABYTE));
 
         List<String> columnNames = orcReader.getColumnNames();
         assertEquals(columnNames.size(), columnIds.size());
@@ -67,7 +68,7 @@ final class OrcTestingUtil
     public static OrcRecordReader createReaderNoRows(OrcDataSource dataSource)
             throws IOException
     {
-        OrcReader orcReader = new OrcReader(dataSource, new OrcMetadataReader());
+        OrcReader orcReader = new OrcReader(dataSource, new OrcMetadataReader(), new DataSize(1, Unit.MEGABYTE), new DataSize(1, Unit.MEGABYTE));
 
         assertEquals(orcReader.getColumnNames().size(), 0);
 


### PR DESCRIPTION
Fixes #3663 