### PR TITLE
Accept credential cache file path without type prefix

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -175,8 +175,7 @@ public class ClientOptions
         if (value != null && value.startsWith("FILE:")) {
             return value.substring("FILE:".length());
         }
-
-        return null;
+        return value;
     }
 
     public static final class ClientSessionProperty


### PR DESCRIPTION
according to http://web.mit.edu/kerberos/krb5-1.13/doc/user/user_commands/klist.html, location of the Kerberos 5 credentials cache is in the form type:residual. If no type prefix is present, the FILE type is assumed.
The change is to allow presto cli to accept credential cache location that does not have the type prefix.