### PR TITLE
Add limited support for cube, rollup and grouping set to grammar

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -59,7 +59,7 @@ public class Analysis
     private final IdentityHashMap<Expression, Integer> resolvedNames = new IdentityHashMap<>();
 
     private final IdentityHashMap<QuerySpecification, List<FunctionCall>> aggregates = new IdentityHashMap<>();
-    private final IdentityHashMap<QuerySpecification, List<FieldOrExpression>> groupByExpressions = new IdentityHashMap<>();
+    private final IdentityHashMap<QuerySpecification, List<List<FieldOrExpression>>> groupByExpressions = new IdentityHashMap<>();
     private final IdentityHashMap<Node, Expression> where = new IdentityHashMap<>();
     private final IdentityHashMap<QuerySpecification, Expression> having = new IdentityHashMap<>();
     private final IdentityHashMap<Node, List<FieldOrExpression>> orderByExpressions = new IdentityHashMap<>();
@@ -172,12 +172,12 @@ public class Analysis
         return coercions.get(expression);
     }
 
-    public void setGroupByExpressions(QuerySpecification node, List<FieldOrExpression> expressions)
+    public void setGroupingSets(QuerySpecification node, List<List<FieldOrExpression>> expressions)
     {
         groupByExpressions.put(node, expressions);
     }
 
-    public List<FieldOrExpression> getGroupByExpressions(QuerySpecification node)
+    public List<List<FieldOrExpression>> getGroupingSets(QuerySpecification node)
     {
         return groupByExpressions.get(node);
     }

