### PR TITLE
Increase default failure detector tolerance

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/failureDetector/FailureDetectorConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/failureDetector/FailureDetectorConfig.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 public class FailureDetectorConfig
 {
     private boolean enabled = true;
-    private double failureRatioThreshold = 0.01; // 1% failure rate
+    private double failureRatioThreshold = 0.1; // ~6secs of failures, given default setting of heartbeatInterval = 500ms
     private Duration heartbeatInterval = new Duration(500, TimeUnit.MILLISECONDS);
     private Duration warmupInterval = new Duration(5, TimeUnit.SECONDS);
     private Duration expirationGraceInterval = new Duration(10, TimeUnit.MINUTES);

--- a/presto-main/src/test/java/com/facebook/presto/server/TestFailureDetectorConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestFailureDetectorConfig.java
@@ -29,7 +29,7 @@ public class TestFailureDetectorConfig
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(FailureDetectorConfig.class)
                 .setExpirationGraceInterval(new Duration(10, TimeUnit.MINUTES))
-                .setFailureRatioThreshold(0.01)
+                .setFailureRatioThreshold(0.1)
                 .setHeartbeatInterval(new Duration(500, TimeUnit.MILLISECONDS))
                 .setWarmupInterval(new Duration(5, TimeUnit.SECONDS))
                 .setEnabled(true));


### PR DESCRIPTION
Because failure-detector.threshold is used to compare the ratio of two
exponentially decayed counters, the current default only tolerates
~600ms of network outage. This changes the default to ~6s.