### PR TITLE
Fix timezone issue while writing dates in Hive

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Reporter;
+import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.sql.Date;
@@ -83,6 +84,7 @@ import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveO
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaLongObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaStringObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaTimestampObjectInspector;
+import static org.joda.time.DateTimeZone.UTC;
 
 public final class HiveWriteUtils
 {
@@ -178,9 +180,8 @@ public final class HiveWriteUtils
             return type.getSlice(block, position).getBytes();
         }
         if (DateType.DATE.equals(type)) {
-            // todo should this be adjusted to midnight in JVM timezone?
             long days = type.getLong(block, position);
-            return new Date(TimeUnit.DAYS.toMillis(days));
+            return new Date(UTC.getMillisKeepLocal(DateTimeZone.getDefault(), TimeUnit.DAYS.toMillis(days)));
         }
         if (TimestampType.TIMESTAMP.equals(type)) {
             long millisUtc = type.getLong(block, position);


### PR DESCRIPTION
Fixes #3780 

@dain can you please review when you have time? 

Unfortunately the unit tests change the default timezone to `Asia/Katmandu` and the problem cannot be reproduced in that timezone. When I change the default timezone to `America/Los Angeles` then I can reproduce it. But, I didn't like changing the default timezone during a single unit test execution as there may be other tests running in parallel (are there?) that may get affected. The following can reproduce this issue:

```Java
@Test
public void testDateWriteTimeZoneIssue()
        throws Exception
{
    TimeZone defaultZone = TimeZone.getDefault();
    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
    @Language("SQL") String select = "SELECT" +
            " cast('2015-10-01' as date) _date";
    String createTableAs = String.format("CREATE TABLE test_date_write AS %s", select);
    assertQuery(createTableAs, "SELECT 1");
    assertQuery("SELECT * from test_date_write", "select '2015-10-01'");
    assertQueryTrue("DROP TABLE test_date_write");
    assertFalse(queryRunner.tableExists(getSession(), "test_date_write"));
    TimeZone.setDefault(defaultZone);
}    
```