--- a/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
@@ -69,7 +69,7 @@ import static java.util.Objects.requireNonNull;
 public class MaterializedResult
         implements Iterable<MaterializedRow>
 {
-    public static final int DEFAULT_PRECISION = 5;
+    public static final int DEFAULT_PRECISION = 4;
 
     private final List<MaterializedRow> rows;
     private final List<Type> types;

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -669,6 +669,39 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testSingleGroupingSet()
+            throws Exception
+    {
+        // TODO: validate output
+        analyze("SELECT a, SUM(b) FROM t1 GROUP BY GROUPING SETS (a)");
+        analyze("SELECT a, SUM(b) FROM t1 GROUP BY GROUPING SETS ((a))");
+    }
+
+    @Test
+    public void testSingleGroupingSetMultipleColumns()
+            throws Exception
+    {
+        // TODO: validate output
+        analyze("SELECT a, SUM(b) FROM t1 GROUP BY GROUPING SETS ((a, b))");
+    }
+
+    @Test
+    public void testMultipleGroupingSetMultipleColumns()
+            throws Exception
+    {
+        // TODO: validate output
+        assertFails(NOT_SUPPORTED, "SELECT a, SUM(b) FROM t1 GROUP BY GROUPING SETS ((a, b), (c, d))");
+    }
+
+    @Test
+    public void testMultipleGroupingSetsMultipleTypes()
+            throws Exception
+    {
+        // TODO: validate output
+        assertFails(NOT_SUPPORTED, "SELECT a, SUM(b) FROM t1 GROUP BY a, b, GROUPING SETS ((c, d))");
+    }
+
+    @Test
     public void testAggregateWithWildcard()
             throws Exception
     {

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -111,8 +111,22 @@ querySpecification
     : SELECT setQuantifier? selectItem (',' selectItem)*
       (FROM relation (',' relation)*)?
       (WHERE where=booleanExpression)?
-      (GROUP BY groupBy+=expression (',' groupBy+=expression)*)?
+      (GROUP BY groupingElement (',' groupingElement)*)?
       (HAVING having=booleanExpression)?
+    ;
+
+groupingElement
+    : simpleGroupByExpressions+=expression (',' simpleGroupByExpressions+=expression)*    #simpleGroupBy
+    | '(' ')'                                                                             #emptyGroupingSet
+    | ROLLUP rollupList=groupingColumnReferenceList                                       #rollupList
+    | CUBE cubeList=groupingColumnReferenceList                                           #cubeList
+    | GROUPING SETS '(' groupingSets+=groupingColumnReferenceList (',' groupingSets+=groupingColumnReferenceList)* ')' #groupingSet
+    ;
+
+groupingColumnReferenceList
+    : '(' qualifiedName (',' qualifiedName)* ')'
+    | qualifiedName
+    | '(' ')'
     ;
 
 namedQuery
@@ -371,6 +385,10 @@ DISTINCT: 'DISTINCT';
 WHERE: 'WHERE';
 GROUP: 'GROUP';
 BY: 'BY';
+GROUPING: 'GROUPING';
+SETS: 'SETS';
+CUBE: 'CUBE';
+ROLLUP: 'ROLLUP';
 ORDER: 'ORDER';
 HAVING: 'HAVING';
 LIMIT: 'LIMIT';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.GroupBySpecification;
 import com.facebook.presto.sql.tree.IfExpression;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -179,13 +180,13 @@ public final class QueryUtil
         return simpleQuery(select, from, where, ImmutableList.of(), Optional.empty(), ordering, Optional.empty());
     }
 
-    public static Query simpleQuery(Select select, Relation from, Optional<Expression> where, List<Expression> grouping, Optional<Expression> having, List<SortItem> ordering, Optional<String> limit)
+    public static Query simpleQuery(Select select, Relation from, Optional<Expression> where, List<GroupBySpecification> groupBy, Optional<Expression> having, List<SortItem> ordering, Optional<String> limit)
     {
         return query(new QuerySpecification(
                 select,
                 Optional.of(from),
                 where,
-                grouping,
+                groupBy,
                 having,
                 ordering,
                 limit));

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -70,6 +70,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static com.facebook.presto.sql.ExpressionFormatter.formatExpression;
+import static com.facebook.presto.sql.ExpressionFormatter.formatGroupBy;
 import static com.facebook.presto.sql.ExpressionFormatter.formatSortItems;
 import static com.facebook.presto.sql.ExpressionFormatter.formatStringLiteral;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -194,8 +195,7 @@ public final class SqlFormatter
             }
 
             if (!node.getGroupBy().isEmpty()) {
-                append(indent, "GROUP BY " + Joiner.on(", ").join(transform(node.getGroupBy(), ExpressionFormatter::formatExpression)))
-                        .append('\n');
+                append(indent, "GROUP BY " + formatGroupBy(node.getGroupBy())).append('\n');
             }
 
             if (node.getHaving().isPresent()) {

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public class Cube
+        extends GroupBySpecification
+{
+    private final List<Expression> columnList;
+
+    public Cube(NodeLocation location, GroupingColumnReferenceList columns)
+    {
+        super(Optional.of(location));
+        requireNonNull(columns, "columns is null");
+        columnList = columns.getGroupingColumns().stream()
+                .map(QualifiedNameReference::new)
+                .collect(toList());
+    }
+
+    public List<Expression> getColumnList()
+    {
+        return columnList;
+    }
+
+    @Override
+    public List<List<Expression>> enumerateGroupingSets()
+    {
+        Set<Set<Expression>> set = Sets.powerSet(ImmutableSet.copyOf(columnList));
+        return set.stream()
+                .map(qualifiedNames -> qualifiedNames.stream()
+                        .collect(toList()))
+                .collect(toList());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Cube cube = (Cube) o;
+        return Objects.equals(columnList, cube.columnList);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(columnList);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("columnList", columnList)
+                .toString();
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -335,8 +335,8 @@ public abstract class DefaultTraversalVisitor<R, C>
         if (node.getWhere().isPresent()) {
             process(node.getWhere().get(), context);
         }
-        for (Expression expression : node.getGroupBy()) {
-            process(expression, context);
+        for (GroupBySpecification groupBySpecification : node.getGroupBy()) {
+            process(groupBySpecification, context);
         }
         if (node.getHaving().isPresent()) {
             process(node.getHaving().get(), context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/EmptyGroupingSet.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/EmptyGroupingSet.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class EmptyGroupingSet
+        extends GroupBySpecification
+{
+    public EmptyGroupingSet(NodeLocation location)
+    {
+        super(Optional.of(location));
+    }
+
+    @Override
+    public List<List<Expression>> enumerateGroupingSets()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        return this == o || (o != null && getClass() == o.getClass());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return 0;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this).toString();
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupBySpecification.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupBySpecification.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.List;
+import java.util.Optional;
+
+public abstract class GroupBySpecification
+        extends Node
+{
+    public GroupBySpecification(Optional<NodeLocation> location)
+    {
+        super(location);
+    }
+
+    public abstract List<List<Expression>> enumerateGroupingSets();
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingColumnReferenceList.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingColumnReferenceList.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.tree;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class GroupingColumnReferenceList
+    extends Node
+{
+    private final List<QualifiedName> groupingColumns;
+
+    public GroupingColumnReferenceList(NodeLocation location, List<QualifiedName> groupingColumns)
+    {
+        super(Optional.of(location));
+        this.groupingColumns = requireNonNull(groupingColumns);
+    }
+
+    public List<QualifiedName> getGroupingColumns()
+    {
+        return groupingColumns;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("groupingColumns", groupingColumns)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GroupingColumnReferenceList that = (GroupingColumnReferenceList) o;
+
+        return groupingColumns.equals(that.groupingColumns);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return groupingColumns.hashCode();
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class GroupingSets
+        extends GroupBySpecification
+{
+    private final List<List<Expression>> sets;
+
+    public GroupingSets(NodeLocation location, List<GroupingColumnReferenceList> groupingSetList)
+    {
+        super(Optional.of(location));
+        sets = groupingSetList.stream()
+                .map(groupingColumnReferenceList -> groupingColumnReferenceList.getGroupingColumns().stream()
+                        .map(QualifiedNameReference::new)
+                        .collect(Collectors.<Expression>toList()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<List<Expression>> enumerateGroupingSets()
+    {
+        return sets;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GroupingSets groupingSets = (GroupingSets) o;
+        return Objects.equals(sets, groupingSets.sets);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sets);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("sets", sets)
+                .toString();
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/QuerySpecification.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/QuerySpecification.java
@@ -26,7 +26,7 @@ public class QuerySpecification
     private final Select select;
     private final Optional<Relation> from;
     private final Optional<Expression> where;
-    private final List<Expression> groupBy;
+    private final List<GroupBySpecification> groupBy;
     private final Optional<Expression> having;
     private final List<SortItem> orderBy;
     private final Optional<String> limit;
@@ -35,7 +35,7 @@ public class QuerySpecification
             Select select,
             Optional<Relation> from,
             Optional<Expression> where,
-            List<Expression> groupBy,
+            List<GroupBySpecification> groupBy,
             Optional<Expression> having,
             List<SortItem> orderBy,
             Optional<String> limit)
@@ -48,7 +48,7 @@ public class QuerySpecification
             Select select,
             Optional<Relation> from,
             Optional<Expression> where,
-            List<Expression> groupBy,
+            List<GroupBySpecification> groupBy,
             Optional<Expression> having,
             List<SortItem> orderBy,
             Optional<String> limit)
@@ -61,7 +61,7 @@ public class QuerySpecification
             Select select,
             Optional<Relation> from,
             Optional<Expression> where,
-            List<Expression> groupBy,
+            List<GroupBySpecification> groupBy,
             Optional<Expression> having,
             List<SortItem> orderBy,
             Optional<String> limit)
@@ -99,7 +99,7 @@ public class QuerySpecification
         return where;
     }
 
-    public List<Expression> getGroupBy()
+    public List<GroupBySpecification> getGroupBy()
     {
         return groupBy;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public class Rollup
+        extends GroupBySpecification
+{
+    private final List<Expression> columnList;
+
+    public Rollup(NodeLocation location, GroupingColumnReferenceList columns)
+    {
+        super(Optional.of(location));
+        requireNonNull(columns, "columns is null");
+        columnList = columns.getGroupingColumns().stream()
+                .map(QualifiedNameReference::new)
+                .collect(toList());
+    }
+
+    public List<Expression> getColumnList()
+    {
+        return columnList;
+    }
+
+    @Override
+    public List<List<Expression>> enumerateGroupingSets()
+    {
+        int numColumns = columnList.size();
+        List<List<Expression>> enumeratedGroupingSets = IntStream.range(0, numColumns)
+                .mapToObj(i -> columnList.subList(0, numColumns - i))
+                .collect(toList());
+        enumeratedGroupingSets.add(ImmutableList.of());
+        return enumeratedGroupingSets;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Rollup rollup = (Rollup) o;
+        return Objects.equals(columnList, rollup.columnList);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(columnList);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("columnList", columnList)
+                .toString();
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleGroupBy.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleGroupBy.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class SimpleGroupBy
+    extends GroupBySpecification
+{
+    private final List<Expression> columnList;
+
+    public SimpleGroupBy(List<Expression> simpleGroupByExpressions)
+    {
+        this(Optional.empty(), simpleGroupByExpressions);
+    }
+
+    public SimpleGroupBy(NodeLocation location, List<Expression> simpleGroupByExpressions)
+    {
+        this(Optional.of(location), simpleGroupByExpressions);
+    }
+
+    private SimpleGroupBy(Optional<NodeLocation> location, List<Expression> simpleGroupByExpressions)
+    {
+        super(location);
+        this.columnList = simpleGroupByExpressions;
+    }
+
+    public List<Expression> getColumnList()
+    {
+        return columnList;
+    }
+
+    @Override
+    public List<List<Expression>> enumerateGroupingSets()
+    {
+        return ImmutableList.of(columnList);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SimpleGroupBy that = (SimpleGroupBy) o;
+        return Objects.equals(columnList, that.columnList);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(columnList);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("columnList", columnList)
+                .toString();
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1233,6 +1233,23 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testSingleGroupingSet()
+            throws Exception
+    {
+        assertQuery(
+                "SELECT orderstatus, SUM(totalprice) FROM ORDERS GROUP BY GROUPING SETS (orderstatus)",
+                "SELECT orderstatus, SUM(totalprice) FROM ORDERS GROUP BY orderstatus");
+    }
+
+    @Test
+    public void testSingleGroupingSetMultipleColumns()
+            throws Exception
+    {
+        assertQuery("SELECT custkey, orderstatus, SUM(totalprice) FROM ORDERS GROUP BY GROUPING SETS (custkey, orderstatus) ORDER BY 3",
+                "SELECT custkey, orderstatus, SUM(totalprice) FROM ORDERS GROUP BY custkey, orderstatus ORDER BY 3");
+    }
+
+    @Test
     public void testCountAllWithComparison()
             throws Exception
     {


### PR DESCRIPTION
- Add CUBE, ROLLUP and simple GROUPING SETS (i.e. one-level of nesting)
to grammar.
- Add analyzer support for simple grouping sets.
- Add planning and execution support for queries with a single
grouping set (this is essentially a simple GROUP BY).