### PR TITLE
Add table_type Hive property for CTAS queries

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveOutputTableHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveOutputTableHandle.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.hive.metastore.TableType;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,6 +29,7 @@ public class HiveOutputTableHandle
         implements ConnectorOutputTableHandle
 {
     private final List<String> partitionedBy;
+    private final TableType hiveTableType;
     private final String tableOwner;
 
     @JsonCreator
@@ -39,6 +41,7 @@ public class HiveOutputTableHandle
             @JsonProperty("filePrefix") String filePrefix,
             @JsonProperty("writePath") String writePath,
             @JsonProperty("hiveStorageFormat") HiveStorageFormat hiveStorageFormat,
+            @JsonProperty("hiveTableType") TableType hiveTableType,
             @JsonProperty("partitionedBy") List<String> partitionedBy,
             @JsonProperty("tableOwner") String tableOwner)
     {
@@ -52,6 +55,7 @@ public class HiveOutputTableHandle
                 hiveStorageFormat);
 
         this.partitionedBy = ImmutableList.copyOf(requireNonNull(partitionedBy, "partitionedBy is null"));
+        this.hiveTableType = requireNonNull(hiveTableType, "hiveTableType is null");
         this.tableOwner = requireNonNull(tableOwner, "tableOwner is null");
     }
 
@@ -59,6 +63,12 @@ public class HiveOutputTableHandle
     public List<String> getPartitionedBy()
     {
         return partitionedBy;
+    }
+
+    @JsonProperty
+    public TableType getHiveTableType()
+    {
+        return hiveTableType;
     }
 
     @JsonProperty

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.hive.metastore.TableType;
 
 import javax.inject.Inject;
 
@@ -31,6 +32,7 @@ public class HiveTableProperties
 {
     public static final String STORAGE_FORMAT_PROPERTY = "format";
     public static final String PARTITIONED_BY_PROPERTY = "partitioned_by";
+    public static final String TABLE_TYPE_PROPERTY = "table_type";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -55,7 +57,15 @@ public class HiveTableProperties
                         false,
                         value -> ImmutableList.copyOf(((List<String>) value).stream()
                                 .map(name -> name.toLowerCase(ENGLISH))
-                                .collect(Collectors.toList()))));
+                                .collect(Collectors.toList()))),
+                new PropertyMetadata<>(
+                        TABLE_TYPE_PROPERTY,
+                        "Table type",
+                        VARCHAR,
+                        TableType.class,
+                        TableType.MANAGED_TABLE,
+                        false,
+                        value -> TableType.valueOf(((String) value).toUpperCase(ENGLISH))));
     }
 
     public List<PropertyMetadata<?>> getTableProperties()
@@ -71,5 +81,10 @@ public class HiveTableProperties
     public static List<String> getPartitionedBy(Map<String, Object> tableProperties)
     {
         return (List<String>) tableProperties.get(PARTITIONED_BY_PROPERTY);
+    }
+
+    public static TableType getHiveTableType(Map<String, Object> tableProperties)
+    {
+        return (TableType) tableProperties.get(TABLE_TYPE_PROPERTY);
     }
 }


### PR DESCRIPTION
Currently all tables created with Presto CTAS queries are managed tables. But we don't always want that as we don't want our data to be deleted on a `drop table`.  This PR adds support for creating external tables by adding a new Hive table property.

BTW currently `table_type` is passed directly to the metastore call, should we restrict the table type to only `MANAGED_TABLE` and `EXTERNAL_TABLE` (there are also `VIRTUAL_VIEW` and `INDEX_TABLE` types in `TableType` enum)?