### PR TITLE
Skipping unpack goal while building RPM is enforced to false.

### DIFF
--- a/presto-server-rpm/pom.xml
+++ b/presto-server-rpm/pom.xml
@@ -52,6 +52,7 @@
                                     <goal>unpack</goal>
                                 </goals>
                                 <configuration>
+                                    <skip>false</skip>
                                     <artifactItems>
                                         <artifactItem>
                                             <groupId>com.facebook.presto</groupId>


### PR DESCRIPTION
This allows any setup of skipping-checks without affecting possibility of building RPM.
Without that patch if flag air.check.skip-dependency was set TRUE, RPM failed to build due to not having presto-server unpacked.