### PR TITLE
Fix TypeUtils.hashPosition for structural types

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
@@ -81,6 +81,9 @@ public final class TypeUtils
             else if (type.getJavaType() == Slice.class) {
                 return (long) methodHandle.invoke(type.getSlice(block, position));
             }
+            else if (!type.getJavaType().isPrimitive()) {
+                return (long) methodHandle.invoke(type.getObject(block, position));
+            }
             else {
                 throw new UnsupportedOperationException("Unsupported native container type: " + type.getJavaType() + " with type " + type.getTypeSignature());
             }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -933,6 +933,13 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testGroupByComplexMap()
+            throws Exception
+    {
+        assertQuery("SELECT MAP_KEYS(x)[1] FROM (VALUES MAP(ARRAY['a'], ARRAY[ARRAY[1]]), MAP(ARRAY['b'], ARRAY[ARRAY[2]])) t(x) GROUP BY x", "SELECT * FROM (VALUES 'a', 'b')");
+    }
+
+    @Test
     public void testGroupByRow()
             throws Exception
     {


### PR DESCRIPTION
- Fixes hashcode generation for maps that contain complex types, and enables GROUP BY on them