### PR TITLE
Adding support for pre and post queries for verifier

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.124.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.124.rst
@@ -6,3 +6,17 @@ General Changes
 ---------------
 
 * The :func:`approx_percentile` aggregation now also accepts an array of percentages
+
+Verifier
+--------
+
+* Add support for pre and post control and test queries
+
+If you're upgrading from 0.123, you need to alter your verifier_queries table
+
+.. code-block:: sql
+
+    ALTER TABLE verifier_queries add column test_postqueries text null;
+    ALTER TABLE verifier_queries add column test_prequeries text null;
+    ALTER TABLE verifier_queries add column control_postqueries text null;
+    ALTER TABLE verifier_queries add column control_prequeries text null;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/PrestoVerifier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/PrestoVerifier.java
@@ -177,7 +177,9 @@ public class PrestoVerifier
                     Query test = new Query(
                             Optional.ofNullable(config.getTestCatalogOverride()).orElse(input.getTest().getCatalog()),
                             Optional.ofNullable(config.getTestSchemaOverride()).orElse(input.getTest().getSchema()),
+                            input.getTest().getPreQueries(),
                             input.getTest().getQuery(),
+                            input.getTest().getPostQueries(),
                             Optional.ofNullable(config.getTestUsernameOverride()).orElse(input.getTest().getUsername()),
                             Optional.ofNullable(config.getTestPasswordOverride()).orElse(
                                     Optional.ofNullable(input.getTest().getPassword()).orElse(null)),
@@ -185,7 +187,9 @@ public class PrestoVerifier
                     Query control = new Query(
                             Optional.ofNullable(config.getControlCatalogOverride()).orElse(input.getControl().getCatalog()),
                             Optional.ofNullable(config.getControlSchemaOverride()).orElse(input.getControl().getSchema()),
+                            input.getControl().getPreQueries(),
                             input.getControl().getQuery(),
+                            input.getControl().getPostQueries(),
                             Optional.ofNullable(config.getControlUsernameOverride()).orElse(input.getControl().getUsername()),
                             Optional.ofNullable(config.getControlPasswordOverride()).orElse(
                                     Optional.ofNullable(input.getControl().getPassword()).orElse(null)),

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Query.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Query.java
@@ -15,22 +15,29 @@ package com.facebook.presto.verifier;
 
 import com.google.common.collect.ImmutableMap;
 
+import java.util.List;
 import java.util.Map;
+
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 
 public class Query
 {
     private final String catalog;
     private final String schema;
+    private final List<String> preQueries;
     private final String query;
+    private final List<String> postQueries;
     private final String username;
     private final String password;
     private final Map<String, String> sessionProperties;
 
-    public Query(String catalog, String schema, String query, String username, String password, Map<String, String> sessionProperties)
+    public Query(String catalog, String schema, List<String> preQueries, String query, List<String> postQueries, String username, String password, Map<String, String> sessionProperties)
     {
         this.catalog = catalog;
         this.schema = schema;
+        this.preQueries = preQueries.stream().map(Query::clean).collect(toImmutableList());
         this.query = clean(query);
+        this.postQueries = postQueries.stream().map(Query::clean).collect(toImmutableList());
         this.username = username;
         this.password = password;
         this.sessionProperties = ImmutableMap.copyOf(sessionProperties);
@@ -46,9 +53,19 @@ public class Query
         return schema;
     }
 
+    public List<String> getPreQueries()
+    {
+        return preQueries;
+    }
+
     public String getQuery()
     {
         return query;
+    }
+
+    public List<String> getPostQueries()
+    {
+        return postQueries;
     }
 
     public String getUsername()

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryResult.java
@@ -24,7 +24,7 @@ public class QueryResult
 {
     public enum State
     {
-        INVALID, FAILED, SUCCESS, TOO_MANY_ROWS, TIMEOUT
+        INVALID, FAILED, SUCCESS, TOO_MANY_ROWS, TIMEOUT, FAILED_TO_SETUP, FAILED_TO_TEARDOWN
     }
 
     private final State state;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/VerifierDao.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/VerifierDao.java
@@ -27,12 +27,16 @@ public interface VerifierDao
             ", name\n" +
             ", test_catalog\n" +
             ", test_schema\n" +
+            ", test_prequeries\n" +
             ", test_query\n" +
+            ", test_postqueries\n" +
             ", test_username\n" +
             ", test_password\n" +
             ", control_catalog\n" +
             ", control_schema\n" +
+            ", control_prequeries\n" +
             ", control_query\n" +
+            ", control_postqueries\n" +
             ", control_username\n" +
             ", control_password\n" +
             ", session_properties_json\n" +


### PR DESCRIPTION
@cberner please, have a look. 
Ran verifier locally, for all queries, for which these 4 added db fields are null the verifier just ignores them (as expected). 

I've updated xdb manually for verifier_queries tables.