### PR TITLE
Avoid over-creation of initial splits

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -381,9 +381,11 @@ public class BackgroundHiveSplitLoader
                 List<HostAddress> addresses = toHostAddress(blockLocation.getHosts());
 
                 long maxBytes = maxSplitSize.toBytes();
+                boolean creatingInitialSplits = false;
 
                 if (remainingInitialSplits.get() > 0) {
                     maxBytes = maxInitialSplitSize.toBytes();
+                    creatingInitialSplits = true;
                 }
 
                 // divide the block into uniform chunks that are smaller than the max split size
@@ -393,6 +395,14 @@ public class BackgroundHiveSplitLoader
 
                 long chunkOffset = 0;
                 while (chunkOffset < blockLocation.getLength()) {
+                    if (remainingInitialSplits.decrementAndGet() < 0 && creatingInitialSplits) {
+                        creatingInitialSplits = false;
+                        // recalculate the target chunk size
+                        maxBytes = maxSplitSize.toBytes();
+                        long remainingLength = blockLocation.getLength() - chunkOffset;
+                        chunks = Math.max(1, (int) (remainingLength / maxBytes));
+                        targetChunkSize = (long) Math.ceil(remainingLength * 1.0 / chunks);
+                    }
                     // adjust the actual chunk size to account for the overrun when chunks are slightly bigger than necessary (see above)
                     long chunkLength = Math.min(targetChunkSize, blockLocation.getLength() - chunkOffset);
 
@@ -410,7 +420,6 @@ public class BackgroundHiveSplitLoader
                             effectivePredicate));
 
                     chunkOffset += chunkLength;
-                    remainingInitialSplits.decrementAndGet();
                 }
                 checkState(chunkOffset == blockLocation.getLength(), "Error splitting blocks");
             }


### PR DESCRIPTION
Fix a race in BackgroundHiveSplitLoader which caused it to create more
initial splits than specified in config.