### PR TITLE
Add support for S3 EncryptionMaterialsProvider to PrestoS3FileSystem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,8 @@
         <air.test.jvmsize>2g</air.test.jvmsize>
 
         <air.javadoc.lint>-missing</air.javadoc.lint>
+
+        <aws.sdk.version>1.9.31</aws.sdk.version>
     </properties>
 
     <modules>
@@ -577,8 +579,20 @@
 
             <dependency>
                 <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk</artifactId>
-                <version>1.8.9.1</version>
+                <artifactId>aws-java-sdk-core</artifactId>
+                <version>${aws.sdk.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-s3</artifactId>
+                <version>${aws.sdk.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -130,7 +130,18 @@
 
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>joda-time</groupId>

--- a/presto-hive/src/test/java/com/facebook/presto/hive/MockAmazonS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/MockAmazonS3.java
@@ -30,6 +30,7 @@ import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
 import com.amazonaws.services.s3.model.BucketLoggingConfiguration;
 import com.amazonaws.services.s3.model.BucketNotificationConfiguration;
 import com.amazonaws.services.s3.model.BucketPolicy;
+import com.amazonaws.services.s3.model.BucketReplicationConfiguration;
 import com.amazonaws.services.s3.model.BucketTaggingConfiguration;
 import com.amazonaws.services.s3.model.BucketVersioningConfiguration;
 import com.amazonaws.services.s3.model.BucketWebsiteConfiguration;
@@ -80,9 +81,11 @@ import com.amazonaws.services.s3.model.SetBucketLifecycleConfigurationRequest;
 import com.amazonaws.services.s3.model.SetBucketLoggingConfigurationRequest;
 import com.amazonaws.services.s3.model.SetBucketNotificationConfigurationRequest;
 import com.amazonaws.services.s3.model.SetBucketPolicyRequest;
+import com.amazonaws.services.s3.model.SetBucketReplicationConfigurationRequest;
 import com.amazonaws.services.s3.model.SetBucketTaggingConfigurationRequest;
 import com.amazonaws.services.s3.model.SetBucketVersioningConfigurationRequest;
 import com.amazonaws.services.s3.model.SetBucketWebsiteConfigurationRequest;
+import com.amazonaws.services.s3.model.SetObjectAclRequest;
 import com.amazonaws.services.s3.model.StorageClass;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
@@ -762,5 +765,36 @@ public class MockAmazonS3
             throws AmazonClientException
     {
         return false;
+    }
+
+    @Override
+    public void setObjectAcl(SetObjectAclRequest setObjectAclRequest)
+            throws AmazonClientException, AmazonServiceException
+    {
+    }
+
+    @Override
+    public void setBucketReplicationConfiguration(String s, BucketReplicationConfiguration bucketReplicationConfiguration)
+            throws AmazonServiceException, AmazonClientException
+    {
+    }
+
+    @Override
+    public void setBucketReplicationConfiguration(SetBucketReplicationConfigurationRequest setBucketReplicationConfigurationRequest)
+            throws AmazonServiceException, AmazonClientException
+    {
+    }
+
+    @Override
+    public BucketReplicationConfiguration getBucketReplicationConfiguration(String s)
+            throws AmazonServiceException, AmazonClientException
+    {
+        return null;
+    }
+
+    @Override
+    public void deleteBucketReplicationConfiguration(String s)
+            throws AmazonServiceException, AmazonClientException
+    {
     }
 }


### PR DESCRIPTION
Add generic support for S3 encryption materials providers to the hive
connector so that files in S3 encrypted using client-supplied keys can
be used.