### PR TITLE
Improve performance of InCodeGenerator

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.126.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.126.rst
@@ -14,6 +14,8 @@ General Changes
   within a task. This allows us to optimize for index cache hits or for more
   CPU parallelism. This option is toggled by the ``task.share-index-loading``
   config property or the ``task_share_index_loading`` session property.
+* Improve performance of queries that use ``IN`` expressions with large lists
+  of constant values.
 
 Hive Changes
 ------------

--- a/presto-main/src/main/java/com/facebook/presto/util/FastutilSetHelper.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/FastutilSetHelper.java
@@ -43,18 +43,21 @@ public final class FastutilSetHelper
     @SuppressWarnings({"unchecked"})
     public static Set<?> toFastutilHashSet(Set<?> set, Type type, FunctionRegistry registry)
     {
+        // 0.25 as the load factor is chosen because the argument set is assumed to be small (<10000),
+        // and the return set is assumed to be read-heavy.
+        // The performance of InCodeGenerator heavily depends on the load factor being small.
         Class<?> javaElementType = type.getJavaType();
         if (javaElementType == long.class) {
-            return new LongOpenCustomHashSet((Collection<Long>) set, new LongStrategy(registry, type));
+            return new LongOpenCustomHashSet((Collection<Long>) set, 0.25f, new LongStrategy(registry, type));
         }
         if (javaElementType == double.class) {
-            return new DoubleOpenCustomHashSet((Collection<Double>) set, new DoubleStrategy(registry, type));
+            return new DoubleOpenCustomHashSet((Collection<Double>) set, 0.25f, new DoubleStrategy(registry, type));
         }
         if (javaElementType == boolean.class) {
-            return new BooleanOpenHashSet((Collection<Boolean>) set);
+            return new BooleanOpenHashSet((Collection<Boolean>) set, 0.25f);
         }
         else if (!type.getJavaType().isPrimitive()) {
-            return new ObjectOpenCustomHashSet(set, new ObjectStrategy(registry, type));
+            return new ObjectOpenCustomHashSet(set, 0.25f, new ObjectStrategy(registry, type));
         }
         else {
             throw new UnsupportedOperationException("Unsupported native type in set: " + type.getJavaType() + " with type " + type.getTypeSignature());

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/InCodeGeneratorBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/InCodeGeneratorBenchmark.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.gen;
+
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.PageProcessor;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.relational.RowExpression;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.metadata.FunctionKind.SCALAR;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.field;
+import static com.facebook.presto.sql.relational.Signatures.IN;
+import static com.google.common.base.Preconditions.checkState;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(10)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(AverageTime)
+@SuppressWarnings("FieldMayBeFinal")
+public class InCodeGeneratorBenchmark
+{
+    @Param({"1", "5", "10", "25", "50", "75", "100", "150", "200", "250", "300", "350", "400", "450", "500", "750", "1000", "10000"})
+    private int inListCount = 1;
+
+    @Param({StandardTypes.BIGINT, StandardTypes.DOUBLE, StandardTypes.VARCHAR})
+    private String type = StandardTypes.BIGINT;
+
+    private Page inputPage;
+    private PageProcessor processor;
+    private Type prestoType;
+
+    @Setup
+    public void setup()
+    {
+        Random random = new Random();
+        RowExpression[] arguments = new RowExpression[1 + inListCount];
+        switch (type) {
+            case StandardTypes.BIGINT:
+                prestoType = BIGINT;
+                for (int i = 1; i <= inListCount; i++) {
+                    arguments[i] = constant((long) random.nextInt(), BIGINT);
+                }
+                break;
+            case StandardTypes.DOUBLE:
+                prestoType = DOUBLE;
+                for (int i = 1; i <= inListCount; i++) {
+                    arguments[i] = constant(random.nextDouble(), DOUBLE);
+                }
+                break;
+            case StandardTypes.VARCHAR:
+                prestoType = VARCHAR;
+                for (int i = 1; i <= inListCount; i++) {
+                    arguments[i] = constant(Slices.utf8Slice(Long.toString(random.nextLong())), VARCHAR);
+                }
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+
+        arguments[0] = field(0, prestoType);
+        RowExpression project = field(0, prestoType);
+
+        PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(prestoType));
+        for (int i = 0; i < 10_000; i++) {
+            pageBuilder.declarePosition();
+
+            switch (type) {
+                case StandardTypes.BIGINT:
+                    BIGINT.writeLong(pageBuilder.getBlockBuilder(0), random.nextInt());
+                    break;
+                case StandardTypes.DOUBLE:
+                    DOUBLE.writeDouble(pageBuilder.getBlockBuilder(0), random.nextDouble());
+                    break;
+                case StandardTypes.VARCHAR:
+                    VARCHAR.writeSlice(pageBuilder.getBlockBuilder(0), Slices.utf8Slice(Long.toString(random.nextLong())));
+                    break;
+            }
+        }
+        inputPage = pageBuilder.build();
+
+        RowExpression filter = call(
+                new Signature(IN, SCALAR, StandardTypes.BOOLEAN),
+                BOOLEAN,
+                arguments);
+
+        processor = new ExpressionCompiler(MetadataManager.createTestMetadataManager()).compilePageProcessor(filter, ImmutableList.of(project));
+    }
+
+    @Benchmark
+    public Page benchmark()
+    {
+        PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(prestoType));
+        int count = processor.process(null, inputPage, 0, inputPage.getPositionCount(), pageBuilder);
+        checkState(count == inputPage.getPositionCount());
+        return pageBuilder.build();
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + InCodeGeneratorBenchmark.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestInCodeGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestInCodeGenerator.java
@@ -61,12 +61,12 @@ public class TestInCodeGenerator
         ));
         assertEquals(checkSwitchGenerationCase(BIGINT, values), DIRECT_SWITCH);
 
-        for  (long i = 6; i <= 1000; ++i) {
+        for  (long i = 6; i <= 32; ++i) {
             values.add(new ConstantExpression(i, BIGINT));
         }
         assertEquals(checkSwitchGenerationCase(BIGINT, values), DIRECT_SWITCH);
 
-        values.add(new ConstantExpression(1001L, BIGINT));
+        values.add(new ConstantExpression(33L, BIGINT));
         assertEquals(checkSwitchGenerationCase(BIGINT, values), SET_CONTAINS);
     }
 
@@ -93,12 +93,12 @@ public class TestInCodeGenerator
         ));
         assertEquals(checkSwitchGenerationCase(BIGINT, values), HASH_SWITCH);
 
