### PR TITLE
Use non-deprecated Parquet API to create splits

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -362,8 +362,7 @@ public class ParquetHiveRecordCursor
             FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
 
-            MessageType schema = fileMetaData.getSchema();
-            PrestoReadSupport readSupport = new PrestoReadSupport(useParquetColumnNames, columns, schema);
+            PrestoReadSupport readSupport = new PrestoReadSupport(useParquetColumnNames, columns, fileSchema);
 
             List<parquet.schema.Type> fields = columns.stream()
                     .filter(column -> !column.isPartitionKey())


### PR DESCRIPTION
This PR updates `ParquetHiveRecordCursor` to use the non-deprecated API for creating `ParquetInputSplit`s.