### PR TITLE
Refactor getCommonSuperType and canCoerce

### DIFF
--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -83,6 +84,18 @@ public class TestKafkaPlugin
         public List<Type> getTypes()
         {
             return ImmutableList.of();
+        }
+
+        @Override
+        public Optional<Type> getCommonSuperType(List<? extends Type> types)
+        {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Type> getCommonSuperType(Type firstType, Type secondType)
+        {
+            return Optional.empty();
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/OperatorNotFoundException.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/OperatorNotFoundException.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeSignature;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 
@@ -27,10 +27,10 @@ import static java.util.Objects.requireNonNull;
 public class OperatorNotFoundException extends PrestoException
 {
     private final OperatorType operatorType;
-    private final Type returnType;
-    private final List<Type> argumentTypes;
+    private final TypeSignature returnType;
+    private final List<TypeSignature> argumentTypes;
 
-    public OperatorNotFoundException(OperatorType operatorType, List<? extends Type> argumentTypes)
+    public OperatorNotFoundException(OperatorType operatorType, List<? extends TypeSignature> argumentTypes)
     {
         super(OPERATOR_NOT_FOUND, format("Operator %s(%s) not registered", operatorType, Joiner.on(", ").join(argumentTypes)));
         this.operatorType = requireNonNull(operatorType, "operatorType is null");
@@ -38,7 +38,7 @@ public class OperatorNotFoundException extends PrestoException
         this.argumentTypes = ImmutableList.copyOf(requireNonNull(argumentTypes, "argumentTypes is null"));
     }
 
-    public OperatorNotFoundException(OperatorType operatorType, List<? extends Type> argumentTypes, Type returnType)
+    public OperatorNotFoundException(OperatorType operatorType, List<? extends TypeSignature> argumentTypes, TypeSignature returnType)
     {
         super(OPERATOR_NOT_FOUND, format("Operator %s(%s):%s not registered", operatorType, Joiner.on(", ").join(argumentTypes), returnType));
         this.operatorType = requireNonNull(operatorType, "operatorType is null");
@@ -51,12 +51,12 @@ public class OperatorNotFoundException extends PrestoException
         return operatorType;
     }
 
-    public Type getReturnType()
+    public TypeSignature getReturnType()
     {
         return returnType;
     }
 
-    public List<Type> getArgumentTypes()
+    public List<TypeSignature> getArgumentTypes()
     {
         return argumentTypes;
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
@@ -33,10 +33,9 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
-import static com.facebook.presto.metadata.FunctionRegistry.canCoerce;
-import static com.facebook.presto.metadata.FunctionRegistry.getCommonSuperType;
 import static com.facebook.presto.metadata.FunctionRegistry.mangleOperatorName;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.type.TypeRegistry.canCoerce;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -270,7 +269,7 @@ public final class Signature
 
         // Bind the variable arity argument first, to make sure it's bound to the common super type
         if (varArgs && types.size() >= argumentTypes.size()) {
-            Optional<Type> superType = getCommonSuperType(types.subList(argumentTypes.size() - 1, types.size()));
+            Optional<Type> superType = typeManager.getCommonSuperType(types.subList(argumentTypes.size() - 1, types.size()));
             if (!superType.isPresent()) {
                 return false;
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -89,8 +89,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
-import static com.facebook.presto.metadata.FunctionRegistry.canCoerce;
-import static com.facebook.presto.metadata.FunctionRegistry.getCommonSuperType;
 import static com.facebook.presto.metadata.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -116,6 +114,8 @@ import static com.facebook.presto.sql.tree.Extract.Field.TIMEZONE_MINUTE;
 import static com.facebook.presto.type.ArrayParametricType.ARRAY;
 import static com.facebook.presto.type.JsonType.JSON;
 import static com.facebook.presto.type.RowType.RowField;
+import static com.facebook.presto.type.TypeRegistry.canCoerce;
+import static com.facebook.presto.type.TypeRegistry.getCommonSuperTypeSignature;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.util.DateTimeUtils.parseTimestampLiteral;
 import static com.facebook.presto.util.DateTimeUtils.timeHasTimeZone;
@@ -420,7 +420,7 @@ public class ExpressionAnalyzer
             Type firstType = process(node.getFirst(), context);
             Type secondType = process(node.getSecond(), context);
 
-            if (!getCommonSuperType(firstType, secondType).isPresent()) {
+            if (!getCommonSuperTypeSignature(firstType.getTypeSignature(), secondType.getTypeSignature()).isPresent()) {
                 throw new SemanticException(TYPE_MISMATCH, node, "Types are not comparable with NULLIF: %s vs %s", firstType, secondType);
             }
 
@@ -941,7 +941,7 @@ public class ExpressionAnalyzer
             // determine super type
             Type superType = UNKNOWN;
             for (Expression expression : expressions) {
-                Optional<Type> newSuperType = getCommonSuperType(superType, process(expression, context));
+                Optional<Type> newSuperType = typeManager.getCommonSuperType(superType, process(expression, context));
                 if (!newSuperType.isPresent()) {
                     throw new SemanticException(TYPE_MISMATCH, expression, message, superType);
                 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -15,7 +15,6 @@ package com.facebook.presto.sql.analyzer;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.FunctionKind;
-import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataUtil;
 import com.facebook.presto.metadata.QualifiedObjectName;
@@ -130,7 +129,6 @@ import static com.facebook.presto.connector.informationSchema.InformationSchemaM
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.metadata.FunctionKind.APPROXIMATE_AGGREGATE;
 import static com.facebook.presto.metadata.FunctionKind.WINDOW;
-import static com.facebook.presto.metadata.FunctionRegistry.getCommonSuperType;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -970,7 +968,7 @@ class StatementAnalyzer
             }
             for (int i = 0; i < descriptor.getVisibleFields().size(); i++) {
                 Type descFieldType = descriptor.getFieldByIndex(i).getType();
-                Optional<Type> commonSuperType = FunctionRegistry.getCommonSuperType(outputFieldTypes[i], descFieldType);
+                Optional<Type> commonSuperType = metadata.getTypeManager().getCommonSuperType(outputFieldTypes[i], descFieldType);
                 if (!commonSuperType.isPresent()) {
                     throw new SemanticException(TYPE_MISMATCH,
                             node,
@@ -1146,7 +1144,7 @@ class StatementAnalyzer
     {
         Type leftType = analysis.getType(leftExpression);
         Type rightType = analysis.getType(rightExpression);
-        Optional<Type> superType = FunctionRegistry.getCommonSuperType(leftType, rightType);
+        Optional<Type> superType = metadata.getTypeManager().getCommonSuperType(leftType, rightType);
         if (!superType.isPresent()) {
             throw new SemanticException(TYPE_MISMATCH, node, "Join criteria has incompatible types: %s, %s", leftType.getDisplayName(), rightType.getDisplayName());
         }
@@ -1181,7 +1179,7 @@ class StatementAnalyzer
                 Type fieldType = rowType.get(i);
                 Type superType = fieldTypes.get(i);
 
-                Optional<Type> commonSuperType = getCommonSuperType(fieldType, superType);
+                Optional<Type> commonSuperType = metadata.getTypeManager().getCommonSuperType(fieldType, superType);
                 if (!commonSuperType.isPresent()) {
                     throw new SemanticException(MISMATCHED_SET_COLUMN_TYPES,
                             node,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -86,13 +86,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.facebook.presto.metadata.FunctionRegistry.canCoerce;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.createConstantAnalyzer;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.EXPRESSION_NOT_CONSTANT;
 import static com.facebook.presto.sql.planner.LiteralInterpreter.toExpression;
 import static com.facebook.presto.sql.planner.LiteralInterpreter.toExpressions;
+import static com.facebook.presto.type.TypeRegistry.canCoerce;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.instanceOf;
@@ -693,7 +693,7 @@ public class ExpressionInterpreter
                 return new NullIfExpression(toExpression(first, firstType), toExpression(second, secondType));
             }
 
-            Type commonType = FunctionRegistry.getCommonSuperType(firstType, secondType).get();
+            Type commonType = metadata.getTypeManager().getCommonSuperType(firstType, secondType).get();
 
             Signature firstCast = metadata.getFunctionRegistry().getCoercion(firstType, commonType);
             Signature secondCast = metadata.getFunctionRegistry().getCoercion(secondType, commonType);

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
@@ -24,6 +25,7 @@ import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -51,6 +53,7 @@ import static com.facebook.presto.type.MapParametricType.MAP;
 import static com.facebook.presto.type.RegexpType.REGEXP;
 import static com.facebook.presto.type.RowParametricType.ROW;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -163,5 +166,153 @@ public final class TypeRegistry
     public static void verifyTypeClass(Type type)
     {
         requireNonNull(type, "type is null");
+    }
+
+    public static boolean canCoerce(List<? extends Type> actualTypes, List<Type> expectedTypes)
+    {
+        if (actualTypes.size() != expectedTypes.size()) {
+            return false;
+        }
+        for (int i = 0; i < expectedTypes.size(); i++) {
+            Type expectedType = expectedTypes.get(i);
+            Type actualType = actualTypes.get(i);
+            if (!canCoerce(actualType, expectedType)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean canCastTypeBase(String fromTypeBase, String toTypeBase)
+    {
+        // canCastTypeBase and isCovariantParameterPosition defines all hand-coded rules for type coercion.
+        // Other methods should reference these two functions instead of hand-code new rules.
+
+        if (UnknownType.NAME.equals(fromTypeBase)) {
+            return true;
+        }
+        if (toTypeBase.equals(fromTypeBase)) {
+            return true;
+        }
+        switch (fromTypeBase) {
+            case StandardTypes.BIGINT:
+                return StandardTypes.DOUBLE.equals(toTypeBase);
+            case StandardTypes.DATE:
+                return StandardTypes.TIMESTAMP.equals(toTypeBase) || StandardTypes.TIMESTAMP_WITH_TIME_ZONE.equals(toTypeBase);
+            case StandardTypes.TIME:
+                return StandardTypes.TIME_WITH_TIME_ZONE.equals(toTypeBase);
+            case StandardTypes.TIMESTAMP:
+                return StandardTypes.TIMESTAMP_WITH_TIME_ZONE.equals(toTypeBase);
+            case StandardTypes.VARCHAR:
+                return RegexpType.NAME.equals(toTypeBase) || LikePatternType.NAME.equals(toTypeBase) || JsonPathType.NAME.equals(toTypeBase);
+        }
+        return false;
+    }
+
+    private static boolean isCovariantParameterPosition(String firstTypeBase, int position)
+    {
+        // canCastTypeBase and isCovariantParameterPosition defines all hand-coded rules for type coercion.
+        // Other methods should reference these two functions instead of hand-code new rules.
+
+        // if we ever introduce contravariant, this function should be changed to return an enumeration: INVARIANT, COVARIANT, CONTRAVARIANT
+        return firstTypeBase.equals(StandardTypes.ARRAY);
+    }
+
+    public static boolean canCoerce(Type actualType, Type expectedType)
+    {
+        return canCoerce(actualType.getTypeSignature(), expectedType.getTypeSignature());
+    }
+
+    public static boolean canCoerce(TypeSignature actualType, TypeSignature expectedType)
+    {
+        Optional<TypeSignature> commonSuperTypeSignature = getCommonSuperTypeSignature(actualType, expectedType);
+        return commonSuperTypeSignature.isPresent() && commonSuperTypeSignature.get().equals(expectedType);
+    }
+
+    @Override
+    public Optional<Type> getCommonSuperType(List<? extends Type> types)
+    {
+        checkArgument(!types.isEmpty(), "types is empty");
+        Optional<TypeSignature> commonSuperTypeSignature = getCommonSuperTypeSignature(
+                types.stream()
+                        .map(Type::getTypeSignature)
+                        .collect(toImmutableList()));
+        return commonSuperTypeSignature.map(this::getType);
+    }
+
+    @Override
+    public Optional<Type> getCommonSuperType(Type firstType, Type secondType)
+    {
+        return getCommonSuperTypeSignature(firstType.getTypeSignature(), secondType.getTypeSignature()).map(this::getType);
+    }
+
+    private static Optional<String> getCommonSuperTypeBase(String firstTypeBase, String secondTypeBase)
+    {
+        if (canCastTypeBase(firstTypeBase, secondTypeBase)) {
+            return Optional.of(secondTypeBase);
+        }
+        if (canCastTypeBase(secondTypeBase, firstTypeBase)) {
+            return Optional.of(firstTypeBase);
+        }
+        return Optional.empty();
+    }
+
+    public static Optional<TypeSignature> getCommonSuperTypeSignature(List<? extends TypeSignature> typeSignatures)
+    {
+        checkArgument(!typeSignatures.isEmpty(), "typeSignatures is empty");
+        TypeSignature superTypeSignature = UNKNOWN.getTypeSignature();
+        for (TypeSignature typeSignature : typeSignatures) {
+            Optional<TypeSignature> commonSuperTypeSignature = getCommonSuperTypeSignature(superTypeSignature, typeSignature);
+            if (!commonSuperTypeSignature.isPresent()) {
+                return Optional.empty();
+            }
+            superTypeSignature = commonSuperTypeSignature.get();
+        }
+        return Optional.of(superTypeSignature);
+    }
+
+    public static Optional<TypeSignature> getCommonSuperTypeSignature(TypeSignature firstType, TypeSignature secondType)
+    {
+        // Special handling for UnknownType is necessary because we forbid cast between types with different number of type parameters.
+        // Without this, cast from null to map<bigint, bigint> will not be allowed.
+        if (UnknownType.NAME.equals(firstType.getBase())) {
+            return Optional.of(secondType);
+        }
+        if (UnknownType.NAME.equals(secondType.getBase())) {
+            return Optional.of(firstType);
+        }
+
+        List<TypeSignature> firstTypeTypeParameters = firstType.getParameters();
+        List<TypeSignature> secondTypeTypeParameters = secondType.getParameters();
+        if (firstTypeTypeParameters.size() != secondTypeTypeParameters.size()) {
+            return Optional.empty();
+        }
+        if (!firstType.getLiteralParameters().equals(secondType.getLiteralParameters())) {
+            return Optional.empty();
+        }
+
+        Optional<String> commonSuperTypeBase = getCommonSuperTypeBase(firstType.getBase(), secondType.getBase());
+        if (!commonSuperTypeBase.isPresent()) {
+            return Optional.empty();
+        }
+
+        ImmutableList.Builder<TypeSignature> typeParameters = ImmutableList.builder();
+        for (int i = 0; i < firstTypeTypeParameters.size(); i++) {
+            if (isCovariantParameterPosition(commonSuperTypeBase.get(), i)) {
+                Optional<TypeSignature> commonSuperType = getCommonSuperTypeSignature(firstTypeTypeParameters.get(i), secondTypeTypeParameters.get(i));
+                if (!commonSuperType.isPresent()) {
+                    return Optional.empty();
+                }
+                typeParameters.add(commonSuperType.get());
+            }
+            else {
+                if (!firstTypeTypeParameters.get(i).equals(secondTypeTypeParameters.get(i))) {
+                    return Optional.empty();
+                }
+                typeParameters.add(firstTypeTypeParameters.get(i));
+            }
+        }
+
+        return Optional.of(new TypeSignature(commonSuperTypeBase.get(), typeParameters.build(), firstType.getLiteralParameters()));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTypeRegistry.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTypeRegistry.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeSignature;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TimeType.TIME;
+import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.type.JsonPathType.JSON_PATH;
+import static com.facebook.presto.type.LikePatternType.LIKE_PATTERN;
+import static com.facebook.presto.type.RegexpType.REGEXP;
+import static com.facebook.presto.type.TypeRegistry.getCommonSuperTypeSignature;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestTypeRegistry
+{
+    @Test
+    public void testCanCoerce()
+    {
+        assertTrue(TypeRegistry.canCoerce(BIGINT, BIGINT));
+        assertTrue(TypeRegistry.canCoerce(UNKNOWN, BIGINT));
+        assertFalse(TypeRegistry.canCoerce(BIGINT, UNKNOWN));
+
+        assertTrue(TypeRegistry.canCoerce(BIGINT, DOUBLE));
+        assertTrue(TypeRegistry.canCoerce(DATE, TIMESTAMP));
+        assertTrue(TypeRegistry.canCoerce(DATE, TIMESTAMP_WITH_TIME_ZONE));
+        assertTrue(TypeRegistry.canCoerce(TIME, TIME_WITH_TIME_ZONE));
+        assertTrue(TypeRegistry.canCoerce(TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE));
+        assertTrue(TypeRegistry.canCoerce(VARCHAR, REGEXP));
+        assertTrue(TypeRegistry.canCoerce(VARCHAR, LIKE_PATTERN));
+        assertTrue(TypeRegistry.canCoerce(VARCHAR, JSON_PATH));
+
+        assertFalse(TypeRegistry.canCoerce(DOUBLE, BIGINT));
+        assertFalse(TypeRegistry.canCoerce(TIMESTAMP, TIME_WITH_TIME_ZONE));
+        assertFalse(TypeRegistry.canCoerce(TIMESTAMP_WITH_TIME_ZONE, TIMESTAMP));
+        assertFalse(TypeRegistry.canCoerce(VARBINARY, VARCHAR));
+
+        assertTrue(TypeRegistry.canCoerce(UNKNOWN.getTypeSignature(), parseTypeSignature("array<bigint>")));
+        assertFalse(TypeRegistry.canCoerce(parseTypeSignature("array<bigint>"), UNKNOWN.getTypeSignature()));
+        assertTrue(TypeRegistry.canCoerce(parseTypeSignature("array<bigint>"), parseTypeSignature("array<double>")));
+        assertFalse(TypeRegistry.canCoerce(parseTypeSignature("array<double>"), parseTypeSignature("array<bigint>")));
+        assertTrue(TypeRegistry.canCoerce(parseTypeSignature("map<bigint,double>"), parseTypeSignature("map<bigint,double>")));
+        assertFalse(TypeRegistry.canCoerce(parseTypeSignature("map<bigint,double>"), parseTypeSignature("map<double,double>"))); // map covariant cast is not supported yet
+        assertTrue(TypeRegistry.canCoerce(parseTypeSignature("row<bigint,double,varchar>"), parseTypeSignature("row<bigint,double,varchar>")));
+        assertFalse(TypeRegistry.canCoerce(parseTypeSignature("row<bigint,double,varchar>('a','b','c')"), parseTypeSignature("row<bigint,double,varchar>")));
+        assertFalse(TypeRegistry.canCoerce(parseTypeSignature("row<bigint,double,varchar>"), parseTypeSignature("row<bigint,double,varchar>('a','b','c')")));
+        assertTrue(TypeRegistry.canCoerce(parseTypeSignature("row<bigint,double,varchar>('a','b','c')"), parseTypeSignature("row<bigint,double,varchar>('a','b','c')")));
+    }
+
+    @Test
+    public void testGetCommonSuperType()
+    {
+        assertCommonSuperType(UNKNOWN, UNKNOWN, UNKNOWN);
+        assertCommonSuperType(BIGINT, BIGINT, BIGINT);
+        assertCommonSuperType(UNKNOWN, BIGINT, BIGINT);
+
+        assertCommonSuperType(BIGINT, DOUBLE, DOUBLE);
+        assertCommonSuperType(DATE, TIMESTAMP, TIMESTAMP);
+        assertCommonSuperType(DATE, TIMESTAMP_WITH_TIME_ZONE, TIMESTAMP_WITH_TIME_ZONE);
+        assertCommonSuperType(TIME, TIME_WITH_TIME_ZONE, TIME_WITH_TIME_ZONE);
+        assertCommonSuperType(TIMESTAMP, TIMESTAMP_WITH_TIME_ZONE, TIMESTAMP_WITH_TIME_ZONE);
+        assertCommonSuperType(VARCHAR, REGEXP, REGEXP);
+        assertCommonSuperType(VARCHAR, LIKE_PATTERN, LIKE_PATTERN);
+        assertCommonSuperType(VARCHAR, JSON_PATH, JSON_PATH);
+
+        assertCommonSuperType(TIMESTAMP, TIME_WITH_TIME_ZONE, null);
+        assertCommonSuperType(VARBINARY, VARCHAR, null);
+
+        assertCommonSuperType("unknown", "array<bigint>", "array<bigint>");
+        assertCommonSuperType("array<bigint>", "array<double>", "array<double>");
+        assertCommonSuperType("array<bigint>", "array<unknown>", "array<bigint>");
+        assertCommonSuperType("map<bigint,double>", "map<bigint,double>", "map<bigint,double>");
+        assertCommonSuperType("map<bigint,double>", "map<double,double>", null); // map covariant cast is not supported yet
+        assertCommonSuperType("row<bigint,double,varchar>", "row<bigint,double,varchar>", "row<bigint,double,varchar>");
+        assertCommonSuperType("row<bigint,double,varchar>('a','b','c')", "row<bigint,double,varchar>", null);
+        assertCommonSuperType("row<bigint,double,varchar>('a','b','c')", "row<bigint,double,varchar>('a','b','c')", "row<bigint,double,varchar>('a','b','c')");
+    }
+
+    private void assertCommonSuperType(Type firstType, Type secondType, Type expected)
+    {
+        TypeRegistry typeManager = new TypeRegistry();
+        assertEquals(typeManager.getCommonSuperType(firstType, secondType), Optional.ofNullable(expected));
+        assertEquals(typeManager.getCommonSuperType(secondType, firstType), Optional.ofNullable(expected));
+    }
+
+    private void assertCommonSuperType(String firstType, String secondType, String expected)
+    {
+        TypeSignature expectedType = expected == null ? null : parseTypeSignature(expected);
+        assertEquals(getCommonSuperTypeSignature(parseTypeSignature(firstType), parseTypeSignature(secondType)), Optional.ofNullable(expectedType));
+        assertEquals(getCommonSuperTypeSignature(parseTypeSignature(secondType), parseTypeSignature(firstType)), Optional.ofNullable(expectedType));
+    }
+}

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisPlugin.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisPlugin.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -83,6 +84,18 @@ public class TestRedisPlugin
         public List<Type> getTypes()
         {
             return ImmutableList.of();
+        }
+
+        @Override
+        public Optional<Type> getCommonSuperType(List<? extends Type> types)
+        {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Type> getCommonSuperType(Type firstType, Type secondType)
+        {
+            return Optional.empty();
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.type;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TypeManager
 {
@@ -31,4 +32,8 @@ public interface TypeManager
      * Gets a list of all registered types.
      */
     List<Type> getTypes();
+
+    Optional<Type> getCommonSuperType(List<? extends Type> types);
+
+    Optional<Type> getCommonSuperType(Type firstType, Type secondType);
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingTypeManager.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingTypeManager.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi.type;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -51,5 +52,17 @@ public class TestingTypeManager
     public List<Type> getTypes()
     {
         return ImmutableList.<Type>of(BOOLEAN, BIGINT, DOUBLE, VARCHAR, VARBINARY, TIMESTAMP, DATE, ID, HYPER_LOG_LOG);
+    }
+
+    @Override
+    public Optional<Type> getCommonSuperType(List<? extends Type> types)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Type> getCommonSuperType(Type firstType, Type secondType)
+    {
+        throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
Prerequisite for type unification code for lambda

* Now that they take both Type and TypeSignature
* Coercion rules were duplicated in the original code (and diverged). The rules appear only once in the code after this commit.
* Coercion between types with type parameters (e.g. array<T> and array<U>)  could be arbitrary and potentially complex. After this commit,  coercibility between types is decoupled from compatibility between  type parameters.
* Add tests