-        for  (long i = 6; i <= 1000; ++i) {
+        for  (long i = 6; i <= 32; ++i) {
             values.add(new ConstantExpression(i, BIGINT));
         }
         assertEquals(checkSwitchGenerationCase(BIGINT, values), HASH_SWITCH);
 
-        values.add(new ConstantExpression(1001L, BIGINT));
+        values.add(new ConstantExpression(33L, BIGINT));
         assertEquals(checkSwitchGenerationCase(BIGINT, values), SET_CONTAINS);
     }
 
@@ -111,12 +111,12 @@ public class TestInCodeGenerator
         values.add(new ConstantExpression(3L, DATE));
         assertEquals(checkSwitchGenerationCase(DATE, values), DIRECT_SWITCH);
 
-        for  (long i = 4; i <= 1000; ++i) {
+        for  (long i = 4; i <= 32; ++i) {
             values.add(new ConstantExpression(i, DATE));
         }
         assertEquals(checkSwitchGenerationCase(DATE, values), DIRECT_SWITCH);
 
-        values.add(new ConstantExpression(1001L, DATE));
+        values.add(new ConstantExpression(33L, DATE));
         assertEquals(checkSwitchGenerationCase(DATE, values), SET_CONTAINS);
     }
 
@@ -132,12 +132,12 @@ public class TestInCodeGenerator
         values.add(new ConstantExpression(null, DOUBLE));
         assertEquals(checkSwitchGenerationCase(DOUBLE, values), HASH_SWITCH);
 
-        for  (int i = 5; i <= 1000; ++i) {
+        for  (int i = 5; i <= 32; ++i) {
             values.add(new ConstantExpression(i + 0.5, DOUBLE));
         }
         assertEquals(checkSwitchGenerationCase(DOUBLE, values), HASH_SWITCH);
 
-        values.add(new ConstantExpression(1001.5, DOUBLE));
+        values.add(new ConstantExpression(33.5, DOUBLE));
         assertEquals(checkSwitchGenerationCase(DOUBLE, values), SET_CONTAINS);
     }
 
@@ -153,12 +153,12 @@ public class TestInCodeGenerator
         values.add(new ConstantExpression(null, VARCHAR));
         assertEquals(checkSwitchGenerationCase(VARCHAR, values), HASH_SWITCH);
 
