### PR TITLE
Fix IndexOutOfBounds when split contains no stripes

### DIFF
--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
@@ -91,6 +91,13 @@ public class TestCachingOrcDataSource
 
         OrcDataSource actual = wrapWithCacheIfTinyStripes(
                 FakeOrcDataSource.INSTANCE,
+                ImmutableList.of(),
+                maxMergeDistance,
+                maxReadSize);
+        assertInstanceOf(actual, CachingOrcDataSource.class);
+
+        actual = wrapWithCacheIfTinyStripes(
+                FakeOrcDataSource.INSTANCE,
                 ImmutableList.of(new StripeInformation(123, 3, 10, 10, 10)),
                 maxMergeDistance,
                 maxReadSize);


### PR DESCRIPTION
In normal circumstance, a stripe is ~200MB and split is ~60MB. As a result, around 2/3 of splits are empty. Processing them causes `IndexOutOfBoundsException` after merging #3692 because `mergeAdjacentDiskRanges` doesn't handle empty stripe list.

This PR also fixes a comment in #3692 that should have been addressed earlier.