### PR TITLE
Improve pending splits accounting

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
@@ -15,7 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.Session;
-import com.facebook.presto.execution.NodeTaskMap.SplitCountChangeListener;
+import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.Node;
@@ -44,7 +44,7 @@ public class MemoryTrackingRemoteTaskFactory
             PlanFragment fragment,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
-            SplitCountChangeListener splitCountChangeListener)
+            PartitionedSplitCountTracker partitionedSplitCountTracker)
     {
         RemoteTask task = remoteTaskFactory.createRemoteTask(session,
                 taskId,
@@ -52,7 +52,7 @@ public class MemoryTrackingRemoteTaskFactory
                 fragment,
                 initialSplits,
                 outputBuffers,
-                splitCountChangeListener);
+                partitionedSplitCountTracker);
 
         task.addStateChangeListener(new UpdatePeakMemory(stateMachine));
         return task;

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
@@ -15,7 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.Session;
-import com.facebook.presto.execution.NodeTaskMap.SplitCountChangeListener;
+import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.sql.planner.PlanFragment;
@@ -30,5 +30,5 @@ public interface RemoteTaskFactory
             PlanFragment fragment,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
-            SplitCountChangeListener splitCountChangeListener);
+            PartitionedSplitCountTracker partitionedSplitCountTracker);
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -313,7 +313,7 @@ public final class SqlStageExecution
                 stateMachine.getFragment(),
                 initialSplits.build(),
                 outputBuffers.get(),
-                nodeTaskMap.getSplitCountChangeListener(node));
+                nodeTaskMap.createPartitionedSplitCountTracker(node, taskId));
 
         completeSources.forEach(task::noMoreSplits);
 

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTaskFactory.java
@@ -16,7 +16,7 @@ package com.facebook.presto.server;
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.LocationFactory;
-import com.facebook.presto.execution.NodeTaskMap.SplitCountChangeListener;
+import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.RemoteTask;
 import com.facebook.presto.execution.RemoteTaskFactory;
@@ -96,7 +96,7 @@ public class HttpRemoteTaskFactory
             PlanFragment fragment,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