-        for  (int i = 5; i <= 1000; ++i) {
+        for  (int i = 5; i <= 32; ++i) {
             values.add(new ConstantExpression(Slices.utf8Slice(String.valueOf(i)), VARCHAR));
         }
         assertEquals(checkSwitchGenerationCase(VARCHAR, values), HASH_SWITCH);
 
-        values.add(new ConstantExpression(Slices.utf8Slice("1001"), VARCHAR));
+        values.add(new ConstantExpression(Slices.utf8Slice("33"), VARCHAR));
         assertEquals(checkSwitchGenerationCase(VARCHAR, values), SET_CONTAINS);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestInCodeGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestInCodeGenerator.java
@@ -14,10 +14,10 @@
 package com.facebook.presto.sql.gen;
 
 import com.facebook.presto.metadata.Signature;
-import com.facebook.presto.sql.gen.InCodeGenerator.SwitchGenerationCase;
 import com.facebook.presto.sql.relational.CallExpression;
 import com.facebook.presto.sql.relational.ConstantExpression;
 import com.facebook.presto.sql.relational.RowExpression;
+import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -28,6 +28,7 @@ import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.gen.InCodeGenerator.SwitchGenerationCase.DIRECT_SWITCH;
 import static com.facebook.presto.sql.gen.InCodeGenerator.SwitchGenerationCase.HASH_SWITCH;
 import static com.facebook.presto.sql.gen.InCodeGenerator.SwitchGenerationCase.SET_CONTAINS;
@@ -38,11 +39,11 @@ import static org.testng.Assert.assertEquals;
 public class TestInCodeGenerator
 {
     @Test
-    public void testDirectSwitchBigint()
+    public void testBigintSmall()
     {
         List<RowExpression> values = new ArrayList<>();
-        values.add(new ConstantExpression(1L, BIGINT));
-        values.add(new ConstantExpression(2L, BIGINT));
+        values.add(new ConstantExpression((long) Integer.MIN_VALUE, BIGINT));
+        values.add(new ConstantExpression((long) Integer.MAX_VALUE, BIGINT));
         values.add(new ConstantExpression(3L, BIGINT));
         assertEquals(checkSwitchGenerationCase(BIGINT, values), DIRECT_SWITCH);
 
@@ -56,57 +57,108 @@ public class TestInCodeGenerator
                         DOUBLE.getDisplayName()
                 ),
                 BIGINT,
-                Collections.singletonList(new ConstantExpression(5.0D, DOUBLE))
+                Collections.singletonList(new ConstantExpression(12345678901234.0, DOUBLE))
         ));
         assertEquals(checkSwitchGenerationCase(BIGINT, values), DIRECT_SWITCH);
 
-        for  (int i = 6; i <= 1000; ++i) {
-            values.add(new ConstantExpression(Long.valueOf(i), BIGINT));
+        for  (long i = 6; i <= 1000; ++i) {
+            values.add(new ConstantExpression(i, BIGINT));
         }
         assertEquals(checkSwitchGenerationCase(BIGINT, values), DIRECT_SWITCH);
+
+        values.add(new ConstantExpression(1001L, BIGINT));
+        assertEquals(checkSwitchGenerationCase(BIGINT, values), SET_CONTAINS);
     }
 
     @Test
-    public void testDirectSwitchDate()
+    public void testBigintLarge()
+    {
+        List<RowExpression> values = new ArrayList<>();
+        values.add(new ConstantExpression(Integer.MAX_VALUE + 1L, BIGINT));
+        values.add(new ConstantExpression(Integer.MIN_VALUE - 1L, BIGINT));
+        values.add(new ConstantExpression(3L, BIGINT));
+        assertEquals(checkSwitchGenerationCase(BIGINT, values), HASH_SWITCH);
+
+        values.add(new ConstantExpression(null, BIGINT));
+        assertEquals(checkSwitchGenerationCase(BIGINT, values), HASH_SWITCH);
+        values.add(new CallExpression(
+                new Signature(
+                        CAST,
+                        SCALAR,
+                        BIGINT.getDisplayName(),
+                        DOUBLE.getDisplayName()
+                ),
+                BIGINT,
+                Collections.singletonList(new ConstantExpression(12345678901234.0, DOUBLE))
+        ));
+        assertEquals(checkSwitchGenerationCase(BIGINT, values), HASH_SWITCH);
+
+        for  (long i = 6; i <= 1000; ++i) {
+            values.add(new ConstantExpression(i, BIGINT));
+        }
+        assertEquals(checkSwitchGenerationCase(BIGINT, values), HASH_SWITCH);
+
+        values.add(new ConstantExpression(1001L, BIGINT));
+        assertEquals(checkSwitchGenerationCase(BIGINT, values), SET_CONTAINS);
+    }
+
+    @Test
+    public void testDate()
     {
         List<RowExpression> values = new ArrayList<>();
         values.add(new ConstantExpression(1L, DATE));
         values.add(new ConstantExpression(2L, DATE));
         values.add(new ConstantExpression(3L, DATE));
         assertEquals(checkSwitchGenerationCase(DATE, values), DIRECT_SWITCH);
+
+        for  (long i = 4; i <= 1000; ++i) {
+            values.add(new ConstantExpression(i, DATE));
+        }
+        assertEquals(checkSwitchGenerationCase(DATE, values), DIRECT_SWITCH);
+
+        values.add(new ConstantExpression(1001L, DATE));
+        assertEquals(checkSwitchGenerationCase(DATE, values), SET_CONTAINS);
     }
 
     @Test
