### PR TITLE
Fix property derivations for partitioned right or full joins

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.125
     release/release-0.124
     release/release-0.123
     release/release-0.122

--- a/presto-docs/src/main/sphinx/release/release-0.125.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.125.rst
@@ -1,0 +1,11 @@
+=============
+Release 0.125
+=============
+
+General Changes
+---------------
+
+* Fix an issue where certain operations such as ``GROUP BY``, ``DISTINCT``, etc. on the
+  output of a ``RIGHT`` or ``FULL OUTER JOIN`` can return incorrect results if they reference columns
+  from the left relation that are also used in the join clause, and not every row from the right relation
+  has a match.

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -291,12 +291,22 @@ class PropertyDerivations
             // TODO: include all equivalent columns in partitioning properties
             ActualProperties probeProperties = inputProperties.get(0);
             ActualProperties indexProperties = inputProperties.get(1);
-            return ActualProperties.builderFrom(probeProperties)
-                    .constants(ImmutableMap.<Symbol, Object>builder()
-                            .putAll(probeProperties.getConstants())
-                            .putAll(indexProperties.getConstants())
-                            .build())
-                    .build();
+
+            switch (node.getType()) {
+                case INNER:
+                    return ActualProperties.builderFrom(probeProperties)
+                            .constants(ImmutableMap.<Symbol, Object>builder()
+                                    .putAll(probeProperties.getConstants())
+                                    .putAll(indexProperties.getConstants())
+                                    .build())
+                            .build();
+                case SOURCE_OUTER:
+                    return ActualProperties.builderFrom(probeProperties)
+                            .constants(probeProperties.getConstants())
+                            .build();
+                default:
+                    throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
+            }
         }
 
         @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1780,6 +1780,30 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testOuterJoinWithNullsOnProbe()
+            throws Exception
+    {
+        assertQuery(
+                "SELECT DISTINCT a.orderkey FROM " +
+                        "(SELECT CASE WHEN orderkey > 10 THEN orderkey END orderkey FROM orders) a " +
+                        "RIGHT OUTER JOIN orders b ON a.orderkey = b.orderkey");
+
+        assertQuery(
+                "SELECT DISTINCT a.orderkey FROM " +
+                        "(SELECT CASE WHEN orderkey > 2 THEN orderkey END orderkey FROM orders) a " +
+                        "FULL OUTER JOIN orders b ON a.orderkey = b.orderkey",
+                "SELECT DISTINCT orderkey FROM (" +
+                        "SELECT a.orderkey FROM " +
+                        "(SELECT CASE WHEN orderkey > 2 THEN orderkey END orderkey FROM orders) a " +
+                        "RIGHT OUTER JOIN orders b ON a.orderkey = b.orderkey " +
+                        "UNION ALL " +
+                        "SELECT a.orderkey FROM" +
+                        "(SELECT CASE WHEN orderkey > 2 THEN orderkey END orderkey FROM orders) a " +
+                        "LEFT OUTER JOIN orders b ON a.orderkey = b.orderkey " +
+                        "WHERE a.orderkey IS NULL)");
+    }
+
+    @Test
     public void testSimpleLeftJoin()
             throws Exception
     {


### PR DESCRIPTION
The derived properties of a hash-partitioned right or full join are currently
derived incorrectly from the properties of the probe side. Since this kind of join
can produce nulls from any of the partitions in case of a lack of matches,
the partitioning properties are violated for nulls.

This is problematic for queries that can benefit from the partitioning properties
after the join to avoid a reshuffle (e.g., an group by aggregation on the join key),
and may result in wrong results if the join produces any nulls on the probe side.

E.g.,

```sql
SELECT a.orderkey, count(*)
FROM (
   SELECT CASE WHEN orderkey > 2 THEN orderkey END orderkey
   FROM orders
   WHERE orderkey < 20
) a RIGHT OUTER JOIN (
   SELECT orderkey
   FROM orders
   WHERE orderkey < 20) b
ON a.orderkey = b.orderkey
GROUP BY 1;
```

Produces:

```
 orderkey | _col1
----------+-------
 NULL     |     1    <<<<<
 NULL     |     1    <<<<<
        4 |     1
        3 |     1
        7 |     1
        6 |     1
        5 |     1
(7 rows)
```