### PR TITLE
Fix race in hash build memory tracking

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -189,6 +189,12 @@ public class DriverContext
         return pipelineContext.getOperatorPreAllocatedMemory();
     }
 
+    public void transferMemoryToTaskContext(long bytes)
+    {
+        pipelineContext.transferMemoryToTaskContext(bytes);
+        checkArgument(memoryReservation.addAndGet(-bytes) >= 0, "Tried to transfer more memory than is reserved");
+    }
+
     public ListenableFuture<?> reserveMemory(long bytes)
     {
         ListenableFuture<?> future = pipelineContext.reserveMemory(bytes);

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -135,9 +135,8 @@ public class HashBuilderOperator
             return;
         }
 
-        // Free memory, as the SharedLookupSource is going to take it over
-        operatorContext.setMemoryReservation(0);
-        lookupSourceSupplier.setLookupSource(new SharedLookupSource(pagesIndex.createLookupSource(hashChannels, hashChannel), operatorContext.getDriverContext().getPipelineContext().getTaskContext()));
+        // After this point the SharedLookupSource will take over our memory reservation, and ours will be zero
+        lookupSourceSupplier.setLookupSource(new SharedLookupSource(pagesIndex.createLookupSource(hashChannels, hashChannel), operatorContext));
         finished = true;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopBuildOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopBuildOperator.java
@@ -78,7 +78,7 @@ public class NestedLoopBuildOperator
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.nestedLoopJoinPagesSupplier = requireNonNull(nestedLoopJoinPagesSupplier, "nestedLoopJoinPagesSupplier is null");
-        this.nestedLoopJoinPagesBuilder = new NestedLoopJoinPagesBuilder(operatorContext.getDriverContext().getPipelineContext().getTaskContext());
+        this.nestedLoopJoinPagesBuilder = new NestedLoopJoinPagesBuilder(operatorContext);
     }
 
     @Override
@@ -100,8 +100,7 @@ public class NestedLoopBuildOperator
             return;
         }
 
-        // Free memory, as the PageSource is going to take it over
-        operatorContext.setMemoryReservation(0);
+        // The NestedLoopJoinPages will take over our memory reservation, so after this point ours will be zero.
         nestedLoopJoinPagesSupplier.setPages(nestedLoopJoinPagesBuilder.build());
 
         finished = true;

--- a/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPagesBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPagesBuilder.java
@@ -27,15 +27,15 @@ import static java.util.Objects.requireNonNull;
 
 public class NestedLoopJoinPagesBuilder
 {
-    private final TaskContext taskContext;
+    private final OperatorContext operatorContext;
     private List<Page> pages;
     private boolean finished;
 
     private long estimatedSize;
 
-    NestedLoopJoinPagesBuilder(TaskContext taskContext)
+    NestedLoopJoinPagesBuilder(OperatorContext operatorContext)
     {
-        this.taskContext = requireNonNull(taskContext, "taskContext is null");
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.pages = Lists.newArrayList();
     }
 
@@ -74,7 +74,7 @@ public class NestedLoopJoinPagesBuilder
 
         finished = true;
         pages = ImmutableList.copyOf(pages);
-        return new NestedLoopJoinPages(pages, getEstimatedSize(), taskContext);
+        return new NestedLoopJoinPages(pages, getEstimatedSize(), operatorContext);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -296,6 +296,13 @@ public class OperatorContext
         memoryFuture.get().set(null);
     }
 
+    public long transferMemoryToTaskContext()
+    {
+        long bytes = memoryReservation.getAndSet(0);
+        driverContext.transferMemoryToTaskContext(bytes);
+        return bytes;
+    }
+
     public void setMemoryReservation(long newMemoryReservation)
     {
         checkArgument(newMemoryReservation >= 0, "newMemoryReservation is negative");

--- a/presto-main/src/main/java/com/facebook/presto/operator/ParallelHashBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ParallelHashBuilder.java
@@ -390,9 +390,8 @@ public class ParallelHashBuilder
             }
 
             PagesIndex pagesIndex = Futures.getUnchecked(pagesIndexFuture);
-            // Free memory, as the SharedLookupSource is going to take it over
-            operatorContext.setMemoryReservation(0);
-            SharedLookupSource sharedLookupSource = new SharedLookupSource(pagesIndex.createLookupSource(hashChannels, hashChannel), operatorContext.getDriverContext().getPipelineContext().getTaskContext());
+            // After this point the SharedLookupSource will take over our memory reservation, and ours will be zero
+            SharedLookupSource sharedLookupSource = new SharedLookupSource(pagesIndex.createLookupSource(hashChannels, hashChannel), operatorContext);
 
             if (!lookupSourceFuture.set(sharedLookupSource)) {
                 sharedLookupSource.freeMemory();

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
@@ -194,6 +194,12 @@ public class PipelineContext
         return taskContext.getOperatorPreAllocatedMemory();
     }
 
+    public void transferMemoryToTaskContext(long bytes)
+    {
+        // The memory is already reserved in the task context, so just decrement our reservation
+        checkArgument(memoryReservation.addAndGet(-bytes) >= 0, "Tried to transfer more memory than is reserved");
+    }
+
     public synchronized ListenableFuture<?> reserveMemory(long bytes)
     {
         ListenableFuture<?> future = taskContext.reserveMemory(bytes);


### PR DESCRIPTION
The transfer of memory reservation ownership from the operator context
to the task context was not atomic. Therefore other tasks will observe a
free memory when there actually isn't any, while the hash build is
finishing.