-            SplitCountChangeListener splitCountChangeListener)
+            PartitionedSplitCountTracker partitionedSplitCountTracker)
     {
         return new HttpRemoteTask(session,
                 taskId,
@@ -112,7 +112,7 @@ public class HttpRemoteTaskFactory
                 taskInfoRefreshMaxWait,
                 taskInfoCodec,
                 taskUpdateRequestCodec,
-                splitCountChangeListener
+                partitionedSplitCountTracker
         );
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -87,6 +87,7 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.type.TypeDeserializer;
 import com.facebook.presto.type.TypeRegistry;
+import com.facebook.presto.util.FinalizerService;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
@@ -329,6 +330,9 @@ public class ServerMainModule
 
         // PageIndexer
         binder.bind(PageIndexerFactory.class).to(GroupByHashPageIndexerFactory.class).in(Scopes.SINGLETON);
+
+        // Finalizer
+        binder.bind(FinalizerService.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/presto-main/src/main/java/com/facebook/presto/util/FinalizerService.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/FinalizerService.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import com.google.common.collect.Sets;
+import io.airlift.log.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class FinalizerService
+{
+    private static final Logger log = Logger.get(FinalizerService.class);
+
+    private final Set<FinalizerReference> finalizers = Sets.newConcurrentHashSet();
+    private final ReferenceQueue<Object> finalizerQueue = new ReferenceQueue<>();
+    private final ExecutorService executor = Executors.newCachedThreadPool(daemonThreadsNamed("FinalizerService-%s"));
+    @GuardedBy("this")
+    private Future<?> finalizerTask;
+
+    @PostConstruct
+    public synchronized void start()
+    {
+        if (finalizerTask != null) {
+            return;
+        }
+        if (executor.isShutdown()) {
+            throw new IllegalStateException("Finalizer service has been destroyed");
+        }
+        finalizerTask = executor.submit((Runnable) this::processFinalizerQueue);
+    }
+
+    @PreDestroy
+    public synchronized void destroy()
+    {
+        if (finalizerTask != null) {
+            finalizerTask.cancel(true);
+            finalizerTask = null;
+        }
+        executor.shutdownNow();
+    }
+
+    /**
+     * When referent is freed by the garbage collector, run cleanup.
+     *
+     * Note: cleanup must not contain a reference to the referent object.
+     */
+    public void addFinalizer(Object referent, Runnable cleanup)
+    {
+        requireNonNull(referent, "referent is null");
+        requireNonNull(cleanup, "cleanup is null");
+        finalizers.add(new FinalizerReference(referent, finalizerQueue, cleanup));
+    }
+
+    private void processFinalizerQueue()
+    {
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                FinalizerReference finalizer = (FinalizerReference) finalizerQueue.remove();
+                finalizers.remove(finalizer);
+                finalizer.cleanup();
+            }
+            catch (InterruptedException e) {
+                return;
+            }
+            catch (Throwable e) {
+                log.error(e, "Finalizer cleanup failed");
+            }
+        }
+    }
+
+    private static class FinalizerReference
+            extends PhantomReference<Object>
+    {
+        private final Runnable cleanup;
+        private final AtomicBoolean executed = new AtomicBoolean();
+
+        public FinalizerReference(Object referent, ReferenceQueue<Object> queue, Runnable cleanup)
+        {
+            super(requireNonNull(referent, "referent is null"), requireNonNull(queue, "queue is null"));
+            this.cleanup = requireNonNull(cleanup, "cleanup is null");
+        }
+
+        public void cleanup()
+        {
+            if (executed.compareAndSet(false, true)) {
+                cleanup.run();
+            }
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -15,7 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.Session;
-import com.facebook.presto.execution.NodeTaskMap.SplitCountChangeListener;
+import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import com.facebook.presto.memory.MemoryPool;
 import com.facebook.presto.memory.MemoryPoolId;
 import com.facebook.presto.memory.QueryContext;
@@ -38,7 +38,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import io.airlift.units.DataSize;
 import org.joda.time.DateTime;
@@ -46,6 +45,7 @@ import org.joda.time.DateTime;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.net.URI;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -74,16 +74,14 @@ public class MockRemoteTaskFactory
         this.executor = executor;
     }
 
-    public RemoteTask createTableScanTask(Node newNode, List<Split> splits, SplitCountChangeListener splitCountChangeListener)
+    public RemoteTask createTableScanTask(TaskId taskId, Node newNode, List<Split> splits, PartitionedSplitCountTracker partitionedSplitCountTracker)
     {
-        TaskId taskId = new TaskId(new StageId("test", "1"), "1");
         Symbol symbol = new Symbol("column");
-        PlanNodeId tableScanNodeId = new PlanNodeId("test");
         PlanNodeId sourceId = new PlanNodeId("sourceId");
         PlanFragment testFragment = new PlanFragment(
                 new PlanFragmentId("test"),
                 new TableScanNode(
-                        new PlanNodeId("test"),
+                        sourceId,
                         new TableHandle("test", new TestingTableHandle()),
                         ImmutableList.of(symbol),
                         ImmutableMap.of(symbol, new TestingColumnHandle("column")),
@@ -93,7 +91,7 @@ public class MockRemoteTaskFactory
                 ImmutableMap.<Symbol, Type>of(symbol, VARCHAR),
                 ImmutableList.of(symbol),
                 PlanFragment.PlanDistribution.SOURCE,
-                tableScanNodeId,
+                sourceId,
                 PlanFragment.OutputPartitioning.NONE,
                 Optional.empty(),
                 Optional.empty(),
@@ -104,7 +102,7 @@ public class MockRemoteTaskFactory
         for (Split sourceSplit : splits) {
             initialSplits.put(sourceId, sourceSplit);
         }
-        return createRemoteTask(TEST_SESSION, taskId, newNode, testFragment, initialSplits.build(), OutputBuffers.INITIAL_EMPTY_OUTPUT_BUFFERS, splitCountChangeListener);
+        return createRemoteTask(TEST_SESSION, taskId, newNode, testFragment, initialSplits.build(), OutputBuffers.INITIAL_EMPTY_OUTPUT_BUFFERS, partitionedSplitCountTracker);
     }
 
     @Override
@@ -115,12 +113,12 @@ public class MockRemoteTaskFactory
             PlanFragment fragment,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
-            SplitCountChangeListener splitCountChangeListener)
+            PartitionedSplitCountTracker partitionedSplitCountTracker)
     {
-        return new MockRemoteTask(taskId, fragment, node.getNodeIdentifier(), executor, initialSplits, splitCountChangeListener);
+        return new MockRemoteTask(taskId, fragment, node.getNodeIdentifier(), executor, initialSplits, partitionedSplitCountTracker);
     }
 
-    public static class MockRemoteTask
+    public static final class MockRemoteTask
             implements RemoteTask
     {
         private final AtomicLong nextTaskInfoVersion = new AtomicLong(TaskInfo.STARTING_VERSION);
@@ -139,14 +137,14 @@ public class MockRemoteTaskFactory
         @GuardedBy("this")
         private final Multimap<PlanNodeId, Split> splits = HashMultimap.create();
 
-        private final SplitCountChangeListener splitCountChangeListener;
+        private final PartitionedSplitCountTracker partitionedSplitCountTracker;
 
         public MockRemoteTask(TaskId taskId,
                 PlanFragment fragment,
                 String nodeId,
                 Executor executor,
                 Multimap<PlanNodeId, Split> initialSplits,
-                SplitCountChangeListener splitCountChangeListener)
+                PartitionedSplitCountTracker partitionedSplitCountTracker)
         {
             this.taskStateMachine = new TaskStateMachine(requireNonNull(taskId, "taskId is null"), requireNonNull(executor, "executor is null"));
 
@@ -160,8 +158,8 @@ public class MockRemoteTaskFactory
             this.fragment = requireNonNull(fragment, "fragment is null");
             this.nodeId = requireNonNull(nodeId, "nodeId is null");
             splits.putAll(initialSplits);
-            this.splitCountChangeListener = requireNonNull(splitCountChangeListener, "splitCountChangeListener is null");
-            this.splitCountChangeListener.splitCountChanged(initialSplits.size());
+            this.partitionedSplitCountTracker = requireNonNull(partitionedSplitCountTracker, "partitionedSplitCountTracker is null");
+            partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
         }
 
         @Override
@@ -200,27 +198,34 @@ public class MockRemoteTaskFactory
 
         public synchronized void clearSplits()
         {
-            splitCountChangeListener.splitCountChanged(-splits.size());
             splits.clear();
+            partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
         }
 
         @Override
         public void start()
         {
+            taskStateMachine.addStateChangeListener(newValue -> {
+                if (newValue.isDone()) {
+                    clearSplits();
+                }
+            });
         }
 
         @Override
-        public synchronized void addSplits(PlanNodeId sourceId, Iterable<Split> splits)
+        public void addSplits(PlanNodeId sourceId, Iterable<Split> splits)
         {
             requireNonNull(splits, "splits is null");
-            for (Split split : splits) {
-                this.splits.put(sourceId, split);
+            synchronized (this) {
+                for (Split split : splits) {
+                    this.splits.put(sourceId, split);
+                }
             }
-            splitCountChangeListener.splitCountChanged(Iterables.size(splits));
+            partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
         }
 
         @Override
-        public void noMoreSplits(PlanNodeId sourceId)
+        public synchronized void noMoreSplits(PlanNodeId sourceId)
         {
             noMoreSplits.add(sourceId);
 
@@ -243,15 +248,7 @@ public class MockRemoteTaskFactory
         @Override
         public void addStateChangeListener(StateChangeListener<TaskInfo> stateChangeListener)
         {
-            taskStateMachine.addStateChangeListener(newValue -> {
-                if (newValue.isDone()) {
-                    synchronized (this) {
-                        splitCountChangeListener.splitCountChanged(-splits.size());
-                        splits.clear();
-                    }
-                }
-                stateChangeListener.stateChanged(getTaskInfo());
-            });
+            taskStateMachine.addStateChangeListener(newValue -> stateChangeListener.stateChanged(getTaskInfo()));
         }
 
         @Override
@@ -267,29 +264,31 @@ public class MockRemoteTaskFactory
         }
 
         @Override
-        public synchronized void abort()
+        public void abort()
         {
             taskStateMachine.abort();
-            splitCountChangeListener.splitCountChanged(-splits.size());
-            splits.clear();
+            clearSplits();
         }
 
         @Override
-        public synchronized int getPartitionedSplitCount()
+        public int getPartitionedSplitCount()
+        {
+            return getQueuedPartitionedSplitCount();
+        }
+
+        @Override
+        public int getQueuedPartitionedSplitCount()
         {
             if (taskStateMachine.getState().isDone()) {
                 return 0;
             }
-            return splits.size();
-        }
-
-        @Override
-        public synchronized int getQueuedPartitionedSplitCount()
-        {
-            if (taskStateMachine.getState().isDone()) {
-                return 0;
+            synchronized (this) {
+                Collection<Split> partitionedSplits = splits.get(fragment.getPartitionedSource());
+                if (partitionedSplits == null) {
+                    return 0;
+                }
+                return partitionedSplits.size();
             }
-            return splits.size();
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -29,6 +29,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -165,9 +166,12 @@ public class TestNodeScheduler
 
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor);
         // Max out number of splits on node
-        RemoteTask remoteTask1 = remoteTaskFactory.createTableScanTask(newNode, initialSplits.build(), nodeTaskMap.getSplitCountChangeListener(newNode));
+        TaskId taskId1 = new TaskId(new StageId("test", "1"), "1");
+        RemoteTask remoteTask1 = remoteTaskFactory.createTableScanTask(taskId1, newNode, initialSplits.build(), nodeTaskMap.createPartitionedSplitCountTracker(newNode, taskId1));
         nodeTaskMap.addTask(newNode, remoteTask1);
-        RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(newNode, initialSplits.build(), nodeTaskMap.getSplitCountChangeListener(newNode));
+
+        TaskId taskId2 = new TaskId(new StageId("test", "1"), "2");
+        RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(taskId2, newNode, initialSplits.build(), nodeTaskMap.createPartitionedSplitCountTracker(newNode, taskId2));
         nodeTaskMap.addTask(newNode, remoteTask2);
 
         Set<Split> splits = new HashSet<>();
@@ -178,6 +182,11 @@ public class TestNodeScheduler
 
         // no split should be assigned to the newNode, as it already has maxNodeSplits assigned to it
         assertFalse(assignments.keySet().contains(newNode));
+
+        remoteTask1.abort();
+        remoteTask2.abort();
+
+        assertEquals(nodeTaskMap.getPartitionedSplitsOnNode(newNode), 0);
     }
 
     @Test
@@ -192,17 +201,22 @@ public class TestNodeScheduler
             initialSplits.add(new Split("foo", new TestSplitRemote()));
         }
 
+        List<RemoteTask> tasks = new ArrayList<>();
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor);
         for (Node node : nodeManager.getActiveDatasourceNodes("foo")) {
             // Max out number of splits on node
-            RemoteTask remoteTask = remoteTaskFactory.createTableScanTask(node, initialSplits.build(), nodeTaskMap.getSplitCountChangeListener(node));
+            TaskId taskId = new TaskId(new StageId("test", "1"), "1");
+            RemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, initialSplits.build(), nodeTaskMap.createPartitionedSplitCountTracker(node, taskId));
             nodeTaskMap.addTask(node, remoteTask);
+            tasks.add(remoteTask);
         }
 
