### PR TITLE
Insert into a table with a list of columns

### DIFF
--- a/presto-docs/src/main/sphinx/sql/insert.rst
+++ b/presto-docs/src/main/sphinx/sql/insert.rst
@@ -7,18 +7,19 @@ Synopsis
 
 .. code-block:: none
 
-    INSERT INTO table_name query
+    INSERT INTO table_name [ ( column [, ... ] ) ] query
 
 Description
 -----------
 
 Insert new rows into a table.
 
-.. note::
+If the list of column names is specified, they must exactly match the list
+of columns produced by the query. Each column in the table not present in the
+column list will be filled with a ``null`` value. Otherwise, if the list of
+columns is not specified, the columns produced by the query must exactly match
+the columns in the table being inserted into.
 
-    Currently, the list of column names cannot be specified. Thus,
-    the columns produced by the query must exactly match the columns
-    in the table being inserted into.
 
 Examples
 --------
@@ -35,3 +36,14 @@ Insert a single row into the ``cities`` table::
 Insert multiple rows into the ``cities`` table::
 
     INSERT INTO cities VALUES (2, 'San Jose'), (3, 'Oakland');
+
+Insert a single row into the ``nation`` table with the specified column list::
+
+    INSERT INTO nation (nationkey, name, regionkey, comment)
+    VALUES (26, 'POLAND', 3, 'no comment');
+
+Insert a row without specifying the ``comment`` column. 
+That column will be ``null``::
+
+    INSERT INTO nation (nationkey, name, regionkey) 
+    VALUES (26, 'POLAND', 3);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
@@ -29,13 +29,6 @@ public class TestHiveDistributedQueries
     }
 
     @Override
