### PR TITLE
Add verification support for byte array

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SqlVarbinary.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SqlVarbinary.java
@@ -20,12 +20,27 @@ import java.util.Arrays;
 import static java.util.Objects.requireNonNull;
 
 public final class SqlVarbinary
+        implements Comparable<SqlVarbinary>
 {
     private final byte[] bytes;
 
     public SqlVarbinary(byte[] bytes)
     {
         this.bytes = requireNonNull(bytes, "bytes is null");
+    }
+
+    @Override
+    public int compareTo(SqlVarbinary obj)
+    {
+        for (int i = 0; i < Math.min(bytes.length, obj.bytes.length); i++) {
+            if (bytes[i] < obj.bytes[i]) {
+                return -1;
+            }
+            else if (bytes[i] > obj.bytes[i]) {
+                return 1;
+            }
+        }
+        return bytes.length - obj.bytes.length;
     }
 
     @JsonValue

--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -108,6 +108,11 @@
             <artifactId>joda-time</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.verifier;
 
 import com.facebook.presto.jdbc.PrestoConnection;
+import com.facebook.presto.spi.type.SqlVarbinary;
 import com.facebook.presto.verifier.Validator.ChangedRow.Changed;
 import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
@@ -445,6 +446,9 @@ public class Validator
                 }
                 if (object instanceof Array) {
                     object = ((Array) object).getArray();
+                }
+                if (object instanceof byte[]) {
+                    object = new SqlVarbinary((byte[]) object);
                 }
                 row.add(object);
             }


### PR DESCRIPTION
If the verify query contains checksum, the object we get is actually a byte array, add support for checking results over byte array.