### PR TITLE
Handle unknown type in array contains

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayContains.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayContains.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
+import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.metadata.FunctionType.SCALAR;
@@ -47,6 +48,7 @@ public final class ArrayContains
     private static final TypeSignature RETURN_TYPE = parseTypeSignature(StandardTypes.BOOLEAN);
     private static final String FUNCTION_NAME = "contains";
     private static final Signature SIGNATURE = new Signature(FUNCTION_NAME, SCALAR, ImmutableList.of(comparableTypeParameter("T")), StandardTypes.BOOLEAN, ImmutableList.of("array<T>", "T"), false);
+    private static final MethodHandle METHOD_HANDLE_UNKNOWN = methodHandle(ArrayContains.class, "arrayWithUnknownType", Type.class, MethodHandle.class, Block.class, Void.class);
 
     @Override
     public Signature getSignature()
@@ -78,11 +80,27 @@ public final class ArrayContains
         Type type = types.get("T");
         TypeSignature valueType = type.getTypeSignature();
         TypeSignature arrayType = parameterizedTypeName(StandardTypes.ARRAY, valueType);
-        MethodHandle methodHandle = methodHandle(ArrayContains.class, "contains", Type.class, MethodHandle.class, Block.class, type.getJavaType());
-        MethodHandle equalsHandle = functionRegistry.getScalarFunctionImplementation(internalOperator(OperatorType.EQUAL, BooleanType.BOOLEAN, ImmutableList.of(type, type))).getMethodHandle();
-        Signature signature = new Signature(FUNCTION_NAME, SCALAR, RETURN_TYPE, arrayType, valueType);
 
-        return new FunctionInfo(signature, getDescription(), isHidden(), methodHandle.bindTo(type).bindTo(equalsHandle), isDeterministic(), true, ImmutableList.of(false, false));
+        MethodHandle methodHandle;
+        MethodHandle equalsHandle = functionRegistry.getScalarFunctionImplementation(internalOperator(OperatorType.EQUAL, BooleanType.BOOLEAN, ImmutableList.of(type, type))).getMethodHandle();
+
+        List<Boolean> nullableArguments;
+        if (type.getJavaType() == void.class) {
+            nullableArguments = ImmutableList.of(false, true);
+            methodHandle = METHOD_HANDLE_UNKNOWN;
+        }
+        else {
+            nullableArguments = ImmutableList.of(false, false);
+            methodHandle = methodHandle(ArrayContains.class, "contains", Type.class, MethodHandle.class, Block.class, type.getJavaType());
+        }
+
+        Signature signature = new Signature(FUNCTION_NAME, SCALAR, RETURN_TYPE, arrayType, valueType);
+        return new FunctionInfo(signature, getDescription(), isHidden(), methodHandle.bindTo(type).bindTo(equalsHandle), isDeterministic(), true, nullableArguments);
+    }
+
+    public static Boolean arrayWithUnknownType(Type elementType, MethodHandle equals, Block arrayBlock, Void value)
+    {
+        return null;
     }
 
     public static Boolean contains(Type elementType, MethodHandle equals, Block arrayBlock, Block value)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -235,6 +235,7 @@ public class TestArrayOperators
         assertFunction("CONTAINS(ARRAY [ARRAY [1, 2], ARRAY [3, 4]], ARRAY [3])", BOOLEAN, false);
         assertFunction("CONTAINS(ARRAY [CAST (NULL AS BIGINT)], 1)", BOOLEAN, null);
         assertFunction("CONTAINS(ARRAY [CAST (NULL AS BIGINT)], NULL)", BOOLEAN, null);
+        assertFunction("CONTAINS(ARRAY [], NULL)", BOOLEAN, null);
     }
 
     @Test


### PR DESCRIPTION
The following query fails with the exception below:

```Sql
SELECT CONTAINS(ARRAY [], null);
```

```Java
Caused by: java.lang.NoSuchMethodException: com.facebook.presto.operator.scalar.ArrayContains.contains(com.facebook.presto.spi.type.Type, java.lang.invoke.MethodHandle, com.facebook.presto.spi.block.Block, void)
	at java.lang.Class.getMethod(Class.java:1786)
	at com.facebook.presto.util.Reflection.methodHandle(Reflection.java:52)
	... 67 more
```

This PR fixes the problem by handling the unknown type in the array contains implementation.