### PR TITLE
Add node.server-log-file and node.launcher-log-file to node.properties

### DIFF
--- a/presto-server-rpm/src/main/resources/dist/config/node.properties
+++ b/presto-server-rpm/src/main/resources/dist/config/node.properties
@@ -3,3 +3,5 @@ node.id=$(uuid-generated-nodeid)
 node.data-dir=/var/lib/presto/data
 plugin.config-dir=/etc/presto/catalog
 plugin.dir=/usr/lib/presto/lib/plugin
+node.server-log-file=/var/log/presto/server.log
+node.launcher-log-file=/var/log/presto/launcher.log

--- a/presto-server-rpm/src/main/resources/dist/etc/init.d/presto
+++ b/presto-server-rpm/src/main/resources/dist/etc/init.d/presto
@@ -25,7 +25,9 @@ SERVICE_USER='presto'
 # Use data-dir from node.properties file (assumes it to be at /etc/presto). For other args use defaults from rpm install
 NODE_PROPERTIES=/etc/presto/node.properties
 DATA_DIR=$(grep -Po "(?<=^node.data-dir=).*" $NODE_PROPERTIES)
-CONFIGURATION=(--launcher-config /usr/lib/presto/bin/launcher.properties --data-dir "$DATA_DIR" --node-config "$NODE_PROPERTIES" --jvm-config /etc/presto/jvm.config --config /etc/presto/config.properties --launcher-log-file /var/log/presto/launcher.log --server-log-file /var/log/presto/server.log)
+SERVER_LOG_FILE=$(grep -Po "(?<=^node.server-log-file=).*" $NODE_PROPERTIES)
+LAUNCHER_LOG_FILE=$(grep -Po "(?<=^node.launcher-log-file=).*" $NODE_PROPERTIES)
+CONFIGURATION=(--launcher-config /usr/lib/presto/bin/launcher.properties --data-dir "$DATA_DIR" --node-config "$NODE_PROPERTIES" --jvm-config /etc/presto/jvm.config --config /etc/presto/config.properties --launcher-log-file "${LAUNCHER_LOG_FILE:-/var/log/presto/launcher.log}" --server-log-file "${SERVER_LOG_FILE:-/var/log/presto/server.log}")
 
 source /etc/presto/env.sh
 
@@ -34,7 +36,7 @@ start () {
     if [ -z "$JAVA8_HOME" ]
     then
         echo "Warning: No value found for JAVA8_HOME. Default Java will be used."
-        sudo -u $SERVICE_USER /usr/lib/presto/bin/launcher start ${CONFIGURATION}
+        sudo -u $SERVICE_USER /usr/lib/presto/bin/launcher start ${CONFIGURATION[@]}
     else
         sudo -u $SERVICE_USER PATH=${JAVA8_HOME}/bin:$PATH /usr/lib/presto/bin/launcher start "${CONFIGURATION[@]}"
     fi


### PR DESCRIPTION
Fix for #3958, log files still default to /var/log/presto/* but can be overridden in node.properties.