-        RemoteTask newRemoteTask = remoteTaskFactory.createTableScanTask(newNode, initialSplits.build(), nodeTaskMap.getSplitCountChangeListener(newNode));
+        TaskId taskId = new TaskId(new StageId("test", "1"), "2");
+        RemoteTask newRemoteTask = remoteTaskFactory.createTableScanTask(taskId, newNode, initialSplits.build(), nodeTaskMap.createPartitionedSplitCountTracker(newNode, taskId));
         // Max out pending splits on new node
         taskMap.put(newNode, newRemoteTask);
         nodeTaskMap.addTask(newNode, newRemoteTask);
+        tasks.add(newRemoteTask);
 
         Set<Split> splits = new HashSet<>();
         for (int i = 0; i < 5; i++) {
@@ -214,6 +228,11 @@ public class TestNodeScheduler
         // maxSplitsPerNode + maxSplitsPerNodePerTask assigned to it
         assertEquals(assignments.keySet().size(), 3); // Splits should be scheduled on the other three nodes
         assertFalse(assignments.keySet().contains(newNode)); // No splits scheduled on the maxed out node
+
+        for (RemoteTask task : tasks) {
+            task.abort();
+        }
+        assertEquals(nodeTaskMap.getPartitionedSplitsOnNode(newNode), 0);
     }
 
     @Test
