### PR TITLE
Free tansfered memory when transferMemoryToContext fails

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
@@ -71,7 +71,9 @@ public class MemoryPool
     public synchronized ListenableFuture<?> reserve(QueryId queryId, long bytes)
     {
         checkArgument(bytes >= 0, "bytes is negative");
-        queryMemoryReservations.merge(queryId, bytes, Long::sum);
+        if (bytes != 0) {
+            queryMemoryReservations.merge(queryId, bytes, Long::sum);
+        }
         freeBytes -= bytes;
         if (freeBytes <= 0) {
             if (future == null) {
@@ -93,7 +95,9 @@ public class MemoryPool
             return false;
         }
         freeBytes -= bytes;
-        queryMemoryReservations.merge(queryId, bytes, Long::sum);
+        if (bytes != 0) {
+            queryMemoryReservations.merge(queryId, bytes, Long::sum);
+        }
         return true;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPages.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPages.java
@@ -50,6 +50,6 @@ public final class NestedLoopJoinPages
     {
         checkState(!freed, "Memory already freed");
         freed = true;
-        operatorContext.freeTaskContextMemory(estimatedSize.toBytes());
+        operatorContext.getTaskContext().freeMemory(estimatedSize.toBytes());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPages.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPages.java
@@ -26,7 +26,7 @@ import static java.util.Objects.requireNonNull;
 
 public final class NestedLoopJoinPages
 {
-    private final TaskContext taskContext;
+    private final OperatorContext operatorContext;
     private final ImmutableList<Page> pages;
     private final DataSize estimatedSize;
     @GuardedBy("this")
@@ -35,17 +35,10 @@ public final class NestedLoopJoinPages
     NestedLoopJoinPages(List<Page> pages, DataSize estimatedSize, OperatorContext operatorContext)
     {
         requireNonNull(pages, "pages is null");
-        requireNonNull(operatorContext, "operatorContext is null");
         this.pages = ImmutableList.copyOf(pages);
-        this.taskContext = operatorContext.getDriverContext().getPipelineContext().getTaskContext();
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.estimatedSize = requireNonNull(estimatedSize, "estimatedSize is null");
-        long transferredBytes = operatorContext.transferMemoryToTaskContext();
-        if (estimatedSize.toBytes() > transferredBytes) {
-            taskContext.reserveMemory(estimatedSize.toBytes() - transferredBytes);
-        }
-        else {
-            taskContext.freeMemory(transferredBytes - estimatedSize.toBytes());
-        }
+        operatorContext.transferMemoryToTaskContext(estimatedSize.toBytes());
     }
 
     public List<Page> getPages()
@@ -57,6 +50,6 @@ public final class NestedLoopJoinPages
     {
         checkState(!freed, "Memory already freed");
         freed = true;
-        taskContext.freeMemory(estimatedSize.toBytes());
+        operatorContext.freeTaskContextMemory(estimatedSize.toBytes());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/SharedLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SharedLookupSource.java
@@ -84,7 +84,7 @@ public final class SharedLookupSource
     {
         checkState(!freed, "Already freed");
         freed = true;
-        operatorContext.freeTaskContextMemory(lookupSource.getInMemorySizeInBytes());
+        operatorContext.getTaskContext().freeMemory(lookupSource.getInMemorySizeInBytes());
     }
 
     @Override


### PR DESCRIPTION
I found a case the `general` memory pool was not recovered to initial value even though no query was running. Heap dump of the memory pool had a query entry which had raised `local memory limit` at  
```
    "stack": [
      "com.facebook.presto.ExceededMemoryLimitException.exceededLocalLimit(ExceededMemoryLimitException.java:34)",
      "com.facebook.presto.memory.QueryContext.reserveMemory(QueryContext.java:68)",
      "com.facebook.presto.operator.TaskContext.reserveMemory(TaskContext.java:153)",
      "com.facebook.presto.operator.SharedLookupSource.<init>(SharedLookupSource.java:40)",
      "com.facebook.presto.operator.ParallelHashBuilder$ParallelHashBuilderOperator.finish(ParallelHashBuilder.java:394)",
      "com.facebook.presto.operator.Driver.processInternal(Driver.java:358)",
      "com.facebook.presto.operator.Driver.processFor(Driver.java:303)",
      "com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:587)",
      "com.facebook.presto.execution.TaskExecutor$PrioritizedSplitRunner.process(TaskExecutor.java:505)",
      "com.facebook.presto.execution.TaskExecutor$Runner.run(TaskExecutor.java:640)",
      "java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)",
      "java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)",
      "java.lang.Thread.run(Thread.java:745)"
    ]
```
I feel like we might need to free transferred `TaskContext` memory when subsequent memory reservation fails. 

Also I found several zero-value entries in the MemoryPool.