### PR TITLE
Convert type to appropriate hive type when adding a new column

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -507,7 +507,7 @@ public class HiveMetadata
 
         ImmutableList.Builder<FieldSchema> columns = ImmutableList.builder();
         columns.addAll(sd.getCols());
-        columns.add(new FieldSchema(column.getName(), column.getType().getDisplayName(), column.getComment()));
+        columns.add(new FieldSchema(column.getName(), toHiveType(column.getType()).getHiveTypeName(), column.getComment()));
         sd.setCols(columns.build());
 
         table.setSd(sd);


### PR DESCRIPTION
This PR converts a column's type to the appropriate Hive type for `alter table` statements.