@@ -222,11 +241,19 @@ public class TestNodeScheduler
     {
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor);
         Node chosenNode = Iterables.get(nodeManager.getActiveDatasourceNodes("foo"), 0);
-        RemoteTask remoteTask = remoteTaskFactory.createTableScanTask(chosenNode, ImmutableList.of(new Split("foo", new TestSplitRemote())), nodeTaskMap.getSplitCountChangeListener(chosenNode));
+        TaskId taskId = new TaskId(new StageId("test", "1"), "1");
+        RemoteTask remoteTask = remoteTaskFactory.createTableScanTask(
+                taskId,
+                chosenNode,
+                ImmutableList.of(new Split("foo", new TestSplitRemote())),
+                nodeTaskMap.createPartitionedSplitCountTracker(chosenNode, taskId));
         nodeTaskMap.addTask(chosenNode, remoteTask);
         assertEquals(nodeTaskMap.getPartitionedSplitsOnNode(chosenNode), 1);
         remoteTask.abort();
         TimeUnit.MILLISECONDS.sleep(100); // Sleep until cache expires
+        assertEquals(nodeTaskMap.getPartitionedSplitsOnNode(chosenNode), 0);
+
+        remoteTask.abort();
         assertEquals(nodeTaskMap.getPartitionedSplitsOnNode(chosenNode), 0);
     }
 