-    public void testHashSwitch()
+    public void testDouble()
     {
         List<RowExpression> values = new ArrayList<>();
-        values.add(new ConstantExpression(1.5D, DOUBLE));
-        values.add(new ConstantExpression(2.5D, DOUBLE));
-        values.add(new ConstantExpression(3.5D, DOUBLE));
+        values.add(new ConstantExpression(1.5, DOUBLE));
+        values.add(new ConstantExpression(2.5, DOUBLE));
+        values.add(new ConstantExpression(3.5, DOUBLE));
         assertEquals(checkSwitchGenerationCase(DOUBLE, values), HASH_SWITCH);
 
         values.add(new ConstantExpression(null, DOUBLE));
         assertEquals(checkSwitchGenerationCase(DOUBLE, values), HASH_SWITCH);
 
         for  (int i = 5; i <= 1000; ++i) {
-            values.add(new ConstantExpression(Double.valueOf(i + 0.5D), DOUBLE));
+            values.add(new ConstantExpression(i + 0.5, DOUBLE));
         }
         assertEquals(checkSwitchGenerationCase(DOUBLE, values), HASH_SWITCH);
+
+        values.add(new ConstantExpression(1001.5, DOUBLE));
+        assertEquals(checkSwitchGenerationCase(DOUBLE, values), SET_CONTAINS);
     }
 
     @Test
-    public void testSetContains()
+    public void testVarchar()
     {
         List<RowExpression> values = new ArrayList<>();
-        for  (int i = 1; i <= 1001; ++i) {
-            values.add(new ConstantExpression(Long.valueOf(i), BIGINT));
-        }
-        SwitchGenerationCase switchGenerationCase = checkSwitchGenerationCase(BIGINT, values);
-        assertEquals(switchGenerationCase, SET_CONTAINS);
+        values.add(new ConstantExpression(Slices.utf8Slice("1"), DOUBLE));
+        values.add(new ConstantExpression(Slices.utf8Slice("2"), DOUBLE));
+        values.add(new ConstantExpression(Slices.utf8Slice("3"), DOUBLE));
+        assertEquals(checkSwitchGenerationCase(VARCHAR, values), HASH_SWITCH);
 
-        for  (int i = 1; i <= 1001; ++i) {
-            values.set(i - 1, new ConstantExpression(Double.valueOf(i + 0.5D), DOUBLE));
+        values.add(new ConstantExpression(null, VARCHAR));
+        assertEquals(checkSwitchGenerationCase(VARCHAR, values), HASH_SWITCH);
+
+        for  (int i = 5; i <= 1000; ++i) {
+            values.add(new ConstantExpression(Slices.utf8Slice(String.valueOf(i)), VARCHAR));
         }
-        assertEquals(checkSwitchGenerationCase(BIGINT, values), SET_CONTAINS);
+        assertEquals(checkSwitchGenerationCase(VARCHAR, values), HASH_SWITCH);
+
+        values.add(new ConstantExpression(Slices.utf8Slice("1001"), VARCHAR));
+        assertEquals(checkSwitchGenerationCase(VARCHAR, values), SET_CONTAINS);
     }
 }


### PR DESCRIPTION
* Threshold between hash set and generated switch is adjusted from 1000 to 32.
* Load factor of hash set is adjusted to 0.25.

BIGINT is 31-bit unsigned integers. DOUBLE is any double between 0.0 and 1.0. VARCHAR is 64-bit signed integer converted to string. Unit is microsecond for a 10000-row page.

