### PR TITLE
Use System.nanoTime() when building Duration objects

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -54,7 +54,6 @@ import static com.facebook.presto.util.Failures.toFailure;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.Duration.nanosSince;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 @ThreadSafe
@@ -64,6 +63,7 @@ public class QueryStateMachine
 
     private final DateTime createTime = DateTime.now();
     private final long createNanos = System.nanoTime();
+    private final AtomicLong endNanos = new AtomicLong();
 
     private final QueryId queryId;
     private final String query;
@@ -145,8 +145,8 @@ public class QueryStateMachine
         QueryState state = queryState.get();
 
         Duration elapsedTime;
-        if (endTime.get() != null) {
-            elapsedTime = new Duration(endTime.get().getMillis() - createTime.getMillis(), MILLISECONDS);
+        if (endNanos.get() != 0) {
+            elapsedTime = new Duration(Long.valueOf(endNanos.get() - createNanos).doubleValue(), NANOSECONDS);
         }
         else {
             elapsedTime = nanosSince(createNanos);
@@ -376,8 +376,9 @@ public class QueryStateMachine
         DateTime now = DateTime.now();
         executionStartTime.compareAndSet(null, now);
         endTime.compareAndSet(null, now);
+        endNanos.compareAndSet(0, System.nanoTime());
 
-        return queryState.setIf(FINISHED, currentState ->!currentState.isDone());
+        return queryState.setIf(FINISHED, currentState -> !currentState.isDone());
     }
 
     public boolean transitionToFailed(Throwable throwable)
@@ -390,6 +391,7 @@ public class QueryStateMachine
         DateTime now = DateTime.now();
         executionStartTime.compareAndSet(null, now);
         endTime.compareAndSet(null, now);
+        endNanos.compareAndSet(0, System.nanoTime());
 
         failureCause.compareAndSet(null, toFailure(throwable));
         boolean failed = queryState.setIf(FAILED, currentState -> !currentState.isDone());

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryExecutionResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryExecutionResource.java
@@ -102,7 +102,7 @@ public class QueryExecutionResource
                     }
                 }
 
-                long last = System.currentTimeMillis();
+                long last = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
                 if (task.getStats().getEndTime() != null) {
                     last = task.getStats().getEndTime().getMillis();
                 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestCompactionSetCreator.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestCompactionSetCreator.java
@@ -82,7 +82,7 @@ public class TestCompactionSetCreator
     {
         CompactionSetCreator compactionSetCreator = new TemporalCompactionSetCreator(new DataSize(100, BYTE), MAX_SHARD_ROWS, TIMESTAMP);
         long tableId = 1L;
-        long day1 = Duration.ofDays(Duration.ofMillis(System.currentTimeMillis()).toDays()).toMillis();
+        long day1 = Duration.ofDays(Duration.ofNanos(System.nanoTime()).toDays()).toMillis();
         long day2 = Duration.ofDays(Duration.ofMillis(day1).toDays() + 1).toMillis();
 
         // compact into two shards
@@ -105,7 +105,7 @@ public class TestCompactionSetCreator
     {
         CompactionSetCreator compactionSetCreator = new TemporalCompactionSetCreator(new DataSize(100, BYTE), MAX_SHARD_ROWS, TIMESTAMP);
         long tableId = 1L;
-        long day1 = Duration.ofDays(Duration.ofMillis(System.currentTimeMillis()).toDays()).toMillis();
+        long day1 = Duration.ofDays(Duration.ofNanos(System.nanoTime()).toDays()).toMillis();
         long day2 = Duration.ofDays(Duration.ofMillis(day1).toDays() + 1).toMillis();
         long day3 = Duration.ofDays(Duration.ofMillis(day1).toDays() + 2).toMillis();
         long day4 = Duration.ofDays(Duration.ofMillis(day1).toDays() + 3).toMillis();
@@ -134,7 +134,7 @@ public class TestCompactionSetCreator
     {
         CompactionSetCreator compactionSetCreator = new TemporalCompactionSetCreator(new DataSize(100, BYTE), MAX_SHARD_ROWS, DATE);
         long tableId = 1L;
-        long day1 = Duration.ofMillis(System.currentTimeMillis()).toDays();
+        long day1 = Duration.ofNanos(System.nanoTime()).toDays();
         long day2 = day1 + 1;
         long day3 = day1 + 2;
 


### PR DESCRIPTION
Favor System.nanoTime() to System.currentTimeMillis() because
System.currentTimeMillis() is not monotonic.