-    public void testInsert()
-            throws Exception
-    {
-        // Hive connector currently does not support insert
-    }
-
-    @Override
     public void testDelete()
             throws Exception
     {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -266,7 +266,7 @@ public class TestHiveIntegrationSmokeTest
                 "(" +
                 "  _varchar VARCHAR," +
                 "  _bigint BIGINT," +
-                "  _doube DOUBLE," +
+                "  _double DOUBLE," +
                 "  _boolean BOOLEAN" +
                 ") " +
                 "WITH (format = '" + storageFormat + "') ";
@@ -285,6 +285,14 @@ public class TestHiveIntegrationSmokeTest
         assertQuery("INSERT INTO test_insert_format_table " + select, "SELECT 1");
 
         assertQuery("SELECT * from test_insert_format_table", select);
+
+        assertQuery("INSERT INTO test_insert_format_table (_bigint, _double) SELECT 2, 14.3", "SELECT 1");
+
+        assertQuery("SELECT * from test_insert_format_table where _bigint = 2", "SELECT null, 2, 14.3, null");
+
+        assertQuery("INSERT INTO test_insert_format_table (_double, _bigint) SELECT 2.72, 3", "SELECT 1");
+
+        assertQuery("SELECT * from test_insert_format_table where _bigint = 3", "SELECT null, 3, 2.72, null");
 
         assertQueryTrue("DROP TABLE test_insert_format_table");
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/TableMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/TableMetadata.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.SchemaTableName;
 
 import java.util.List;
 
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public class TableMetadata
@@ -53,5 +54,28 @@ public class TableMetadata
     public List<ColumnMetadata> getColumns()
     {
         return metadata.getColumns();
+    }
+
+    public List<String> getVisibleColumnNames()
+    {
+        return getColumns().stream()
+                .filter(column -> !column.isHidden())
+                .map(ColumnMetadata::getName)
+                .collect(toImmutableList());
+    }
+
+    public List<ColumnMetadata> getVisibleColumns()
+    {
+        return getColumns().stream()
+                .filter(column -> !column.isHidden())
+                .collect(toImmutableList());
+    }
+
+    public ColumnMetadata getColumn(String name)
+    {
+        return getColumns().stream()
+                .filter(columnMetadata -> columnMetadata.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Invalid column name: %s", name)));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -35,6 +35,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 
+import javax.annotation.concurrent.Immutable;
+
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +44,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class Analysis
@@ -83,8 +86,7 @@ public class Analysis
     private Map<String, Expression> createTableProperties = ImmutableMap.of();
     private boolean createTableAsSelectWithData = true;
 
-    // for insert
-    private Optional<TableHandle> insertTarget = Optional.empty();
+    private Optional<Insert> insert = Optional.empty();
 
     // for delete
     private Optional<Delete> delete = Optional.empty();
@@ -146,7 +148,7 @@ public class Analysis
 
     public Type getType(Expression expression)
     {
-        Preconditions.checkArgument(types.containsKey(expression), "Expression not analyzed: %s", expression);
+        checkArgument(types.containsKey(expression), "Expression not analyzed: %s", expression);
         return types.get(expression);
     }
 
@@ -356,14 +358,14 @@ public class Analysis
         return createTableProperties;
     }
 
-    public void setInsertTarget(TableHandle target)
+    public void setInsert(Insert insert)
     {
-        this.insertTarget = Optional.of(target);
+        this.insert = Optional.of(insert);
     }
 
-    public Optional<TableHandle> getInsertTarget()
+    public Optional<Insert> getInsert()
     {
-        return insertTarget;
+        return insert;
     }
 
     public void setDelete(Delete delete)
@@ -439,6 +441,30 @@ public class Analysis
             final JoinInPredicates other = (JoinInPredicates) obj;
             return Objects.equals(this.leftInPredicates, other.leftInPredicates) &&
                     Objects.equals(this.rightInPredicates, other.rightInPredicates);
+        }
+    }
+
+    @Immutable
+    public static final class Insert
+    {
+        private final TableHandle target;
+        private final List<ColumnHandle> columns;
+
+        public Insert(TableHandle target, List<ColumnHandle> columns)
+        {
+            this.target = requireNonNull(target, "target is null");
+            this.columns = requireNonNull(columns, "columns is null");
+            checkArgument(columns.size() > 0, "No columns given to insert");
+        }
+
+        public List<ColumnHandle> getColumns()
+        {
+            return columns;
+        }
+
+        public TableHandle getTarget()
+        {
+            return target;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -16,8 +16,8 @@ package com.facebook.presto.sql.planner;
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedTableName;
-import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.metadata.TableMetadata;
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.PrestoException;
@@ -29,10 +29,13 @@ import com.facebook.presto.sql.planner.plan.DeleteNode;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.TableCommitNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.NullLiteral;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
 import java.util.Map;
@@ -79,7 +82,7 @@ public class LogicalPlanner
         if (analysis.getCreateTableDestination().isPresent()) {
             plan = createTableCreationPlan(analysis);
         }
-        else if (analysis.getInsertTarget().isPresent()) {
+        else if (analysis.getInsert().isPresent()) {
             plan = createInsertPlan(analysis);
         }
         else if (analysis.getDelete().isPresent()) {
@@ -113,26 +116,55 @@ public class LogicalPlanner
 
         TableMetadata tableMetadata = createTableMetadata(destination, getOutputTableColumns(plan), analysis.getCreateTableProperties(), plan.getSampleWeight().isPresent());
         if (plan.getSampleWeight().isPresent() && !metadata.canCreateSampledTables(session, destination.getCatalogName())) {
-          throw new PrestoException(NOT_SUPPORTED, "Cannot write sampled data to a store that doesn't support sampling");
+            throw new PrestoException(NOT_SUPPORTED, "Cannot write sampled data to a store that doesn't support sampling");
         }
 
         return createTableWriterPlan(
                 analysis,
                 plan,
-                new CreateName(destination.getCatalogName(), tableMetadata), getVisibleColumnNames(tableMetadata));
+                new CreateName(destination.getCatalogName(), tableMetadata), tableMetadata.getVisibleColumnNames());
     }
 
     private RelationPlan createInsertPlan(Analysis analysis)
     {
-        TableHandle target = analysis.getInsertTarget().get();
+        Analysis.Insert insert = analysis.getInsert().get();
 
-        TableMetadata tableMetadata = metadata.getTableMetadata(session, target);
+        TableMetadata tableMetadata = metadata.getTableMetadata(session, insert.getTarget());
+
+        List<String> visibleTableColumnNames = tableMetadata.getVisibleColumnNames();
+        List<ColumnMetadata> visibleTableColumns = tableMetadata.getVisibleColumns();
+
+        RelationPlan plan = createRelationPlan(analysis);
+
+        Map<String, ColumnHandle> columns = metadata.getColumnHandles(session, insert.getTarget());
+        ImmutableMap.Builder<Symbol, Expression> assignments = ImmutableMap.builder();
+        for (ColumnMetadata column : tableMetadata.getVisibleColumns()) {
+            Symbol output = symbolAllocator.newSymbol(column.getName(), column.getType());
+            int index = insert.getColumns().indexOf(columns.get(column.getName()));
+            if (index < 0) {
+                assignments.put(output, new NullLiteral());
+            }
+            else {
+                assignments.put(output, plan.getSymbol(index).toQualifiedNameReference());
+            }
+        }
+        ProjectNode projectNode = new ProjectNode(idAllocator.getNextId(), plan.getRoot(), assignments.build());
+
+        RelationType relationType = new RelationType(visibleTableColumns.stream()
+                .map(column -> Field.newUnqualified(column.getName(), column.getType()))
+                .collect(toImmutableList()));
+
+        plan = new RelationPlan(
+                projectNode,
+                relationType,
+                projectNode.getOutputSymbols(),
+                plan.getSampleWeight());
 
         return createTableWriterPlan(
                 analysis,
-                createRelationPlan(analysis),
-                new InsertReference(target),
-                getVisibleColumnNames(tableMetadata));
+                plan,
+                new InsertReference(insert.getTarget()),
+                visibleTableColumnNames);
     }
 
     private RelationPlan createTableWriterPlan(Analysis analysis, RelationPlan plan, WriterTarget target, List<String> columnNames)
@@ -226,13 +258,5 @@ public class LogicalPlanner
             columns.add(new ColumnMetadata(field.getName().get(), field.getType(), false));
         }
         return columns.build();