Overall performance after tuning (10 fork, 10 warmup, 10 run, Linux E5-2660):
```
            bigint             double             varchar
    1    71.299 ± 0.593     75.100 ± 0.250    392.109 ± 18.397
    5   139.101 ± 4.758    160.138 ± 7.903    488.277 ±  6.884
   10   171.374 ± 3.307    243.076 ± 3.173    542.460 ±  6.216
   25   216.118 ± 2.685    293.696 ± 3.388    602.593 ±  3.933
   50   226.435 ± 1.825    233.620 ± 2.641    586.078 ±  7.143
   75   208.593 ± 1.599    212.449 ± 0.936    557.064 ±  7.618
  100   226.122 ± 0.988    229.184 ± 1.151    592.266 ±  6.021
  150   206.488 ± 1.126    212.651 ± 1.396    570.001 ±  9.624
  200   227.632 ± 1.801    234.063 ± 2.066    591.663 ±  5.204
  250   248.663 ± 2.260    254.747 ± 1.793    624.223 ±  6.793
  300   209.389 ± 1.317    212.957 ± 1.327    567.363 ±  4.229
  350   215.955 ± 1.120    222.608 ± 1.559    584.569 ±  5.289
  400   228.595 ± 1.211    233.784 ± 1.366    596.820 ±  6.282
  450   239.963 ± 1.549    243.192 ± 1.362    620.790 ±  3.858
  500   250.862 ± 1.622    256.127 ± 2.767    634.933 ±  4.485
  750   223.741 ± 1.275    226.601 ± 1.218    595.052 ±  6.548
 1000   250.443 ± 0.982    254.663 ± 1.343    653.762 ±  4.397
10000   220.256 ± 1.061    226.338 ± 0.910    661.664 ±  7.526
```
Benchmark results for different strategies (1 fork, 5 warmup, 10 run, OSX i7-4960HQ):
```
        hash 0.75 load factor    hash 0.5 load factor     hash 0.25 load factor     generated switch
        BIGINT  DOUBLE  VARCHAR  BIGINT  DOUBLE  VARCHAR  BIGINT  DOUBLE  VARCHAR   BIGINT  DOUBLE   VARCHAR
    1   235.74  225.23   706.36  182.28  181.29   588.15  163.85  165.74  545.860    39.76    51.12   254.47
    5   388.62  305.17   999.64  232.17  221.40   656.43  174.95  164.54  580.087    89.19   119.79   367.25
   10   427.94  360.83  1122.43  223.10  230.58   684.98  175.28  171.46  600.098   139.09   198.23   396.69
   25   283.84  271.31   753.11  273.71  266.14   834.23  183.88  181.93  616.971   178.48   218.09   435.17
   50   268.04  270.22   817.26  267.91  250.73   798.80  202.50  184.64  649.919   249.21   254.60   454.71
   75   398.50  382.17  1306.62  232.38  233.09   650.71  168.15  164.87  568.743   262.46   278.25   484.06
  100   261.93  280.38   906.26  270.54  276.77   816.94  187.18  191.77  614.767   270.46   282.47   493.71
  150   424.19  395.80  1318.54  231.03  226.42   691.79  174.91  173.50  592.280   293.14   292.15   513.29
  200   287.61  263.83   838.44  280.64  282.62   826.32  193.01  190.98  623.896   305.62   313.68   519.65
  250   364.81  490.35  1038.71  372.73  334.62  1068.17  206.48  214.01  662.589   316.55   323.35   545.67
  300   422.06  385.28  1449.77  214.26  216.09   732.39  175.13  171.39  594.354   332.34  1750.36  1955.22
  350   536.78  554.96  1648.89  246.64  257.35   810.53  185.83  185.97  611.776   336.92  1774.38  2028.32
  400   277.07  281.35   860.19  280.14  276.10   910.70  193.19  190.66  625.258   349.76  1784.38  1987.22
  450   309.79  306.55  1019.18  304.69  304.47   956.27  203.24  198.90  660.130   352.02  1718.63  1976.81
  500   391.65  343.55  1050.55  335.05  340.80  1066.33  217.58  222.25  667.676   350.37  1719.94  1968.86
  750   719.82  737.52  2510.43  283.80  268.24   827.40  181.36  185.56  617.092   387.30  1827.96  2092.34
 1000   350.08  345.73  1060.12  338.92  344.01  1026.75  214.20  215.72  692.699  1769.19  1800.66  2045.39
10000   464.89  451.28  1786.75  244.11  237.86   750.99  184.81  183.78  659.567
```