### PR TITLE
Fixes of two bugs in CREATE TABLE AS SELECT WITH NO DATA

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -500,7 +500,7 @@ class StatementAnalyzer
         }
         accessControl.checkCanCreateTable(session.getIdentity(), targetTable);
 
-        analysis.setCreateTableAsSelectWithData(node.getWithData());
+        analysis.setCreateTableAsSelectWithData(node.isWithData());
 
         // analyze the query that creates the table
         TupleDescriptor descriptor = process(node.getQuery(), context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -617,6 +617,10 @@ public final class SqlFormatter
             builder.append(" AS ");
             process(node.getQuery(), indent);
 
+            if (! node.isWithData()) {
+                builder.append("WITH NO DATA");
+            }
+
             return null;
         }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTableAsSelect.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTableAsSelect.java
@@ -52,7 +52,7 @@ public class CreateTableAsSelect
         return properties;
     }
 
-    public boolean getWithData()
+    public boolean isWithData()
     {
         return withData;
     }
@@ -66,7 +66,7 @@ public class CreateTableAsSelect
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, query, properties);
+        return Objects.hash(name, query, properties, withData);
     }
 
     @Override
@@ -81,7 +81,8 @@ public class CreateTableAsSelect
         CreateTableAsSelect o = (CreateTableAsSelect) obj;
         return Objects.equals(name, o.name)
                 && Objects.equals(query, o.query)
-                && Objects.equals(properties, o.properties);
+                && Objects.equals(properties, o.properties)
+                && Objects.equals(withData, o.withData);
     }
 
     @Override

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
@@ -129,6 +129,7 @@ public class TestStatementBuilder
 
         printStatement("create table foo as (select * from abc)");
         printStatement("create table foo with (a = 'apple', b = 'banana') as select * from abc");
+        printStatement("create table foo as select * from abc WITH NO DATA");
         printStatement("drop table foo");
 
         printStatement("insert into foo select * from abc");


### PR DESCRIPTION
Fixes of two bugs in CREATE TABLE AS SELECT WITH NO DATA

 - CreateTableAsSelect did not take into account withData field for
 equals and hashCode methods
 - SqlFormatter did not take into account that CREATE TABLE AS SELECT
 can be WITH NO DATA

Additionally, getter CreateTableAsSelect.withData was renamed from
getWithData to isWithData