-    }
-
-    private static List<String> getVisibleColumnNames(TableMetadata tableMetadata)
-    {
-        return tableMetadata.getColumns().stream()
-                .filter(column -> !column.isHidden())
-                .map(ColumnMetadata::getName)
-                .collect(toImmutableList());
     }
 }

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -37,7 +37,7 @@ statement
         '(' tableElement (',' tableElement)* ')'
         (WITH tableProperties)?                                        #createTable
     | DROP TABLE (IF EXISTS)? qualifiedName                            #dropTable
-    | INSERT INTO qualifiedName query                                  #insertInto
+    | INSERT INTO qualifiedName columnAliases? query                   #insertInto
     | DELETE FROM qualifiedName (WHERE booleanExpression)?             #delete
     | ALTER TABLE from=qualifiedName RENAME TO to=qualifiedName        #renameTable
     | ALTER TABLE tableName=qualifiedName

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -705,6 +705,12 @@ public final class SqlFormatter
                     .append(node.getTarget())
                     .append(" ");
 
+            if (node.getColumns().isPresent()) {
+                builder.append("(")
+                        .append(Joiner.on(", ").join(node.getColumns().get()))
+                        .append(") ");
+            }
+
             process(node.getQuery(), indent);
 
             return null;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -186,7 +186,10 @@ class AstBuilder
     @Override
     public Node visitInsertInto(SqlBaseParser.InsertIntoContext context)
     {
-        return new Insert(getQualifiedName(context.qualifiedName()), (Query) visit(context.query()));
+        return new Insert(
+                getQualifiedName(context.qualifiedName()),
+                Optional.ofNullable(getColumnAliases(context.columnAliases())),
+                (Query) visit(context.query()));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Insert.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Insert.java
@@ -13,7 +13,9 @@
  */
 package com.facebook.presto.sql.tree;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -23,16 +25,23 @@ public final class Insert
 {
     private final QualifiedName target;
     private final Query query;
+    private final Optional<List<String>> columns;
 
-    public Insert(QualifiedName target, Query query)
+    public Insert(QualifiedName target, Optional<List<String>> columns, Query query)
     {
         this.target = requireNonNull(target, "target is null");
+        this.columns = requireNonNull(columns, "columns is null");
         this.query = requireNonNull(query, "query is null");
     }
 
     public QualifiedName getTarget()
     {
         return target;
+    }
+
+    public Optional<List<String>> getColumns()
+    {
+        return columns;
     }
 
     public Query getQuery()
@@ -49,7 +58,7 @@ public final class Insert
     @Override
     public int hashCode()
     {
-        return Objects.hash(target, query);
+        return Objects.hash(target, columns, query);
     }
 
     @Override
@@ -63,6 +72,7 @@ public final class Insert
         }
         Insert o = (Insert) obj;
         return Objects.equals(target, o.target) &&
+                Objects.equals(columns, o.columns) &&
                 Objects.equals(query, o.query);
     }
 