@@ -236,14 +263,25 @@ public class TestNodeScheduler
     {
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor);
         Node chosenNode = Iterables.get(nodeManager.getActiveDatasourceNodes("foo"), 0);
-        RemoteTask remoteTask = remoteTaskFactory.createTableScanTask(chosenNode, ImmutableList.of(new Split("foo", new TestSplitRemote()), new Split("bar", new TestSplitRemote())), nodeTaskMap.getSplitCountChangeListener(chosenNode));
-        RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(chosenNode, ImmutableList.of(new Split("foo2", new TestSplitRemote())), nodeTaskMap.getSplitCountChangeListener(chosenNode));
 
-        nodeTaskMap.addTask(chosenNode, remoteTask);
+        TaskId taskId1 = new TaskId(new StageId("test", "1"), "1");
+        RemoteTask remoteTask1 = remoteTaskFactory.createTableScanTask(taskId1,
+                chosenNode,
+                ImmutableList.of(new Split("foo", new TestSplitRemote()), new Split("bar", new TestSplitRemote())),
+                nodeTaskMap.createPartitionedSplitCountTracker(chosenNode, taskId1));
+
+        TaskId taskId2 = new TaskId(new StageId("test", "1"), "2");
+        RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(
+                taskId2,
+                chosenNode,
+                ImmutableList.of(new Split("foo2", new TestSplitRemote())),
+                nodeTaskMap.createPartitionedSplitCountTracker(chosenNode, taskId2));
+
+        nodeTaskMap.addTask(chosenNode, remoteTask1);
         nodeTaskMap.addTask(chosenNode, remoteTask2);
         assertEquals(nodeTaskMap.getPartitionedSplitsOnNode(chosenNode), 3);
 
