### PR TITLE
Fix NPE in presto-cli auto-completion

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/TableNameCompleter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/TableNameCompleter.java
@@ -107,18 +107,22 @@ public class TableNameCompleter
         int blankPos = findLastBlank(buffer.substring(0, cursor));
         String prefix = buffer.substring(blankPos + 1, cursor);
         String schemaName = queryRunner.getSession().getSchema();
-        List<String> functionNames = functionCache.getIfPresent(schemaName);
-        List<String> tableNames = tableCache.getIfPresent(schemaName);
 
-        SortedSet<String> sortedCandidates = new TreeSet<>();
-        if (functionNames != null) {
-            sortedCandidates.addAll(filterResults(functionNames, prefix));
-        }
-        if (tableNames != null) {
-            sortedCandidates.addAll(filterResults(tableNames, prefix));
+        if (schemaName != null) {
+            List<String> functionNames = functionCache.getIfPresent(schemaName);
+            List<String> tableNames = tableCache.getIfPresent(schemaName);
+
+            SortedSet<String> sortedCandidates = new TreeSet<>();
+            if (functionNames != null) {
+                sortedCandidates.addAll(filterResults(functionNames, prefix));
+            }
+            if (tableNames != null) {
+                sortedCandidates.addAll(filterResults(tableNames, prefix));
+            }
+
+            candidates.addAll(sortedCandidates);
         }
 
-        candidates.addAll(sortedCandidates);
         return blankPos + 1;
     }
 

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestTableNameCompleter.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestTableNameCompleter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cli;
+
+import com.facebook.presto.client.ClientSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.HostAndPort;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestTableNameCompleter
+{
+    @Test
+    public void testAutoCompleteWithoutSchema()
+    {
+        ClientSession session = new ClientOptions().toClientSession();
+        QueryRunner runner = QueryRunner.create(session,
+                Optional.<HostAndPort>empty(),
+                Optional.<String>empty(),
+                Optional.<String>empty(),
+                Optional.<String>empty(),
+                Optional.<String>empty(),
+                false,
+                null);
+        TableNameCompleter completer = new TableNameCompleter(runner);
+        assertEquals(completer.complete("SELECT is_infi", 14, ImmutableList.of()), 7);
+    }
+}


### PR DESCRIPTION
When the schema is `null` `TableNameCompleter` throws NPE and cli terminates.

```Java
[master] ~/other_workspace/presto/presto-cli/target $ ./presto-cli-0.124-SNAPSHOT-executable.jar --debug
presto> select is_infiniException in thread "main" java.lang.NullPointerException
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:210)
	at com.google.common.cache.LocalCache.getIfPresent(LocalCache.java:3925)
	at com.google.common.cache.LocalCache$LocalManualCache.getIfPresent(LocalCache.java:4733)
	at com.facebook.presto.cli.TableNameCompleter.complete(TableNameCompleter.java:110)
	at jline.console.ConsoleReader.complete(ConsoleReader.java:3306)
	at jline.console.ConsoleReader.readLine(ConsoleReader.java:2646)
	at jline.console.ConsoleReader.readLine(ConsoleReader.java:2372)
	at com.facebook.presto.cli.LineReader.readLine(LineReader.java:51)
	at jline.console.ConsoleReader.readLine(ConsoleReader.java:2360)
	at com.facebook.presto.cli.Console.runConsole(Console.java:149)
	at com.facebook.presto.cli.Console.run(Console.java:128)
	at com.facebook.presto.cli.Presto.main(Presto.java:32)
```