@@ -71,6 +81,7 @@ public final class Insert
     {
         return toStringHelper(this)
                 .add("target", target)
+                .add("columns", columns)
                 .add("query", query)
                 .toString();
     }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -855,8 +855,14 @@ public class TestSqlParser
     public void testInsertInto()
             throws Exception
     {
+        QualifiedName table = QualifiedName.of("a");
+        Query query = simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t")));
+
         assertStatement("INSERT INTO a SELECT * FROM t",
-                new Insert(QualifiedName.of("a"), simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t")))));
+                new Insert(table, Optional.empty(), query));
+
+        assertStatement("INSERT INTO a (c1, c2) SELECT * FROM t",
+                new Insert(table, Optional.of(ImmutableList.of("c1", "c2")), query));
     }
 
     @Test

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
@@ -177,6 +177,9 @@ public class TestStatementBuilder
         printStatement("create or replace view foo as select 123 from t");
 
         printStatement("drop view foo");
+
+        printStatement("insert into t select * from t");
+        printStatement("insert into t (c1, c2) select * from t");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -279,12 +279,23 @@ public abstract class AbstractTestDistributedQueries
     {
         @Language("SQL") String query = "SELECT orderdate, orderkey FROM orders";
 
-        assertQuery("CREATE TABLE test_insert AS " + query, "SELECT count(*) FROM orders");
-        assertQuery("SELECT * FROM test_insert", query);
+        assertQuery("CREATE TABLE test_insert AS " + query + " WITH NO DATA", "SELECT 0");
+        assertQuery("SELECT count(*) FROM test_insert", "SELECT 0");
 
         assertQuery("INSERT INTO test_insert " + query, "SELECT count(*) FROM orders");
 
-        assertQuery("SELECT * FROM test_insert", query + " UNION ALL " + query);
+        assertQuery("SELECT * FROM test_insert", query);
+
+        assertQuery("INSERT INTO test_insert (orderkey) VALUES (-1)", "SELECT 1");
+        assertQuery("INSERT INTO test_insert (orderdate) VALUES (DATE '2001-01-01')", "SELECT 1");
+        assertQuery("INSERT INTO test_insert (orderkey, orderdate) VALUES (-2, DATE '2001-01-02')", "SELECT 1");
+        assertQuery("INSERT INTO test_insert (orderdate, orderkey) VALUES (DATE '2001-01-03', -3)", "SELECT 1");
+
+        assertQuery("SELECT * FROM test_insert", query
+                + " UNION ALL SELECT null, -1"
+                + " UNION ALL SELECT DATE '2001-01-01', null"
+                + " UNION ALL SELECT DATE '2001-01-02', -2"
+                + " UNION ALL SELECT DATE '2001-01-03', -3");
 
         assertQueryTrue("DROP TABLE test_insert");
     }


### PR DESCRIPTION
Insert into a table with a list of columns

Now it is possible to specify list of columns with INSERT INTO e.g.
INSERT INTO orders (orderkey) VALUES(1);

When the list of column names is specified the columns produced by the
query must exactly match to them. Each column not being present in
the column list will be filled with a ``null`` value.
In case the list of column names is not given then the columns produced
by query must exactly match the columns in the table being inserted
into.

When the list of columns is present then there is added additional
ProjectNode to logical plan which represents mapping between query
columns and table columns. Also it takes care of table columns not
present in a list.
