### PR TITLE
Upgrade airbase version to 46.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>43</version>
+        <version>46</version>
     </parent>
 
     <groupId>com.facebook.presto</groupId>
@@ -284,7 +284,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
             <dependency>
                 <groupId>com.facebook.hive</groupId>
                 <artifactId>hive-dwrf-shims</artifactId>
@@ -450,7 +449,7 @@
             <dependency>
                 <groupId>io.airlift.resolver</groupId>
                 <artifactId>resolver</artifactId>
-                <version>1.2</version>
+                <version>1.3</version>
             </dependency>
 
             <dependency>
@@ -572,7 +571,7 @@
             <dependency>
                 <groupId>io.airlift.discovery</groupId>
                 <artifactId>discovery-server</artifactId>
-                <version>1.24</version>
+                <version>1.25</version>
             </dependency>
 
             <dependency>

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCovarianceSampAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCovarianceSampAggregation.java
@@ -17,7 +17,6 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.correlation.Covariance;
-import org.testng.Assert;
 
 import java.util.List;
 
@@ -51,22 +50,6 @@ public class TestCovarianceSampAggregation
         if (length <= 1) {
             return null;
         }
-        Covariance covariance = new Covariance();
-        final double expected = covariance.covariance(constructDoublePrimitiveArray(start + 5, length), constructDoublePrimitiveArray(start, length), true);
-        return new Object() {
-            @Override
-            public boolean equals(Object obj)
-            {
-                Assert.assertEquals(expected, (Double) obj, 1e-10);
-                return true;
-            }
-
-            @Override
-            public int hashCode()
-            {
-                // required by checkstyle
-                return super.hashCode();
-            }
-        };
+        return new Covariance().covariance(constructDoublePrimitiveArray(start + 5, length), constructDoublePrimitiveArray(start, length), true);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRegrInterceptAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRegrInterceptAggregation.java
@@ -17,7 +17,6 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.regression.SimpleRegression;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -75,20 +74,6 @@ public class TestRegrInterceptAggregation
         }
         double expected = regression.getIntercept();
         checkArgument(Double.isFinite(expected) && expected != 0., "Expected result is trivial");
-        testAggregation(new Object() {
-            @Override
-            public boolean equals(Object obj)
-            {
-                Assert.assertEquals(expected, (Double) obj, 1e-10);
-                return true;
-            }
-
-            @Override
-            public int hashCode()
-            {
-                // required by checkstyle
-                return super.hashCode();
-            }
-        }, createDoublesBlock(y), createDoublesBlock(x));
+        testAggregation(expected, createDoublesBlock(y), createDoublesBlock(x));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.type.JsonType.JSON;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.util.StructuralTestUtil.arrayBlockOf;
 import static com.facebook.presto.util.StructuralTestUtil.mapBlockOf;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 
 public class TestMapOperators
@@ -229,7 +230,7 @@ public class TestMapOperators
         assertFunction("MAP_KEYS(MAP(ARRAY['puppies'], ARRAY['kittens']))", new ArrayType(VARCHAR), ImmutableList.of("puppies"));
         assertFunction("MAP_KEYS(MAP(ARRAY[TRUE], ARRAY[2]))", new ArrayType(BOOLEAN), ImmutableList.of(true));
         assertFunction("MAP_KEYS(MAP(ARRAY[from_unixtime(1)], ARRAY[1.0]))", new ArrayType(TIMESTAMP), ImmutableList.of(new SqlTimestamp(1000, TEST_SESSION.getTimeZoneKey())));
-        assertFunction("MAP_KEYS(MAP(ARRAY[CAST('puppies' as varbinary)], ARRAY['kittens']))", new ArrayType(VARBINARY), ImmutableList.of(new SqlVarbinary("puppies".getBytes("utf-8"))));
+        assertFunction("MAP_KEYS(MAP(ARRAY[CAST('puppies' as varbinary)], ARRAY['kittens']))", new ArrayType(VARBINARY), ImmutableList.of(new SqlVarbinary("puppies".getBytes(UTF_8))));
         assertFunction("MAP_KEYS(MAP(ARRAY[1,2],  ARRAY[ARRAY[1, 2], ARRAY[3]]))", new ArrayType(BIGINT), ImmutableList.of(1L, 2L));
         assertFunction("MAP_KEYS(MAP(ARRAY[1,4], ARRAY[MAP(ARRAY[2], ARRAY[3]), MAP(ARRAY[5], ARRAY[6])]))",  new ArrayType(BIGINT), ImmutableList.of(1L, 4L));
         assertFunction("MAP_KEYS(MAP(ARRAY [ARRAY [1], ARRAY [2, 3]],  ARRAY [ARRAY [3, 4], ARRAY [5]]))", new ArrayType(new ArrayType(BIGINT)), ImmutableList.of(ImmutableList.of(1L), ImmutableList.of(2L, 3L)));

--- a/presto-main/src/test/java/com/facebook/presto/util/Numbers.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/Numbers.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+public final class Numbers
+{
+    private Numbers() {}
+
+    public static boolean isFloatingNumber(Object number)
+    {
+        return number instanceof Double || number instanceof Float;
+    }
+
+    public static boolean isNan(Object number)
+    {
+        return number.equals(Double.NaN) || number.equals(Float.NaN);
+    }
+}


### PR DESCRIPTION
Upgrade airbase version to 46.

 - As new airbase comes with new version of testng some tests had to be
refactored as they started to fail.
 - Upgrade also airlift, discover-server and resolver to versions which
 also are using airbase at version 46, as with older version there were
 a dependency conflict.