-        remoteTask.abort();
+        remoteTask1.abort();
         assertEquals(nodeTaskMap.getPartitionedSplitsOnNode(chosenNode), 1);
         remoteTask2.abort();
         assertEquals(nodeTaskMap.getPartitionedSplitsOnNode(chosenNode), 0);

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestCurrentNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestCurrentNodeScheduler.java
@@ -15,8 +15,9 @@ package com.facebook.presto.execution.scheduler;
 
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.execution.MockRemoteTaskFactory;
+import com.facebook.presto.execution.StageId;
+import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.metadata.PrestoNode;
-import com.facebook.presto.spi.Node;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -46,8 +47,7 @@ public class TestCurrentNodeScheduler
         MockRemoteTaskFactory taskFactory = new MockRemoteTaskFactory(executor);
 
         CurrentNodeScheduler nodeScheduler = new CurrentNodeScheduler(
-                node -> taskFactory.createTableScanTask((Node) node, ImmutableList.of(), (delta) -> {
-                }),
+                node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), node, ImmutableList.of(), delta -> { }),
                 () -> new PrestoNode("other1", URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN));
 
         ScheduleResult result = nodeScheduler.schedule();

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestCurrentNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestCurrentNodeScheduler.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution.scheduler;
 
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.execution.MockRemoteTaskFactory;
+import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import com.facebook.presto.execution.StageId;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.metadata.PrestoNode;
@@ -47,7 +48,7 @@ public class TestCurrentNodeScheduler
         MockRemoteTaskFactory taskFactory = new MockRemoteTaskFactory(executor);
 
         CurrentNodeScheduler nodeScheduler = new CurrentNodeScheduler(
-                node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), node, ImmutableList.of(), delta -> { }),
+                node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), node, ImmutableList.of(), new PartitionedSplitCountTracker(delta -> { })),
                 () -> new PrestoNode("other1", URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN));
 
         ScheduleResult result = nodeScheduler.schedule();

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
@@ -16,6 +16,8 @@ package com.facebook.presto.execution.scheduler;
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.execution.MockRemoteTaskFactory;
 import com.facebook.presto.execution.RemoteTask;
+import com.facebook.presto.execution.StageId;
+import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.metadata.PrestoNode;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.PrestoException;
@@ -56,8 +58,7 @@ public class TestFixedCountScheduler
             throws Exception
     {
         FixedCountScheduler nodeScheduler = new FixedCountScheduler(
-                node -> taskFactory.createTableScanTask((Node) node, ImmutableList.of(), delta -> {
-                }),
+                node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), node, ImmutableList.of(), delta -> { }),
                 TestFixedCountScheduler::generateRandomNodes,
                 1);
 
@@ -73,8 +74,7 @@ public class TestFixedCountScheduler
             throws Exception
     {
         FixedCountScheduler nodeScheduler = new FixedCountScheduler(
-                node -> taskFactory.createTableScanTask((Node) node, ImmutableList.of(), delta -> {
-                }),
+                node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), node, ImmutableList.of(), delta -> { }),
                 TestFixedCountScheduler::generateRandomNodes,
                 5);
 
@@ -90,8 +90,7 @@ public class TestFixedCountScheduler
             throws Exception
     {
         FixedCountScheduler nodeScheduler = new FixedCountScheduler(
-                node -> taskFactory.createTableScanTask((Node) node, ImmutableList.of(), delta -> {
-                }),
+                node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), node, ImmutableList.of(), delta -> { }),
                 count -> generateRandomNodes(3),
                 5);
 
@@ -108,8 +107,7 @@ public class TestFixedCountScheduler
     {
         try {
             FixedCountScheduler nodeScheduler = new FixedCountScheduler(
-                    node -> taskFactory.createTableScanTask((Node) node, ImmutableList.of(), delta -> {
-                    }),
+                    node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), (Node) node, ImmutableList.of(), delta -> { }),
                     count -> generateRandomNodes(0),
                     5);
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution.scheduler;
 
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.execution.MockRemoteTaskFactory;
+import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import com.facebook.presto.execution.RemoteTask;
 import com.facebook.presto.execution.StageId;
 import com.facebook.presto.execution.TaskId;
@@ -58,7 +59,7 @@ public class TestFixedCountScheduler
             throws Exception
     {
         FixedCountScheduler nodeScheduler = new FixedCountScheduler(
-                node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), node, ImmutableList.of(), delta -> { }),
+                node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), node, ImmutableList.of(), new PartitionedSplitCountTracker(delta -> { })),
                 TestFixedCountScheduler::generateRandomNodes,
                 1);
 
@@ -74,7 +75,7 @@ public class TestFixedCountScheduler
             throws Exception
     {
         FixedCountScheduler nodeScheduler = new FixedCountScheduler(
-                node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), node, ImmutableList.of(), delta -> { }),
+                node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), node, ImmutableList.of(), new PartitionedSplitCountTracker(delta -> { })),
                 TestFixedCountScheduler::generateRandomNodes,
                 5);
 
