### PR TITLE
Add GRANT query support for hive connector

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/NoAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/NoAccessControl.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.ConnectorAccessControl;
 import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
 
 import javax.inject.Inject;
 
@@ -116,6 +117,11 @@ public class NoAccessControl
 
     @Override
     public void checkCanSetCatalogSessionProperty(Identity identity, String propertyName)
+    {
+    }
+
+    @Override
+    public void checkCanGrantTablePrivilege(Identity identity, Privilege privilege, SchemaTableName tableName)
     {
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ReadOnlyAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ReadOnlyAccessControl.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.ConnectorAccessControl;
 import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
 
 import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;
@@ -23,6 +24,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateV
 import static com.facebook.presto.spi.security.AccessDeniedException.denyDeleteTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyDropTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyDropView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyGrantTablePrivilege;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyInsertTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameColumn;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
@@ -112,5 +114,11 @@ public class ReadOnlyAccessControl
     public void checkCanSetCatalogSessionProperty(Identity identity, String propertyName)
     {
         // allow
+    }
+
+    @Override
+    public void checkCanGrantTablePrivilege(Identity identity, Privilege privilege, SchemaTableName tableName)
+    {
+        denyGrantTablePrivilege(privilege.toString(), tableName.toString());
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SqlStandardAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SqlStandardAccessControl.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.metastore.HivePrivilege;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.ConnectorAccessControl;
 import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
 import com.google.common.collect.ImmutableSet;
 
 import javax.inject.Inject;
@@ -35,6 +36,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateV
 import static com.facebook.presto.spi.security.AccessDeniedException.denyDeleteTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyDropTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyDropView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyGrantTablePrivilege;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyInsertTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameColumn;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
@@ -174,6 +176,14 @@ public class SqlStandardAccessControl
     {
         if (!metastore.getRoles(identity.getUser()).contains(ADMIN_ROLE_NAME)) {
             denySetCatalogSessionProperty(connectorId, propertyName);
+        }
+    }
+
+    @Override
+    public void checkCanGrantTablePrivilege(Identity identity, Privilege privilege, SchemaTableName tableName)
+    {
+        if (!checkTablePermission(identity, tableName, OWNERSHIP)) {
+            denyGrantTablePrivilege(privilege.toString(), tableName.toString());
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ThriftHiveMetastoreClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ThriftHiveMetastoreClient.java
@@ -19,6 +19,7 @@ import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
+import org.apache.hadoop.hive.metastore.api.PrivilegeBag;
 import org.apache.hadoop.hive.metastore.api.Role;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
@@ -172,5 +173,12 @@ public class ThriftHiveMetastoreClient
             throws TException
     {
         return client.get_privilege_set(hiveObject, userName, groupNames);
+    }
+
+    @Override
+    public boolean grantPrivileges(PrivilegeBag privilegeBag)
+            throws TException
+    {
+        return client.grant_privileges(privilegeBag);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveMetastore.java
@@ -13,8 +13,10 @@
  */
 package com.facebook.presto.hive.metastore;
 
+import com.facebook.presto.spi.security.Identity;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.PrivilegeGrantInfo;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.weakref.jmx.Managed;
 
@@ -73,6 +75,8 @@ public interface HiveMetastore
     Set<HivePrivilege> getDatabasePrivileges(String user, String databaseName);
 
     Set<HivePrivilege> getTablePrivileges(String user, String databaseName, String tableName);
+
+    void grantTablePrivilege(String databaseName, String tableName, Identity identity, PrivilegeGrantInfo privilege);
 
     default boolean isDatabaseOwner(String user, String databaseName)
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveMetastoreClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveMetastoreClient.java
@@ -18,6 +18,7 @@ import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
+import org.apache.hadoop.hive.metastore.api.PrivilegeBag;
 import org.apache.hadoop.hive.metastore.api.Role;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.thrift.TException;
@@ -80,5 +81,8 @@ public interface HiveMetastoreClient
             throws TException;
 
     PrincipalPrivilegeSet getPrivilegeSet(HiveObjectRef hiveObject, String userName, List<String> groupNames)
+            throws TException;
+
+    boolean grantPrivileges(PrivilegeBag privilegeBag)
             throws TException;
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/InMemoryHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/InMemoryHiveMetastore.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive.metastore;
 import com.facebook.presto.hive.TableAlreadyExistsException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.security.Identity;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -44,6 +45,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import static com.facebook.presto.hive.AbstractTestHiveClient.listAllDataPaths;
 import static com.facebook.presto.hive.HiveUtil.createPartitionName;
 import static com.facebook.presto.hive.metastore.HivePrivilege.OWNERSHIP;
+import static com.facebook.presto.hive.metastore.HivePrivilege.parsePrivilege;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.testing.FileUtils.deleteRecursively;
@@ -381,6 +383,13 @@ public class InMemoryHiveMetastore
     @Override
     public void flushCache()
     {
+    }
+
+    @Override
+    public void grantTablePrivilege(String databaseName, String tableName, Identity identity, PrivilegeGrantInfo privilege)
+    {
+        Set<HivePrivilege> hivePrivileges = parsePrivilege(privilege);
+        setTablePrivileges(identity.getUser(), PrincipalType.USER, databaseName, tableName, hivePrivileges);
     }
 
     private static boolean isParentDir(File directory, File baseDirectory)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/MockHiveMetastoreClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/MockHiveMetastoreClient.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
+import org.apache.hadoop.hive.metastore.api.PrivilegeBag;
 import org.apache.hadoop.hive.metastore.api.Role;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.thrift.TException;
@@ -221,6 +222,12 @@ public class MockHiveMetastoreClient
 
     @Override
     public PrincipalPrivilegeSet getPrivilegeSet(HiveObjectRef hiveObject, String userName, List<String> groupNames)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean grantPrivileges(PrivilegeBag privilegeBag)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/GrantTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/GrantTask.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.QualifiedTableName;
+import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.sql.analyzer.SemanticException;
+import com.facebook.presto.sql.tree.Grant;
+
+import java.util.Optional;
+
+import static com.facebook.presto.metadata.MetadataUtil.createQualifiedTableName;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
+
+public class GrantTask
+    implements DataDefinitionTask<Grant>
+{
+    @Override
+    public String getName()
+    {
+        return "GRANT";
+    }
+
+    @Override
+    public void execute(Grant statement, Session session, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine)
+    {
+        QualifiedTableName tableName = createQualifiedTableName(session, statement, statement.getTableName());
+        Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
+        if (!tableHandle.isPresent()) {
+            throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);
+        }
+
+        // TODO: check that the user/role exists -- I think that this check can't be performed at this level. Each connector will have
+        // to perform this check.
+
+        // check that the current user can grant the requested privilege on the table
+        // NOTE: You want to pass the identity from the session and NOT the identity from Grant node. Because the
+        // session carries "the current user" (or grantor's) information, where as the Grant node carries the grantee's information.
+        accessControl.checkCanGrantTablePrivilege(session.getIdentity(), statement.getPrestoPrivilege(), tableName);
+
+        // TODO: if [WITH GRANT OPTION] is present, check that the current user has the ("GRANT") privilege to grant the privilege
+
+        Privilege privilege = new Privilege(statement.getPrestoPrivilege().getTypeString());
+
+        // I don't fully understand the Identity object; what is user and what is principal? For now, I am passing grantee
+        // as the user, but not sure if this is right.
+        Identity identity = new Identity(statement.getPrestoIdentity().getName().toString(), Optional.empty());
+
+        metadata.grantTablePrivilege(session, tableName, privilege, identity, statement.isOption());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -18,6 +18,8 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
@@ -236,6 +238,11 @@ public interface Metadata
      * Drops the specified view.
      */
     void dropView(Session session, QualifiedTableName viewName);
+
+    /**
+     * Grants the specified privilege to the specified user on the specified table
+     */
+    void grantTablePrivilege(Session session, QualifiedTableName tableName, Privilege privilege, Identity identity, boolean grantOption);
 
     FunctionRegistry getFunctionRegistry();
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -37,6 +37,8 @@ import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
@@ -663,6 +665,15 @@ public class MetadataManager
         ConnectorMetadataEntry connectorMetadata = connectorsByCatalog.get(viewName.getCatalogName());
         checkArgument(connectorMetadata != null, "Catalog %s does not exist", viewName.getCatalogName());
         connectorMetadata.getMetadata().dropView(session.toConnectorSession(connectorMetadata.getCatalog()), viewName.asSchemaTableName());
+    }
+
+    @Override
+    public void grantTablePrivilege(Session session, QualifiedTableName tableName, Privilege privilege, Identity identity, boolean grantOption)
+    {
+        ConnectorMetadataEntry connectorMetadata = connectorsByCatalog.get(tableName.getCatalogName());
+        checkArgument(connectorMetadata != null, "Catalog %s does not exist", tableName.getCatalogName());
+        connectorMetadata.getMetadata().grantTablePrivilege(session.toConnectorSession(connectorMetadata.getCatalog()),
+                tableName.asSchemaTableName(), privilege, identity, grantOption);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -15,6 +15,7 @@ package com.facebook.presto.security;
 
 import com.facebook.presto.metadata.QualifiedTableName;
 import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.sql.tree.PrestoPrivilege;
 
 import java.security.Principal;
 
@@ -103,6 +104,12 @@ public interface AccessControl
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */
     void checkCanCreateViewWithSelectFromView(Identity identity, QualifiedTableName viewName);
+
+    /**
+     * Check if identity is allowed to grant to any other user the specified privilege on the specified table.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanGrantTablePrivilege(Identity identity, PrestoPrivilege privilege, QualifiedTableName tableName);
 
     /**
      * Check if identity is allowed to set the specified system property.

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -17,8 +17,10 @@ import com.facebook.presto.metadata.QualifiedTableName;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.security.ConnectorAccessControl;
 import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.spi.security.SystemAccessControl;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
+import com.facebook.presto.sql.tree.PrestoPrivilege;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
@@ -304,6 +306,18 @@ public class AccessControlManager
         ConnectorAccessControl accessControl = catalogAccessControl.get(viewName.getCatalogName());
         if (accessControl != null) {
             authorizationCheck(() -> accessControl.checkCanCreateViewWithSelectFromView(identity, viewName.asSchemaTableName()));
+        }
+    }
+
+    @Override
+    public void checkCanGrantTablePrivilege(Identity identity, PrestoPrivilege privilege, QualifiedTableName tableName)
+    {
+        requireNonNull(identity, "identity is null");
+        requireNonNull(privilege, "privilege is null");
+
+        ConnectorAccessControl accessControl = catalogAccessControl.get(tableName.getCatalogName());
+        if (accessControl != null) {
+            accessControl.checkCanGrantTablePrivilege(identity, new Privilege(privilege.getTypeString()), tableName.asSchemaTableName());
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
@@ -15,6 +15,7 @@ package com.facebook.presto.security;
 
 import com.facebook.presto.metadata.QualifiedTableName;
 import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.sql.tree.PrestoPrivilege;
 
 import java.security.Principal;
 
@@ -88,6 +89,11 @@ public class AllowAllAccessControl
 
     @Override
     public void checkCanCreateViewWithSelectFromView(Identity identity, QualifiedTableName viewName)
+    {
+    }
+
+    @Override
+    public void checkCanGrantTablePrivilege(Identity identity, PrestoPrivilege privilege, QualifiedTableName tableName)
     {
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
@@ -15,6 +15,7 @@ package com.facebook.presto.security;
 
 import com.facebook.presto.metadata.QualifiedTableName;
 import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.sql.tree.PrestoPrivilege;
 
 import java.security.Principal;
 
@@ -24,6 +25,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateV
 import static com.facebook.presto.spi.security.AccessDeniedException.denyDeleteTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyDropTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyDropView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyGrantTablePrivilege;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyInsertTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameColumn;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
@@ -118,6 +120,12 @@ public class DenyAllAccessControl
     public void checkCanCreateViewWithSelectFromView(Identity identity, QualifiedTableName viewName)
     {
         denySelectView(viewName.toString());
+    }
+
+    @Override
+    public void checkCanGrantTablePrivilege(Identity identity, PrestoPrivilege privilege, QualifiedTableName tableName)
+    {
+        denyGrantTablePrivilege(privilege.toString(), tableName.toString());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -21,6 +21,7 @@ import com.facebook.presto.execution.DataDefinitionTask;
 import com.facebook.presto.execution.DropTableTask;
 import com.facebook.presto.execution.DropViewTask;
 import com.facebook.presto.execution.ForQueryExecution;
+import com.facebook.presto.execution.GrantTask;
 import com.facebook.presto.execution.NodeScheduler;
 import com.facebook.presto.execution.NodeSchedulerConfig;
 import com.facebook.presto.execution.NodeTaskMap;
@@ -56,6 +57,7 @@ import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
 import com.facebook.presto.sql.tree.Explain;
+import com.facebook.presto.sql.tree.Grant;
 import com.facebook.presto.sql.tree.Insert;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.RenameColumn;
@@ -173,6 +175,7 @@ public class CoordinatorModule
         bindDataDefinitionTask(binder, executionBinder, DropView.class, DropViewTask.class);
         bindDataDefinitionTask(binder, executionBinder, SetSession.class, SetSessionTask.class);
         bindDataDefinitionTask(binder, executionBinder, ResetSession.class, ResetSessionTask.class);
+        bindDataDefinitionTask(binder, executionBinder, Grant.class, GrantTask.class);
 
         MapBinder<String, ExecutionPolicy> executionPolicyBinder = newMapBinder(binder, String.class, ExecutionPolicy.class);
         executionPolicyBinder.addBinding("all-at-once").to(AllAtOnceExecutionPolicy.class);

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.ConnectorAccessControl;
 import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.spi.security.SystemAccessControl;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.google.common.collect.ImmutableMap;
@@ -230,6 +231,12 @@ public class TestAccessControlManager
 
         @Override
         public void checkCanSetCatalogSessionProperty(Identity identity, String propertyName)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void checkCanGrantTablePrivilege(Identity identity, Privilege privilege, SchemaTableName tableName)
         {
             throw new UnsupportedOperationException();
         }

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -46,6 +46,9 @@ statement
         ADD COLUMN column=tableElement                                 #addColumn
     | CREATE (OR REPLACE)? VIEW qualifiedName AS query                 #createView
     | DROP VIEW (IF EXISTS)? qualifiedName                             #dropView
+    | GRANT privilege
+        ON (TABLE)? qualifiedName TO (userList | PUBLIC)
+        (WITH GRANT OPTION)?                                           #grant
     | EXPLAIN ('(' explainOption (',' explainOption)* ')')? statement  #explain
     | SHOW TABLES ((FROM | IN) qualifiedName)? (LIKE pattern=STRING)?  #showTables
     | SHOW SCHEMAS ((FROM | IN) identifier)?                           #showSchemas
@@ -318,6 +321,14 @@ explainOption
     | TYPE value=(LOGICAL | DISTRIBUTED)     #explainType
     ;
 
+privilege
+    : value=(SELECT | INSERT | DELETE )      #prestoPrivilege
+    ;
+
+userList
+    : qualifiedName
+    ;
+
 qualifiedName
     : identifier ('.' identifier)*
     ;
@@ -451,6 +462,9 @@ DELETE: 'DELETE';
 INTO: 'INTO';
 CONSTRAINT: 'CONSTRAINT';
 DESCRIBE: 'DESCRIBE';
+GRANT: 'GRANT';
+PUBLIC: 'PUBLIC';
+OPTION: 'OPTION';
 EXPLAIN: 'EXPLAIN';
 FORMAT: 'FORMAT';
 TYPE: 'TYPE';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -29,6 +29,7 @@ import com.facebook.presto.sql.tree.ExplainFormat;
 import com.facebook.presto.sql.tree.ExplainOption;
 import com.facebook.presto.sql.tree.ExplainType;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Grant;
 import com.facebook.presto.sql.tree.Insert;
 import com.facebook.presto.sql.tree.Intersect;
 import com.facebook.presto.sql.tree.Join;
@@ -726,6 +727,25 @@ public final class SqlFormatter
         {
             builder.append("RESET SESSION ")
                     .append(node.getName());
+
+            return null;
+        }
+
+        @Override
+        public Void visitGrant(Grant node, Integer indent)
+        {
+            builder.append("GRANT ")
+                    .append(node.getPrestoPrivilege().getTypeString())
+                    .append(" ON ");
+            if (node.isTable()) {
+                builder.append("TABLE ");
+            }
+            builder.append(node.getTableName())
+                    .append(" TO ")
+                    .append(node.getPrestoIdentity().getName());
+            if (node.isOption()) {
+                builder.append(" WITH GRANT OPTION");
+            }
 
             return null;
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -481,4 +481,14 @@ public abstract class AstVisitor<R, C>
     {
         return visitStatement(node, context);
     }
+
+    protected R visitGrant(Grant node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
+    protected  R visitPrestoPrivilege(PrestoPrivilege node, C context)
+    {
+        return visitNode(node, context);
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Grant.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Grant.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class Grant
+        extends Statement
+{
+    private final PrestoPrivilege prestoPrivilege;
+    private final boolean table;
+    private final QualifiedName tableName;
+    private final PrestoIdentity prestoIdentity;
+    private final boolean option;
+
+    public Grant(PrestoPrivilege prestoPrivilege, boolean table, QualifiedName tableName, PrestoIdentity prestoIdentity, boolean option)
+    {
+        this.prestoPrivilege = requireNonNull(prestoPrivilege, "privilege is null");
+        this.table = table;
+        this.tableName = requireNonNull(tableName, "table name is null");
+        this.prestoIdentity = requireNonNull(prestoIdentity, "user/role is null");
+        this.option = option;
+    }
+
+    public PrestoPrivilege getPrestoPrivilege()
+    {
+        return prestoPrivilege;
+    }
+
+    public boolean isTable()
+    {
+        return table;
+    }
+
+    public QualifiedName getTableName()
+    {
+        return tableName;
+    }
+
+    public PrestoIdentity getPrestoIdentity()
+    {
+        return prestoIdentity;
+    }
+
+    public boolean isOption()
+    {
+        return option;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitGrant(this, context);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(prestoPrivilege, table, tableName, prestoIdentity, option);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Grant o = (Grant) obj;
+        return Objects.equals(prestoPrivilege, o.prestoPrivilege) &&
+                Objects.equals(table, o.table) &&
+                Objects.equals(tableName, o.tableName) &&
+                Objects.equals(prestoIdentity, o.prestoIdentity) &&
+                Objects.equals(option, o.option);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("prestoPrivilege", prestoPrivilege)
+                .add("table", table)
+                .add("tableName", tableName)
+                .add("prestoIdentity", prestoIdentity)
+                .add("option", option)
+                .toString();
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/PrestoIdentity.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/PrestoIdentity.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoIdentity
+        extends Node
+{
+    private final QualifiedName name;
+
+    public PrestoIdentity(QualifiedName name)
+    {
+        this.name = requireNonNull(name, "user/role is null");
+    }
+
+    public QualifiedName getName()
+    {
+        return name;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitNode(this, context);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || (getClass() != obj.getClass())) {
+            return false;
+        }
+        PrestoIdentity o = (PrestoIdentity) obj;
+        return Objects.equals(name, o.name);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .toString();
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/PrestoPrivilege.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/PrestoPrivilege.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoPrivilege
+        extends Node
+{
+    public enum Type
+    {
+        SELECT,
+        INSERT,
+        DELETE
+    }
+
+    private final Type type;
+
+    public PrestoPrivilege(Type type)
+    {
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+    public String getTypeString()
+    {
+        switch (this.type) {
+            case SELECT:
+                return "SELECT";
+            case INSERT:
+                return "INSERT";
+            case DELETE:
+                return "DELETE";
+        }
+        return null;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitPrestoPrivilege(this, context);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(type);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || (getClass() != obj.getClass())) {
+            return false;
+        }
+        PrestoPrivilege o = (PrestoPrivilege) obj;
+        return Objects.equals(type, o.type);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("type", type)
+                .toString();
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -37,6 +37,7 @@ import com.facebook.presto.sql.tree.ExplainType;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GenericLiteral;
+import com.facebook.presto.sql.tree.Grant;
 import com.facebook.presto.sql.tree.Insert;
 import com.facebook.presto.sql.tree.Intersect;
 import com.facebook.presto.sql.tree.IntervalLiteral;
@@ -52,6 +53,8 @@ import com.facebook.presto.sql.tree.NaturalJoin;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.PrestoIdentity;
+import com.facebook.presto.sql.tree.PrestoPrivilege;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.Query;
@@ -904,6 +907,18 @@ public class TestSqlParser
                 QualifiedName.of("a"),
                 simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
                 true));
+    }
+
+    @Test
+    public void testGrant()
+            throws Exception
+    {
+        assertStatement("GRANT INSERT ON customer to admin",
+                new Grant(new PrestoPrivilege(PrestoPrivilege.Type.INSERT), false, QualifiedName.of("customer"),
+                        new PrestoIdentity(QualifiedName.of("admin")), false));
+        assertStatement("GRANT SELECT ON orders to PUBLIC WITH GRANT OPTION",
+                new Grant(new PrestoPrivilege(PrestoPrivilege.Type.SELECT), false, QualifiedName.of("orders"),
+                        new PrestoIdentity(QualifiedName.of("PUBLIC")), true));
     }
 
     @Test

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
@@ -177,6 +177,10 @@ public class TestStatementBuilder
         printStatement("create or replace view foo as select 123 from t");
 
         printStatement("drop view foo");
+
+        printStatement("grant select on foo to testUser with grant option");
+        printStatement("grant insert on foo to testUser");
+        printStatement("grant delete on foo to public");
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorMetadata.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.spi;
 
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
 import io.airlift.slice.Slice;
 
 import java.util.Collection;
@@ -271,5 +273,13 @@ public interface ConnectorMetadata
     default OptionalLong metadataDelete(ConnectorSession session, ConnectorTableHandle tableHandle, ConnectorTableLayoutHandle tableLayoutHandle)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support deletes");
+    }
+
+    /**
+     * Grants the specified privilege to the specified user on the specified table
+     */
+    default void grantTablePrivilege(ConnectorSession session, SchemaTableName tableName, Privilege privilege, Identity identity, boolean grantOption)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support grants");
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -28,6 +28,8 @@ import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
 import io.airlift.slice.Slice;
 
 import java.util.Collection;
@@ -276,6 +278,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.metadataDelete(session, tableHandle, tableLayoutHandle);
+        }
+    }
+
+    @Override
+    public void grantTablePrivilege(ConnectorSession session, SchemaTableName tableName, Privilege privilege, Identity identity, boolean grantOption)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.grantTablePrivilege(session, tableName, privilege, identity, grantOption);
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
@@ -148,6 +148,11 @@ public class AccessDeniedException
         throw new AccessDeniedException(format("Cannot select from view %s%s", viewName, formatExtraInfo(extraInfo)));
     }
 
+    public static void denyGrantTablePrivilege(String privilege, String tableName)
+    {
+        throw new AccessDeniedException(format("Cannot grant privilege %s on table %s", privilege, tableName));
+    }
+
     public static void denySetSystemSessionProperty(String propertyName)
     {
         denySetSystemSessionProperty(propertyName, null);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/ConnectorAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/ConnectorAccessControl.java
@@ -100,4 +100,10 @@ public interface ConnectorAccessControl
      * @throws AccessDeniedException if not allowed
      */
     void checkCanSetCatalogSessionProperty(Identity identity, String propertyName);
+
+    /**
+     * Check if identity is allowed to grant to any other user the specified privilege on the specified table.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     */
+    void checkCanGrantTablePrivilege(Identity identity, Privilege privilege, SchemaTableName tableName);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/Privilege.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/Privilege.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.security;
+
+import com.facebook.presto.spi.PrestoException;
+
+import java.util.Objects;
+
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Objects.requireNonNull;
+
+public class Privilege
+{
+    public enum Type
+    {
+        SELECT,
+        INSERT,
+        DELETE
+    }
+
+    private final Type type;
+
+    public Privilege(Type type)
+    {
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    public Privilege(String typeString)
+    {
+        switch (typeString) {
+            case "SELECT":
+                type = Type.SELECT;
+                break;
+            case "INSERT":
+                type = Type.INSERT;
+                break;
+            case "DELETE":
+                type = Type.DELETE;
+                break;
+            default:
+                throw new PrestoException(NOT_SUPPORTED, "Unsupported privilege: " + typeString);
+        }
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+    public String getTypeString()
+    {
+        switch (this.type) {
+            case SELECT:
+                return "SELECT";
+            case INSERT:
+                return "INSERT";
+            case DELETE:
+                return "DELETE";
+        }
+        return null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(type);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || (getClass() != obj.getClass())) {
+            return false;
+        }
+        Privilege o = (Privilege) obj;
+        return Objects.equals(type, o.getType());
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder("Privilege{");
+        sb.append("type=").append(type).append("}");
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
This is a prototype implementation of adding parsing support for GRANT query. I am listing the issues in the code that I am aware of:

- The current parsing code doesn't reflect the exact syntax of GRANT query that we want to support. I haven't iterated over the syntax, since this implementation is a prototype. I will refine it in due course. Here are some differences between the current syntax and the sql-99 standard syntax that we want to support:
-- Current syntax can accept only a single privilege at a time instead of a list of privileges
-- Current syntax doesn't take the keyword ALL which implies all privileges

- There are some TODO's in the code. These are issues which need deeper digging.

- Some of the comments, specially in the hive connector code, are unnecessary. I will remove them  eventually.

- The current implementation of function checkCanGrantTablePrivilege() performs the check of whether the current user can grant the privilege by checking whether the current user is the owner of the table and if so, the check passes. If not, the check fails. We may have to change this as per the security policy we decide to adopt (for ex., one of the privileges a user can have will be a 'GRANT' privilege that denotes whether a user can grant privileges to other users. We will then check whether the user has the GRANT privilege instead).