### PR TITLE
Some fixes for the Tableau web connector

### DIFF
--- a/presto-docs/src/main/sphinx/tableau.rst
+++ b/presto-docs/src/main/sphinx/tableau.rst
@@ -14,14 +14,22 @@ where ``presto_coordinator_host`` is the hostname that Presto coordinator is
 running on, ``port`` is 8080 by default. When Tableau first loads the Presto
 web connector it will render an HTML form. In this form you need to fill in
 details such as your user name, the catalog and the schema you want to query,
-the data source name, and finally the SQL query to run. After you click
-``Submit`` the query will be submitted to the Presto coordinator and Tableau
-will then create an extract out of the results retrieved from the coordinator
-page by page. After Tableau is done extracting the results of your query you
-can then use this extract for further analysis with Tableau.
+the data source name, session parameters you want to set, and finally the SQL
+query to run. After you click ``Submit`` the query will be submitted to the
+Presto coordinator and Tableau will then create an extract out of the results
+retrieved from the coordinator page by page. After Tableau is done extracting
+the results of your query you can then use this extract for further analysis with Tableau.
 
 .. note::
      With Presto web connector you can only create Tableau extracts as the web
      connector API currently doesn't support the live mode.
+
+.. note::
+     Tableau web connector API only supports a subset of the data types available in Presto.
+     In particular, Tableau web connector API currently supports the following data types:
+     bool, date, datetime, float, int, and string. What this means is, only boolean and
+     date columns from Presto will be marked as bool and date on the Tableau client side,
+     and the rest of the Presto types (such as map/row/array, double, bigint, etc.) will
+     be converted to strings as they do not map to any Tableau type.
 
 

--- a/presto-main/src/main/resources/webapp/tableu/presto-connector.html
+++ b/presto-main/src/main/resources/webapp/tableu/presto-connector.html
@@ -28,6 +28,9 @@
                     case 'boolean':
                         columnType = 'bool';
                         break;
+                    case 'date':
+                        columnType = 'date';
+                        break;
                     default:
                         columnType = 'string';
                 }

--- a/presto-main/src/main/resources/webapp/tableu/presto-connector.html
+++ b/presto-main/src/main/resources/webapp/tableu/presto-connector.html
@@ -28,9 +28,6 @@
                     case 'boolean':
                         columnType = 'bool';
                         break;
-                    case 'bigint':
-                        columnType = 'int';
-                        break;
                     default:
                         columnType = 'string';
                 }


### PR DESCRIPTION
@haozhun When the Tableau web connector PR (#3104) was merged last week, two of the commits in that PR were somehow left out (86ca924 and d84d7f6). This PR adds those fixes and updates the connector documentation to document the data type limitations.