### PR TITLE
Add a math function "cut" to support precision cut of double value

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -106,6 +106,14 @@ Mathematical Functions
 
     Returns ``x`` rounded to ``d`` decimal places.
 
+.. function:: cut(x) -> [same as input]
+
+    Returns ``x`` cut to the nearest integer.
+
+.. function:: cut(x, d) -> [same as input]
+
+    Returns ``x`` cut to ``d`` decimal places.
+
 .. function:: sqrt(x) -> double
 
     Returns the square root of ``x``.

--- a/presto-docs/src/main/sphinx/release/release-0.124.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.124.rst
@@ -7,6 +7,8 @@ General Changes
 
 * The :func:`approx_percentile` aggregation now also accepts an array of percentages.
 
+* Add math :func:`cut` which supports precision cut to the specific decimal.
+
 Hive Changes
 ------------
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -20,6 +20,8 @@ import com.facebook.presto.type.SqlType;
 import com.google.common.primitives.Doubles;
 import io.airlift.slice.Slice;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -279,6 +281,38 @@ public final class MathFunctions
 
         double factor = Math.pow(10, decimals);
         return Math.floor(num * factor + 0.5) / factor;
+    }
+
+    @Description("cut to nearest integer")
+    @ScalarFunction
+    @SqlType(StandardTypes.BIGINT)
+    public static long cut(@SqlType(StandardTypes.BIGINT) long num)
+    {
+        return cut(num, 0);
+    }
+
+    @Description("cut to nearest integer")
+    @ScalarFunction
+    @SqlType(StandardTypes.BIGINT)
+    public static long cut(@SqlType(StandardTypes.BIGINT) long num, @SqlType(StandardTypes.BIGINT) long decimals)
+    {
+        return num;
+    }
+
+    @Description("cut to nearest integer")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double cut(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return cut(num, 0);
+    }
+
+    @Description("cut to given number of decimal places")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double cut(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.BIGINT) long decimals)
+    {
+        return new BigDecimal(num).setScale((int) decimals, RoundingMode.DOWN).doubleValue();
     }
 
     @Description("sine")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -382,13 +382,58 @@ public class TestMathFunctions
     }
 
     @Test
+    public void testCut()
+    {
+        assertFunction("cut( 3)", BIGINT, 3);
+        assertFunction("cut(-3)", BIGINT, -3);
+        assertFunction("cut(CAST(NULL as BIGINT))", BIGINT, null);
+        assertFunction("cut( 3.0)", DOUBLE, 3.0);
+        assertFunction("cut(-3.0)", DOUBLE, -3.0);
+        assertFunction("cut( 3.499)", DOUBLE, 3.0);
+        assertFunction("cut(-3.499)", DOUBLE, -3.0);
+        assertFunction("cut( 3.5)", DOUBLE, 3.0);
+        assertFunction("cut(-3.5)", DOUBLE, -3.0);
+        assertFunction("cut(-3.5001)", DOUBLE, -3.0);
+        assertFunction("cut(-3.99)", DOUBLE, -3.0);
+        assertFunction("cut(CAST(NULL as DOUBLE))", DOUBLE, null);
+
+        assertFunction("cut( 3, 0)", BIGINT, 3);
+        assertFunction("cut(-3, 0)", BIGINT, -3);
+        assertFunction("cut( 3.0, 0)", DOUBLE, 3.0);
+        assertFunction("cut(-3.0, 0)", DOUBLE, -3.0);
+        assertFunction("cut( 3.499, 0)", DOUBLE, 3.0);
+        assertFunction("cut(-3.499, 0)", DOUBLE, -3.0);
+        assertFunction("cut( 3.5, 0)", DOUBLE, 3.0);
+        assertFunction("cut(-3.5, 0)", DOUBLE, -3.0);
+        assertFunction("cut(-3.5001, 0)", DOUBLE, -3.0);
+        assertFunction("cut(-3.99, 0)", DOUBLE, -3.0);
+
+        assertFunction("cut( 3, 1)", BIGINT, 3);
+        assertFunction("cut(-3, 1)", BIGINT, -3);
+        assertFunction("cut(CAST(NULL as BIGINT), CAST(NULL as BIGINT))", BIGINT, null);
+        assertFunction("cut(-3, CAST(NULL as BIGINT))", BIGINT, null);
+        assertFunction("cut(CAST(NULL as BIGINT), 1)", BIGINT, null);
+        assertFunction("cut( 3.0, 1)", DOUBLE, 3.0);
+        assertFunction("cut(-3.0, 1)", DOUBLE, -3.0);
+        assertFunction("cut( 3.499, 1)", DOUBLE, 3.4);
+        assertFunction("cut(-3.499, 1)", DOUBLE, -3.4);
+        assertFunction("cut( 3.5, 1)", DOUBLE, 3.5);
+        assertFunction("cut(-3.5, 1)", DOUBLE, -3.5);
+        assertFunction("cut(-3.5001, 1)", DOUBLE, -3.5);
+        assertFunction("cut(-3.99, 1)", DOUBLE, -3.9);
+        assertFunction("cut(-3.99, 10000)", DOUBLE, -3.99);
+        assertFunction("cut(CAST(NULL as DOUBLE), CAST(NULL as BIGINT))", DOUBLE, null);
+        assertFunction("cut(-3.0, CAST(NULL as BIGINT))", DOUBLE, null);
+        assertFunction("cut(CAST(NULL as DOUBLE), 1)", DOUBLE, null);
+    }
+
+    @Test
     public void testSin()
     {
         for (double doubleValue : DOUBLE_VALUES) {
             assertFunction("sin(" + doubleValue + ")", DOUBLE, Math.sin(doubleValue));
         }
         assertFunction("sin(NULL)", DOUBLE, null);
-
     }
 
     @Test


### PR DESCRIPTION
Add a function cut(x, d) to cut the precision of a double value to a specific decimal. This can help us to do the checksum over the double value columns.   