### PR TITLE
Fix NoSuchElementException when cross join is used inside IN subquery

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -415,9 +415,9 @@ public abstract class DefaultTraversalVisitor<R, C>
         process(node.getLeft(), context);
         process(node.getRight(), context);
 
-        if (node.getCriteria().get() instanceof JoinOn) {
-            process(((JoinOn) node.getCriteria().get()).getExpression(), context);
-        }
+        node.getCriteria()
+                .filter(criteria -> criteria instanceof JoinOn)
+                .map(criteria -> process(((JoinOn) criteria).getExpression(), context));
 
         return null;
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3143,6 +3143,14 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testInSubqueryWithCrossJoin()
+            throws Exception
+    {
+        assertQuery("SELECT a FROM (VALUES (1),(2)) t(a) WHERE a IN " +
+                    "(SELECT b FROM (VALUES (ARRAY[2])) AS t1 (a) CROSS JOIN UNNEST(a) as t2(b))", "SELECT 2");
+    }
+
+    @Test
     public void testGroupByIf()
             throws Exception
     {


### PR DESCRIPTION
```
presto> select a from (values (1),(2)) t(a) where a in (SELECT b FROM (VALUES (ARRAY[2])) AS t1 (a) CROSS JOIN UNNEST(a) as t2(b));
Query 20151002_013328_00000_dm9s2 failed: No value present
```
NoSuchElementException("No value present") occurs when `CROSS JOIN` is used inside `IN` subquery