### PR TITLE
bugfix in AbstractTestQueryFramework

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -53,7 +53,7 @@ public abstract class AbstractTestQueryFramework
     }
 
     @AfterClass(alwaysRun = true)
-    private void close()
+    public void close()
             throws Exception
     {
         try {


### PR DESCRIPTION
bugfix in AbstractTestQueryFramework

close() method was annotated with @AfterClass but was private because of
that it was not called and testng didn't failed.
Making this method public nicely closes h2 and presto query runners.
