### PR TITLE
Improve session/table property validation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/TablePropertyManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/TablePropertyManager.java
@@ -14,10 +14,16 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.block.BlockUtils;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.session.PropertyMetadata;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
 import java.util.List;
@@ -25,10 +31,12 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.facebook.presto.metadata.SessionPropertyManager.evaluatePropertyValue;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static com.facebook.presto.sql.planner.ExpressionInterpreter.evaluateConstantExpression;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class TablePropertyManager
@@ -52,25 +60,52 @@ public class TablePropertyManager
             Session session,
             Metadata metadata)
     {
-        Map<String, PropertyMetadata<?>> tableProperties = catalogTableProperties.get(catalog);
-        if (tableProperties == null) {
+        Map<String, PropertyMetadata<?>> supportedTableProperties = catalogTableProperties.get(catalog);
+        if (supportedTableProperties == null) {
             throw new PrestoException(NOT_FOUND, "Catalog not found: " + catalog);
         }
 
         ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
-        for (PropertyMetadata<?> tableProperty : tableProperties.values()) {
-            Expression expression = sqlPropertyValues.get(tableProperty.getName());
+
+        // Fill in user-specified properties
+        for (Map.Entry<String, Expression> sqlProperty : sqlPropertyValues.entrySet()) {
+            PropertyMetadata<?> tableProperty = supportedTableProperties.get(sqlProperty.getKey());
+            if (tableProperty == null) {
+                throw new PrestoException(INVALID_TABLE_PROPERTY, format("Catalog '%s' does not support table property '%s'", catalog, sqlProperty.getKey()));
+            }
+
+            Object sqlObjectValue;
+            try {
+                sqlObjectValue = evaluatePropertyValue(sqlProperty.getValue(), tableProperty.getSqlType(), session, metadata);
+            }
+            catch (SemanticException e) {
+                throw new PrestoException(INVALID_TABLE_PROPERTY,
+                        format("Invalid value for table property '%s': Cannot convert '%s' to %s",
+                                tableProperty.getName(),
+                                sqlProperty.getValue(),
+                                tableProperty.getSqlType()), e);
+            }
+
             Object value;
-            if (expression != null) {
-                Object sqlObjectValue = evaluatePropertyValue(expression, tableProperty.getSqlType(), session, metadata);
+            try {
                 value = tableProperty.decode(sqlObjectValue);
             }
-            else {
-                value = tableProperty.getDefaultValue();
+            catch (Exception e) {
+                throw new PrestoException(INVALID_TABLE_PROPERTY,
+                        format("Unable to set table property '%s' to '%s': %s", tableProperty.getName(), sqlProperty.getValue(), e.getMessage()), e);
             }
-            // do not include default properties that are null
-            if (value != null) {
-                properties.put(tableProperty.getName(), value);
+
+            properties.put(tableProperty.getName(), value);
+        }
+        Map<String, Object> userSpecifiedProperties = properties.build();
+
+        // Fill in the remaining properties with non-null defaults
+        for (PropertyMetadata<?> tableProperty : supportedTableProperties.values()) {
+            if (!userSpecifiedProperties.containsKey(tableProperty.getName())) {
+                Object value = tableProperty.getDefaultValue();
+                if (value != null) {
+                    properties.put(tableProperty.getName(), value);
+                }
             }
         }
         return properties.build();
@@ -79,5 +114,20 @@ public class TablePropertyManager
     public Map<String, Map<String, PropertyMetadata<?>>> getAllTableProperties()
     {
         return ImmutableMap.copyOf(catalogTableProperties);
+    }
+
+    private static Object evaluatePropertyValue(Expression expression, Type expectedType, Session session, Metadata metadata)
+    {
+        Object value = evaluateConstantExpression(expression, expectedType, metadata, session, ImmutableSet.of());
+
+        // convert to object value type of SQL type
+        BlockBuilder blockBuilder = expectedType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockUtils.appendObject(expectedType, blockBuilder, value);
+        Object objectValue = expectedType.getObjectValue(session.toConnectorSession(), blockBuilder, 0);
+
+        if (objectValue == null) {
+            throw new PrestoException(INVALID_TABLE_PROPERTY, "Table property value cannot be null");
+        }
+        return objectValue;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -24,12 +24,12 @@ import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordCursor;
-import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.AnalysisContext;
 import com.facebook.presto.sql.analyzer.ExpressionAnalyzer;
+import com.facebook.presto.sql.analyzer.SemanticErrorCode;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.analyzer.TupleDescriptor;
 import com.facebook.presto.sql.planner.optimizations.CanonicalizeExpressions;
@@ -147,7 +147,7 @@ public class ExpressionInterpreter
 
         Type actualType = analyzer.getExpressionTypes().get(expression);
         if (!canCoerce(actualType, expectedType)) {
-            throw new PrestoException(StandardErrorCode.INVALID_SESSION_PROPERTY, String.format("Can not set property of type %s to %s",
+            throw new SemanticException(SemanticErrorCode.TYPE_MISMATCH, expression, String.format("Cannot cast type %s to %s",
                     expectedType.getTypeSignature(),
                     actualType.getTypeSignature()));
         }


### PR DESCRIPTION
Fixes #3793 

Presto now validates and produces (more) useful error messages for:

- Invalid property names:
```
presto> CREATE TABLE test_raghavsethi_presto_5 (x varchar) WITH (foo = bar);
Query 20151023_211129_00000_kidpb failed: Table property 'foo' unsupported for catalog 'catalog'
```

- Incorrect types:
```
presto> CREATE TABLE test_raghavsethi_presto_5 (x varchar) WITH (format = true);
Query 20151023_223656_00001_nur8f failed: Unsupported value for table property 'format': Cannot convert 'true' to varchar
```

- Incorrect values:
```
presto> CREATE TABLE test_raghavsethi_presto_5 (x varchar) WITH (format = 'FOOBAR');
Query 20151023_223623_00000_nur8f failed: Unable to set table property 'format' to ''FOOBAR'': No enum constant com.facebook.presto.hive.HiveStorageFormat.FOOBAR
```