@@ -90,7 +91,7 @@ public class TestFixedCountScheduler
             throws Exception
     {
         FixedCountScheduler nodeScheduler = new FixedCountScheduler(
-                node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), node, ImmutableList.of(), delta -> { }),
+                node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), node, ImmutableList.of(), new PartitionedSplitCountTracker(delta -> { })),
                 count -> generateRandomNodes(3),
                 5);
 
@@ -107,7 +108,7 @@ public class TestFixedCountScheduler
     {
         try {
             FixedCountScheduler nodeScheduler = new FixedCountScheduler(
-                    node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), (Node) node, ImmutableList.of(), delta -> { }),
+                    node -> taskFactory.createTableScanTask(new TaskId(new StageId("test", "1"), "1"), (Node) node, ImmutableList.of(), new PartitionedSplitCountTracker(delta -> { })),
                     count -> generateRandomNodes(0),
                     5);
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -119,6 +119,8 @@ public class TestSourcePartitionedScheduler
         assertTrue(scheduleResult.isFinished());
         assertTrue(scheduleResult.getBlocked().isDone());
         assertTrue(scheduleResult.getNewTasks().isEmpty());
+
+        stage.abort();
     }
 
     @Test
@@ -150,6 +152,8 @@ public class TestSourcePartitionedScheduler
         for (RemoteTask remoteTask : stage.getAllTasks()) {
             assertEquals(remoteTask.getPartitionedSplitCount(), 20);
         }
+
+        stage.abort();
     }
 
     @Test
@@ -181,6 +185,8 @@ public class TestSourcePartitionedScheduler
         for (RemoteTask remoteTask : stage.getAllTasks()) {
             assertEquals(remoteTask.getPartitionedSplitCount(), 20);
         }
+
+        stage.abort();
     }
 
     @Test
@@ -239,6 +245,8 @@ public class TestSourcePartitionedScheduler
         for (RemoteTask remoteTask : stage.getAllTasks()) {
             assertEquals(remoteTask.getPartitionedSplitCount(), 20);
         }
+
+        stage.abort();
     }
 
     @Test
@@ -331,6 +339,9 @@ public class TestSourcePartitionedScheduler
         assertEquals(secondStage.getAllTasks().size(), 1);
         RemoteTask task = secondStage.getAllTasks().get(0);
         assertEquals(task.getPartitionedSplitCount(), 5);
+
+        firstStage.abort();
+        secondStage.abort();
     }
 
     @Test
@@ -366,6 +377,9 @@ public class TestSourcePartitionedScheduler
         for (RemoteTask remoteTask : secondStage.getAllTasks()) {
             assertEquals(remoteTask.getPartitionedSplitCount(), 0);
         }
+
+        firstStage.abort();
+        secondStage.abort();
     }
 
     private static void assertPartitionedSplitCount(SqlStageExecution stage, int expectedPartitionedSplitCount)

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -51,10 +51,12 @@ import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.facebook.presto.util.FinalizerService;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
@@ -89,6 +91,7 @@ public class TestSourcePartitionedScheduler
     private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stageExecutor-%s"));
     private final LocationFactory locationFactory = new MockLocationFactory();
     private final InMemoryNodeManager nodeManager = new InMemoryNodeManager();
+    private final FinalizerService finalizerService = new FinalizerService();
 
     public TestSourcePartitionedScheduler()
     {
@@ -98,10 +101,17 @@ public class TestSourcePartitionedScheduler
                 new PrestoNode("other3", URI.create("http://127.0.0.1:13"), NodeVersion.UNKNOWN));
     }
 
+    @BeforeClass
+    public void setUp()
+    {
+        finalizerService.start();
+    }
+
     @AfterClass
     public void destroyExecutor()
     {
         executor.shutdownNow();
+        finalizerService.destroy();
     }
 
     @Test
