### PR TITLE
Reset error delay on successful requests

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
@@ -312,7 +312,7 @@ public final class HttpPageBufferClient
                     }
                     future = null;
                     lastUpdate = DateTime.now();
-
+                    errorDelayMillis = 0;
                 }
                 requestsCompleted.incrementAndGet();
                 clientCallback.requestComplete(HttpPageBufferClient.this);
@@ -350,6 +350,7 @@ public final class HttpPageBufferClient
                     closed = true;
                     future = null;
                     lastUpdate = DateTime.now();
+                    errorDelayMillis = 0;
                 }
                 requestsCompleted.incrementAndGet();
                 clientCallback.clientFinished(HttpPageBufferClient.this);

--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
@@ -388,8 +388,8 @@ public final class HttpPageBufferClient
             clientCallback.clientFailed(HttpPageBufferClient.this, t);
         }
 
-        increaseErrorDelay();
         synchronized (HttpPageBufferClient.this) {
+            increaseErrorDelay();
             future = null;
             lastUpdate = DateTime.now();
         }


### PR DESCRIPTION
When we encounter an error in the ``HttpPageBufferClient`` we have a backoff and we retry after the backoff. We need to reset this error backoff on successful requests to avoid latencies in requests. 