### PR TITLE
Add response body to the exception on the cli side

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -276,7 +276,8 @@ public class StatementClient
     {
         gone.set(true);
         if (!response.hasValue()) {
-            return new RuntimeException(format("Error %s at %s returned an invalid response: %s", task, request.getUri(), response), response.getException());
+            return new RuntimeException(format("Error %s at %s returned an invalid response: %s [Error: %s]",
+                    task, request.getUri(), response, response.getResponseBody()), response.getException());
         }
         return new RuntimeException(format("Error %s at %s returned %s: %s", task, request.getUri(), response.getStatusCode(), response.getStatusMessage()));
     }


### PR DESCRIPTION
When the server returns bad request the actual error message ends up in the
response body and it is not propagated properly to the user.