### PR TITLE
Fix correctness for certain types of IN lists

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.124.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.124.rst
@@ -8,6 +8,10 @@ General Changes
 * Fix race in memory tracking of ``JOIN`` which could cause the cluster to become over
   committed and possibly crash.
 * The :func:`approx_percentile` aggregation now also accepts an array of percentages.
+* Fix correctness for some queries with ``IN`` lists. When all constants in the
+  list are in the range of 32-bit signed integers but the test value can be
+  outside of the range, ``true`` may be produced when the correct result should
+  be ``false``.
 
 Hive Changes
 ------------

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/InCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/InCodeGenerator.java
@@ -182,6 +182,13 @@ public class InCodeGenerator
                 switchBlock = new ByteCodeBlock()
                         .comment("lookupSwitch(<stackValue>))")
                         .dup(javaType)
+                        .append(new IfStatement()
+                                .condition(new ByteCodeBlock()
+                                        .dup(javaType)
+                                        .invokeStatic(InCodeGenerator.class, "isInteger", boolean.class, long.class))
+                                .ifFalse(new ByteCodeBlock()
+                                        .pop(javaType)
+                                        .gotoLabel(defaultLabel)))
                         .longToInt()
                         .append(switchBuilder.build());
                 break;
@@ -255,6 +262,11 @@ public class InCodeGenerator
         block.visitLabel(end);
 
         return block;
+    }
+
+    public static boolean isInteger(long value)
+    {
+        return value == (int) value;
     }
 
     private ByteCodeBlock buildInCase(ByteCodeGeneratorContext generatorContext,

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3381,6 +3381,8 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT x FROM (values 1, 2, 3, 4) t(x) WHERE x IN (1 + cast(rand() < 0 as bigint), 2 + cast(rand() < 0 as bigint), 4)", "values 1, 2, 4");
         assertQuery("SELECT x FROM (values 1, 2, 3, 4) t(x) WHERE x IN (4, 2, 1)", "values 1, 2, 4");
         assertQuery("SELECT x FROM (values 1, 2, 3, 2147483648) t(x) WHERE x IN (1 + cast(rand() < 0 as bigint), 2 + cast(rand() < 0 as bigint), 2147483648)", "values 1, 2, 2147483648");
+        assertQuery("SELECT x IN (0) FROM (values 4294967296) t(x)", "values false");
+        assertQuery("SELECT x IN (0, 4294967297 + cast(rand() < 0 as bigint)) FROM (values 4294967296, 4294967297) t(x)", "values false, true");
         assertQuery("SELECT NULL in (1, 2, 3)", "values null");
         assertQuery("SELECT 1 in (1, NULL, 3)", "values true");
         assertQuery("SELECT 2 in (1, NULL, 3)", "values null");


### PR DESCRIPTION
In a query of shape `x in (1, 3, 101)`. If all the constant values in the list
is within the range of 32-bit signed integer, high-bits in `x` will be
truncated. As a result, `true` can potentially be returned when the correct
result is `false`.