@@ -109,7 +119,7 @@ public class TestSourcePartitionedScheduler
             throws Exception
     {
         StageExecutionPlan plan = createPlan(createFixedSplitSource(0, TestingSplit::createRemoteSplit));
-        NodeTaskMap nodeTaskMap = new NodeTaskMap();
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
         SqlStageExecution stage = createSqlStageExecution(plan, nodeTaskMap);
 
         SourcePartitionedScheduler scheduler = getSourcePartitionedScheduler(plan, stage, nodeManager, nodeTaskMap, 1);
@@ -128,7 +138,7 @@ public class TestSourcePartitionedScheduler
             throws Exception
     {
         StageExecutionPlan plan = createPlan(createFixedSplitSource(60, TestingSplit::createRemoteSplit));
-        NodeTaskMap nodeTaskMap = new NodeTaskMap();
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
         SqlStageExecution stage = createSqlStageExecution(plan, nodeTaskMap);
 
         SourcePartitionedScheduler scheduler = getSourcePartitionedScheduler(plan, stage, nodeManager, nodeTaskMap, 1);
@@ -161,7 +171,7 @@ public class TestSourcePartitionedScheduler
             throws Exception
     {
         StageExecutionPlan plan = createPlan(createFixedSplitSource(60, TestingSplit::createRemoteSplit));
-        NodeTaskMap nodeTaskMap = new NodeTaskMap();
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
         SqlStageExecution stage = createSqlStageExecution(plan, nodeTaskMap);
 
         SourcePartitionedScheduler scheduler = getSourcePartitionedScheduler(plan, stage, nodeManager, nodeTaskMap, 7);
@@ -194,7 +204,7 @@ public class TestSourcePartitionedScheduler
             throws Exception
     {
         StageExecutionPlan plan = createPlan(createFixedSplitSource(80, TestingSplit::createRemoteSplit));
-        NodeTaskMap nodeTaskMap = new NodeTaskMap();
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
         SqlStageExecution stage = createSqlStageExecution(plan, nodeTaskMap);
 
         SourcePartitionedScheduler scheduler = getSourcePartitionedScheduler(plan, stage, nodeManager, nodeTaskMap, 1);
@@ -255,7 +265,7 @@ public class TestSourcePartitionedScheduler
     {
         QueuedSplitSource queuedSplitSource = new QueuedSplitSource(TestingSplit::createRemoteSplit);
         StageExecutionPlan plan = createPlan(queuedSplitSource);
-        NodeTaskMap nodeTaskMap = new NodeTaskMap();
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
         SqlStageExecution stage = createSqlStageExecution(plan, nodeTaskMap);
 
         SourcePartitionedScheduler scheduler = getSourcePartitionedScheduler(plan, stage, nodeManager, nodeTaskMap, 1);
@@ -276,7 +286,7 @@ public class TestSourcePartitionedScheduler
             throws Exception
     {
         try {
-            NodeTaskMap nodeTaskMap = new NodeTaskMap();
+            NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
             InMemoryNodeManager nodeManager = new InMemoryNodeManager();
             NodeScheduler nodeScheduler = new NodeScheduler(nodeManager, new NodeSchedulerConfig().setIncludeCoordinator(false), nodeTaskMap);
 
@@ -307,7 +317,7 @@ public class TestSourcePartitionedScheduler
                 new PrestoNode("other1", URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN),
                 new PrestoNode("other2", URI.create("http://127.0.0.1:12"), NodeVersion.UNKNOWN),
                 new PrestoNode("other3", URI.create("http://127.0.0.1:13"), NodeVersion.UNKNOWN));
-        NodeTaskMap nodeTaskMap = new NodeTaskMap();
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
 
         // Schedule 15 splits - there are 3 nodes, each node should get 5 splits
         StageExecutionPlan firstPlan = createPlan(createFixedSplitSource(15, TestingSplit::createRemoteSplit));
@@ -348,7 +358,7 @@ public class TestSourcePartitionedScheduler
     public void testBlockCausesFullSchedule()
             throws Exception
     {
-        NodeTaskMap nodeTaskMap = new NodeTaskMap();
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
 
         // Schedule 60 splits - filling up all nodes
         StageExecutionPlan firstPlan = createPlan(createFixedSplitSource(60, TestingSplit::createRemoteSplit));


### PR DESCRIPTION
Insead of updating by deltas, which is error prone, set the full current
value.  Also, add a finalizer to detect leaked slots, and remove the leaked
slots (and log an error).  Finally, change HttpRemoteTask get count methods
to return zero when the task is in a done state.