### PR TITLE
Add support for graceful worker shutdown

### DIFF
--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxSplitManager.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxSplitManager.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 
 import static com.facebook.presto.connector.jmx.Types.checkType;
+import static com.facebook.presto.spi.NodeState.ACTIVE;
 import static com.facebook.presto.spi.predicate.TupleDomain.fromFixedValues;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -76,7 +77,7 @@ public class JmxSplitManager
         //TODO is there a better way to get the node column?
         JmxColumnHandle nodeColumnHandle = tableHandle.getColumns().get(0);
 
-        List<ConnectorSplit> splits = nodeManager.getActiveNodes()
+        List<ConnectorSplit> splits = nodeManager.getNodes(ACTIVE)
                 .stream()
                 .filter(node -> {
                     NullableValue value = NullableValue.of(VARCHAR, utf8Slice(node.getNodeIdentifier()));

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxSplitManager.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxSplitManager.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.NodeState;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.SchemaTableName;
@@ -132,7 +133,7 @@ public class TestJmxSplitManager
             implements NodeManager
     {
         @Override
-        public Set<Node> getActiveNodes()
+        public Set<Node> getNodes(NodeState state)
         {
             return nodes;
         }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.ConnectorFactory;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.NodeState;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
@@ -91,7 +92,7 @@ public class TestKafkaPlugin
         private static final Node LOCAL_NODE = new TestingNode();
 
         @Override
-        public Set<Node> getActiveNodes()
+        public Set<Node> getNodes(NodeState state)
         {
             return ImmutableSet.of(LOCAL_NODE);
         }

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplitManager.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.facebook.presto.spi.NodeState.ACTIVE;
 import static com.facebook.presto.spi.SystemTable.Distribution.ALL_COORDINATORS;
 import static com.facebook.presto.spi.SystemTable.Distribution.ALL_NODES;
 import static com.facebook.presto.spi.SystemTable.Distribution.SINGLE_COORDINATOR;
@@ -74,7 +75,7 @@ public class SystemSplitManager
             nodes.addAll(nodeManager.getCoordinators());
         }
         else if (tableDistributionMode == ALL_NODES) {
-            nodes.addAll(nodeManager.getActiveNodes());
+            nodes.addAll(nodeManager.getNodes(ACTIVE));
         }
         Set<Node> nodeSet = nodes.build();
         for (Node node : nodeSet) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/NodeScheduler.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.facebook.presto.spi.NodeState.ACTIVE;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
@@ -108,7 +109,7 @@ public class NodeScheduler
                 nodes = nodeManager.getActiveDatasourceNodes(dataSourceName);
             }
             else {
-                nodes = nodeManager.getActiveNodes();
+                nodes = nodeManager.getNodes(ACTIVE);
             }
 
             for (Node node : nodes) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -371,4 +371,9 @@ public class SqlTask
             return new SqlTaskIoStats(taskContext.getInputDataSize(), taskContext.getInputPositions(), taskContext.getOutputDataSize(), taskContext.getOutputPositions());
         }
     }
+
+    public void addStateChangeListener(StateChangeListener<TaskState> stateChangeListener)
+    {
+        taskStateMachine.addStateChangeListener(stateChangeListener);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -17,6 +17,7 @@ import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.Session;
 import com.facebook.presto.TaskSource;
 import com.facebook.presto.event.query.QueryMonitor;
+import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.memory.LocalMemoryManager;
 import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.memory.MemoryPoolAssignment;
@@ -355,5 +356,12 @@ public class SqlTaskManager
                 .forEach(task -> tempIoStats.merge(task.getIoStats()));
 
         cachedStats.resetTo(tempIoStats);
+    }
+
+    @Override
+    public void addStateChangeListener(TaskId taskId, StateChangeListener<TaskState> stateChangeListener)
+    {
+        requireNonNull(taskId, "taskId is null");
+        tasks.getUnchecked(taskId).addStateChangeListener(stateChangeListener);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution;
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.Session;
 import com.facebook.presto.TaskSource;
+import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
 import com.facebook.presto.sql.planner.PlanFragment;
 import io.airlift.units.DataSize;
@@ -90,4 +91,9 @@ public interface TaskManager
      * eventually exist are queried.
      */
     TaskInfo abortTaskResults(TaskId taskId, TaskId outputId);
+
+    /**
+     * Adds a state change listener to the specified task.
+     */
+    void addStateChangeListener(TaskId taskId, StateChangeListener<TaskState> stateChangeListener);
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/AllNodes.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/AllNodes.java
@@ -24,11 +24,13 @@ public class AllNodes
 {
     private final Set<Node> activeNodes;
     private final Set<Node> inactiveNodes;
+    private final Set<Node> shuttingDownNodes;
 
-    public AllNodes(Set<Node> activeNodes, Set<Node> inactiveNodes)
+    public AllNodes(Set<Node> activeNodes, Set<Node> inactiveNodes, Set<Node> shuttingDownNodes)
     {
         this.activeNodes = ImmutableSet.copyOf(requireNonNull(activeNodes, "activeNodes is null"));
         this.inactiveNodes = ImmutableSet.copyOf(requireNonNull(inactiveNodes, "inactiveNodes is null"));
+        this.shuttingDownNodes = ImmutableSet.copyOf(requireNonNull(shuttingDownNodes, "shuttingDownNodes is null"));
     }
 
     public Set<Node> getActiveNodes()
@@ -39,5 +41,10 @@ public class AllNodes
     public Set<Node> getInactiveNodes()
     {
         return inactiveNodes;
+    }
+
+    public Set<Node> getShuttingDownNodes()
+    {
+        return shuttingDownNodes;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -17,6 +17,7 @@ import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.connector.system.SystemConnector;
 import com.facebook.presto.failureDetector.FailureDetector;
 import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.NodeState;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -24,23 +25,36 @@ import com.google.common.collect.SetMultimap;
 import io.airlift.discovery.client.ServiceDescriptor;
 import io.airlift.discovery.client.ServiceSelector;
 import io.airlift.discovery.client.ServiceType;
+import io.airlift.http.client.HttpClient;
 import io.airlift.node.NodeInfo;
 import io.airlift.units.Duration;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static com.facebook.presto.spi.NodeState.ACTIVE;
+import static com.facebook.presto.spi.NodeState.INACTIVE;
+import static com.facebook.presto.spi.NodeState.SHUTTING_DOWN;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableSet;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Sets.difference;
+import static io.airlift.concurrent.Threads.threadsNamed;
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static java.util.Arrays.asList;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 
 @ThreadSafe
 public final class DiscoveryNodeManager
@@ -53,6 +67,9 @@ public final class DiscoveryNodeManager
     private final NodeInfo nodeInfo;
     private final FailureDetector failureDetector;
     private final NodeVersion expectedNodeVersion;
+    private final ConcurrentHashMap<String, RemoteNodeState> nodeStates = new ConcurrentHashMap<>();
+    private final HttpClient httpClient;
+    private final ScheduledExecutorService nodeStateUpdateExecutor;
 
     @GuardedBy("this")
     private SetMultimap<String, Node> activeNodesByDataSource;
@@ -69,13 +86,61 @@ public final class DiscoveryNodeManager
     private Set<Node> coordinators;
 
     @Inject
-    public DiscoveryNodeManager(@ServiceType("presto") ServiceSelector serviceSelector, NodeInfo nodeInfo, FailureDetector failureDetector, NodeVersion expectedNodeVersion)
+    public DiscoveryNodeManager(
+            @ServiceType("presto") ServiceSelector serviceSelector,
+            NodeInfo nodeInfo,
+            FailureDetector failureDetector,
+            NodeVersion expectedNodeVersion,
+            @ForGracefulShutdown HttpClient httpClient)
     {
         this.serviceSelector = requireNonNull(serviceSelector, "serviceSelector is null");
         this.nodeInfo = requireNonNull(nodeInfo, "nodeInfo is null");
         this.failureDetector = requireNonNull(failureDetector, "failureDetector is null");
         this.expectedNodeVersion = requireNonNull(expectedNodeVersion, "expectedNodeVersion is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.nodeStateUpdateExecutor = newSingleThreadScheduledExecutor(threadsNamed("node-state-poller-%s"));
         this.currentNode = refreshNodesInternal();
+    }
+
+    @PostConstruct
+    public void startPollingNodeStates()
+    {
+        // poll worker states only on the coordinators
+        if (getCoordinators().contains(currentNode)) {
+            nodeStateUpdateExecutor.scheduleWithFixedDelay(() -> {
+                ImmutableSet.Builder nodeSetBuilder = ImmutableSet.builder();
+                AllNodes allNodes = getAllNodes();
+                Set<Node> aliveNodes = nodeSetBuilder
+                        .addAll(allNodes.getActiveNodes())
+                        .addAll(allNodes.getShuttingDownNodes())
+                        .build();
+
+                ImmutableSet<String> aliveNodeIds = aliveNodes.stream()
+                        .map(Node::getNodeIdentifier)
+                        .collect(toImmutableSet());
+
+                // Remove nodes that don't exist anymore
+                // Make a copy to materialize the set difference
+                Set<String> deadNodes = difference(nodeStates.keySet(), aliveNodeIds).immutableCopy();
+                nodeStates.keySet().removeAll(deadNodes);
+
+                // Add new nodes
+                for (Node node : aliveNodes) {
+                    nodeStates.putIfAbsent(node.getNodeIdentifier(),
+                            new RemoteNodeState(httpClient, uriBuilderFrom(node.getHttpUri()).appendPath("/v1/info/state").build()));
+                }
+
+                // Schedule refresh
+                nodeStates.values().forEach(RemoteNodeState::asyncRefresh);
+
+            }, 1, 5, TimeUnit.SECONDS);
+        }
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        nodeStateUpdateExecutor.shutdownNow();
     }
 
     @Override
@@ -98,6 +163,7 @@ public final class DiscoveryNodeManager
 
         ImmutableSet.Builder<Node> activeNodesBuilder = ImmutableSet.builder();
         ImmutableSet.Builder<Node> inactiveNodesBuilder = ImmutableSet.builder();
+        ImmutableSet.Builder<Node> shuttingDownNodesBuilder = ImmutableSet.builder();
         ImmutableSet.Builder<Node> coordinatorsBuilder = ImmutableSet.builder();
         ImmutableSetMultimap.Builder<String, Node> byDataSourceBuilder = ImmutableSetMultimap.builder();
 
@@ -106,6 +172,7 @@ public final class DiscoveryNodeManager
             NodeVersion nodeVersion = getNodeVersion(service);
             if (uri != null && nodeVersion != null) {
                 PrestoNode node = new PrestoNode(service.getNodeId(), uri, nodeVersion);
+                NodeState nodeState = getNodeState(node);
 
                 // record current node
                 if (node.getNodeIdentifier().equals(nodeInfo.getNodeId())) {
@@ -113,31 +180,38 @@ public final class DiscoveryNodeManager
                     checkState(currentNode.getNodeVersion().equals(expectedNodeVersion), "INVARIANT: current node version should be equal to expected node version");
                 }
 
-                if (isActive(node)) {
-                    activeNodesBuilder.add(node);
-                    if (Boolean.parseBoolean(service.getProperties().get("coordinator"))) {
-                        coordinatorsBuilder.add(node);
-                    }
-
-                    // record available active nodes organized by data source
-                    String dataSources = service.getProperties().get("datasources");
-                    if (dataSources != null) {
-                        dataSources = dataSources.toLowerCase(ENGLISH);
-                        for (String dataSource : DATASOURCES_SPLITTER.split(dataSources)) {
-                            byDataSourceBuilder.put(dataSource, node);
+                switch (nodeState) {
+                    case ACTIVE:
+                        activeNodesBuilder.add(node);
+                        if (Boolean.parseBoolean(service.getProperties().get("coordinator"))) {
+                            coordinatorsBuilder.add(node);
                         }
-                    }
 
-                    // always add system data source
-                    byDataSourceBuilder.put(SystemConnector.NAME, node);
-                }
-                else {
-                    inactiveNodesBuilder.add(node);
+                        // record available active nodes organized by data source
+                        String dataSources = service.getProperties().get("datasources");
+                        if (dataSources != null) {
+                            dataSources = dataSources.toLowerCase(ENGLISH);
+                            for (String dataSource : DATASOURCES_SPLITTER.split(dataSources)) {
+                                byDataSourceBuilder.put(dataSource, node);
+                            }
+                        }
+
+                        // always add system data source
+                        byDataSourceBuilder.put(SystemConnector.NAME, node);
+                        break;
+                    case INACTIVE:
+                        inactiveNodesBuilder.add(node);
+                        break;
+                    case SHUTTING_DOWN:
+                        shuttingDownNodesBuilder.add(node);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unknown node state " + nodeState);
                 }
             }
         }
 
-        allNodes = new AllNodes(activeNodesBuilder.build(), inactiveNodesBuilder.build());
+        allNodes = new AllNodes(activeNodesBuilder.build(), inactiveNodesBuilder.build(), shuttingDownNodesBuilder.build());
         activeNodesByDataSource = byDataSourceBuilder.build();
         coordinators = coordinatorsBuilder.build();
 
@@ -152,9 +226,27 @@ public final class DiscoveryNodeManager
         }
     }
 
-    private boolean isActive(PrestoNode node)
+    private NodeState getNodeState(PrestoNode node)
     {
-        return expectedNodeVersion.equals(node.getNodeVersion());
+        if (expectedNodeVersion.equals(node.getNodeVersion())) {
+            if (isNodeShuttingDown(node.getNodeIdentifier())) {
+                return SHUTTING_DOWN;
+            }
+            else {
+                return ACTIVE;
+            }
+        }
+        else {
+            return INACTIVE;
+        }
+    }
+
+    private boolean isNodeShuttingDown(String nodeId)
+    {
+        Optional<NodeState> remoteNodeState = nodeStates.containsKey(nodeId)
+                ? nodeStates.get(nodeId).getNodeState()
+                : Optional.empty();
+        return remoteNodeState.isPresent() && remoteNodeState.get().equals(SHUTTING_DOWN);
     }
 
     @Override
@@ -165,9 +257,18 @@ public final class DiscoveryNodeManager
     }
 
     @Override
-    public Set<Node> getActiveNodes()
+    public Set<Node> getNodes(NodeState state)
     {
-        return getAllNodes().getActiveNodes();
+        switch (state) {
+            case ACTIVE:
+                return getAllNodes().getActiveNodes();
+            case INACTIVE:
+                return getAllNodes().getInactiveNodes();
+            case SHUTTING_DOWN:
+                return getAllNodes().getShuttingDownNodes();
+            default:
+                throw new IllegalArgumentException("Unknown node state " + state);
+        }
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/ForGracefulShutdown.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/ForGracefulShutdown.java
@@ -11,17 +11,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.spi;
+package com.facebook.presto.metadata;
 
-import java.util.Set;
+import javax.inject.Qualifier;
 
-public interface NodeManager
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForGracefulShutdown
 {
-    Set<Node> getNodes(NodeState state);
-
-    Set<Node> getActiveDatasourceNodes(String datasourceName);
-
-    Node getCurrentNode();
-
-    Set<Node> getCoordinators();
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/InMemoryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/InMemoryNodeManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.NodeState;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -59,9 +60,18 @@ public class InMemoryNodeManager
     }
 
     @Override
-    public Set<Node> getActiveNodes()
+    public Set<Node> getNodes(NodeState state)
     {
-        return getAllNodes().getActiveNodes();
+        switch (state) {
+            case ACTIVE:
+                return getAllNodes().getActiveNodes();
+            case INACTIVE:
+                return getAllNodes().getInactiveNodes();
+            case SHUTTING_DOWN:
+                return getAllNodes().getShuttingDownNodes();
+            default:
+                throw new IllegalArgumentException("Unknown node state " + state);
+        }
     }
 
     @Override
@@ -73,7 +83,7 @@ public class InMemoryNodeManager
     @Override
     public AllNodes getAllNodes()
     {
-        return new AllNodes(ImmutableSet.<Node>builder().add(localNode).addAll(remoteNodes.values()).build(), ImmutableSet.<Node>of());
+        return new AllNodes(ImmutableSet.<Node>builder().add(localNode).addAll(remoteNodes.values()).build(), ImmutableSet.<Node>of(), ImmutableSet.<Node>of());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/RemoteNodeState.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/RemoteNodeState.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.spi.NodeState;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpClient.HttpResponseFuture;
+import io.airlift.http.client.Request;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static io.airlift.http.client.HttpStatus.OK;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.airlift.units.Duration.nanosSince;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+
+@ThreadSafe
+public class RemoteNodeState
+{
+    private static final Logger log = Logger.get(RemoteNodeState.class);
+
+    private final HttpClient httpClient;
+    private final URI stateInfoUri;
+    private final AtomicReference<Optional<NodeState>> nodeState = new AtomicReference<>(empty());
+    private final AtomicReference<Future<?>> future = new AtomicReference<>();
+    private final AtomicLong lastUpdateNanos = new AtomicLong();
+    private final AtomicLong lastWarningLogged = new AtomicLong();
+
+    public RemoteNodeState(HttpClient httpClient, URI stateInfoUri)
+    {
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.stateInfoUri = requireNonNull(stateInfoUri, "stateInfoUri is null");
+    }
+
+    public Optional<NodeState> getNodeState()
+    {
+        return nodeState.get();
+    }
+
+    public synchronized void asyncRefresh()
+    {
+        Duration sinceUpdate = nanosSince(lastUpdateNanos.get());
+        if (nanosSince(lastWarningLogged.get()).toMillis() > 1_000 &&
+                sinceUpdate.toMillis() > 10_000 &&
+                future.get() != null) {
+            log.warn("Node state update request to %s has not returned in %s", stateInfoUri, sinceUpdate.toString(SECONDS));
+            lastWarningLogged.set(System.nanoTime());
+        }
+        if (sinceUpdate.toMillis() > 1_000 && future.get() == null) {
+            Request request = prepareGet()
+                    .setUri(stateInfoUri)
+                    .setHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                    .build();
+            HttpResponseFuture<JsonResponse<NodeState>> responseFuture = httpClient.executeAsync(request, createFullJsonResponseHandler(jsonCodec(NodeState.class)));
+            future.compareAndSet(null, responseFuture);
+
+            Futures.addCallback(responseFuture, new FutureCallback<JsonResponse<NodeState>>() {
+                @Override
+                public void onSuccess(@Nullable JsonResponse<NodeState> result)
+                {
+                    lastUpdateNanos.set(System.nanoTime());
+                    future.compareAndSet(responseFuture, null);
+                    if (result != null) {
+                        if (result.hasValue()) {
+                            nodeState.set(ofNullable(result.getValue()));
+                        }
+                        if (result.getStatusCode() != OK.code()) {
+                            log.warn("Error fetching node state from %s returned status %d: %s", stateInfoUri, result.getStatusCode(), result.getStatusMessage());
+                            return;
+                        }
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable t)
+                {
+                    log.warn("Error fetching node state from %s: %s", stateInfoUri, t.getMessage());
+                    lastUpdateNanos.set(System.nanoTime());
+                    future.compareAndSet(responseFuture, null);
+                }
+            });
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/DefaultShutdownAction.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/DefaultShutdownAction.java
@@ -11,17 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.spi;
+package com.facebook.presto.server;
 
-import java.util.Set;
-
-public interface NodeManager
+public class DefaultShutdownAction
+        implements ShutdownAction
 {
-    Set<Node> getNodes(NodeState state);
-
-    Set<Node> getActiveDatasourceNodes(String datasourceName);
-
-    Node getCurrentNode();
-
-    Set<Node> getCoordinators();
+    @Override
+    public void onShutdown()
+    {
+        System.exit(0);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/GracefulShutdownHandler.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/GracefulShutdownHandler.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.execution.TaskManager;
+import com.facebook.presto.util.ImmutableCollectors;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeoutException;
+
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static io.airlift.concurrent.Threads.threadsNamed;
+import static java.lang.Thread.currentThread;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class GracefulShutdownHandler
+{
+    private static final Logger log = Logger.get(GracefulShutdownHandler.class);
+    private static final Duration LIFECYCLE_STOP_TIMEOUT = new Duration(30, SECONDS);
+
+    private final ScheduledExecutorService shutdownHandler = newSingleThreadScheduledExecutor(threadsNamed("shutdown-handler-%s"));
+    private final ExecutorService lifeCycleStopper = newSingleThreadExecutor(threadsNamed("lifecycle-stopper-%s"));
+    private final LifeCycleManager lifeCycleManager;
+    private final TaskManager sqlTaskManager;
+    private final boolean isCoordinator;
+    private final ShutdownAction shutdownAction;
+    private final Duration gracePeriod;
+
+    @GuardedBy("this")
+    private boolean shutdownRequested;
+
+    @Inject
+    public GracefulShutdownHandler(
+            TaskManager sqlTaskManager,
+            ServerConfig serverConfig,
+            ShutdownAction shutdownAction,
+            LifeCycleManager lifeCycleManager)
+    {
+        this.sqlTaskManager = requireNonNull(sqlTaskManager, "sqlTaskManager is null");
+        this.shutdownAction = requireNonNull(shutdownAction, "shutdownAction is null");
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
+        this.isCoordinator = requireNonNull(serverConfig, "serverConfig is null").isCoordinator();
+        this.gracePeriod = serverConfig.getGracePeriod();
+    }
+
+    public synchronized void requestShutdown()
+    {
+        log.info("Shutdown requested");
+
+        if (isShutdownRequested() || isCoordinator) {
+            return;
+        }
+
+        setShutdownRequested(true);
+
+        //wait for a grace period to start the shutdown sequence
+        shutdownHandler.schedule(() -> {
+            List<TaskInfo> activeTasks = getActiveTasks();
+            while (activeTasks.size() > 0) {
+                CountDownLatch countDownLatch = new CountDownLatch(activeTasks.size());
+
+                for (TaskInfo taskInfo : activeTasks) {
+                    sqlTaskManager.addStateChangeListener(taskInfo.getTaskId(), newState -> {
+                        if (newState.isDone()) {
+                            countDownLatch.countDown();
+                        }
+                    });
+                }
+
+                log.info("Waiting for all tasks to finish");
+
+                try {
+                    countDownLatch.await();
+                }
+                catch (InterruptedException e) {
+                    log.warn("Interrupted while waiting for all tasks to finish");
+                    currentThread().interrupt();
+                }
+
+                activeTasks = getActiveTasks();
+            }
+
+            // wait for another grace period for all task states to be observed by the coordinator
+            sleepUninterruptibly(gracePeriod.toMillis(), MILLISECONDS);
+
+            Future<?> shutdownFuture = lifeCycleStopper.submit(() -> {
+                lifeCycleManager.stop();
+                return null;
+            });
+
+            // terminate the jvm if life cycle cannot be stopped in a timely manner
+            try {
+                shutdownFuture.get(LIFECYCLE_STOP_TIMEOUT.toMillis(), MILLISECONDS);
+            }
+            catch (TimeoutException e) {
+                log.warn(e, "Timed out waiting for the life cycle to stop");
+            }
+            catch (InterruptedException e) {
+                log.warn(e, "Interrupted while waiting for the life cycle to stop");
+                currentThread().interrupt();
+            }
+            catch (ExecutionException e) {
+                log.warn(e, "Problem stopping the life cycle");
+            }
+
+            shutdownAction.onShutdown();
+        }, gracePeriod.toMillis(), MILLISECONDS);
+    }
+
+    private List<TaskInfo> getActiveTasks()
+    {
+        return sqlTaskManager.getAllTaskInfo()
+                .stream()
+                .filter(taskInfo -> !taskInfo.getState().isDone())
+                .collect(ImmutableCollectors.toImmutableList());
+    }
+
+    private synchronized void setShutdownRequested(boolean shutdownRequested)
+    {
+        this.shutdownRequested = shutdownRequested;
+    }
+
+    public synchronized boolean isShutdownRequested()
+    {
+        return shutdownRequested;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/GracefulShutdownModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/GracefulShutdownModule.java
@@ -11,17 +11,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.spi;
+package com.facebook.presto.server;
 
-import java.util.Set;
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
 
-public interface NodeManager
+public class GracefulShutdownModule
+        extends AbstractConfigurationAwareModule
 {
-    Set<Node> getNodes(NodeState state);
-
-    Set<Node> getActiveDatasourceNodes(String datasourceName);
-
-    Node getCurrentNode();
-
-    Set<Node> getCoordinators();
+    @Override
+    protected void setup(Binder binder)
+    {
+        binder.bind(ShutdownAction.class).to(DefaultShutdownAction.class).in(Scopes.SINGLETON);
+        binder.bind(GracefulShutdownHandler.class).in(Scopes.SINGLETON);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -100,7 +100,8 @@ public class PrestoServer
                 new EmbeddedDiscoveryModule(),
                 new ServerSecurityModule(),
                 new AccessControlModule(),
-                new ServerMainModule(sqlParserOptions));
+                new ServerMainModule(sqlParserOptions),
+                new GracefulShutdownModule());
 
         modules.addAll(getAdditionalModules());
 

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -14,6 +14,9 @@
 package com.facebook.presto.server;
 
 import io.airlift.configuration.Config;
+import io.airlift.units.Duration;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class ServerConfig
 {
@@ -21,6 +24,7 @@ public class ServerConfig
     private String prestoVersion;
     private String dataSources;
     private boolean includeExceptionInResponse = true;
+    private Duration gracePeriod = new Duration(2, MINUTES);
 
     public boolean isCoordinator()
     {
@@ -69,6 +73,18 @@ public class ServerConfig
     public ServerConfig setIncludeExceptionInResponse(boolean includeExceptionInResponse)
     {
         this.includeExceptionInResponse = includeExceptionInResponse;
+        return this;
+    }
+
+    public Duration getGracePeriod()
+    {
+        return gracePeriod;
+    }
+
+    @Config("shutdown.grace-period")
+    public ServerConfig setGracePeriod(Duration gracePeriod)
+    {
+        this.gracePeriod = gracePeriod;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerInfoResource.java
@@ -14,30 +14,82 @@
 package com.facebook.presto.server;
 
 import com.facebook.presto.client.ServerInfo;
+import com.facebook.presto.spi.NodeState;
 
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
+import static com.facebook.presto.spi.NodeState.ACTIVE;
+import static com.facebook.presto.spi.NodeState.SHUTTING_DOWN;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 
 @Path("/v1/info")
 public class ServerInfoResource
 {
     private final ServerInfo serverInfo;
+    private final GracefulShutdownHandler shutdownHandler;
 
     @Inject
-    public ServerInfoResource(ServerInfo serverInfo)
+    public ServerInfoResource(ServerInfo serverInfo, GracefulShutdownHandler shutdownHandler)
     {
         this.serverInfo = requireNonNull(serverInfo, "serverInfo is null");
+        this.shutdownHandler = requireNonNull(shutdownHandler, "shutdownHandler is null");
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     public ServerInfo getServerInfo()
     {
         return serverInfo;
+    }
+
+    @PUT
+    @Path("state")
+    @Consumes(APPLICATION_JSON)
+    @Produces(TEXT_PLAIN)
+    public Response updateState(NodeState state)
+            throws WebApplicationException
+    {
+        switch (state) {
+            case SHUTTING_DOWN:
+                shutdownHandler.requestShutdown();
+                return Response.ok().build();
+            case ACTIVE:
+            case INACTIVE:
+                throw new WebApplicationException(Response
+                        .status(BAD_REQUEST)
+                        .type(MediaType.TEXT_PLAIN)
+                        .entity(format("Invalid state transition to %s", state))
+                        .build());
+            default:
+                return Response.status(BAD_REQUEST)
+                        .type(TEXT_PLAIN)
+                        .entity(format("Invalid state %s", state))
+                        .build();
+        }
+    }
+
+    @GET
+    @Path("state")
+    @Produces(APPLICATION_JSON)
+    public NodeState getServerState()
+    {
+        if (shutdownHandler.isShutdownRequested()) {
+            return SHUTTING_DOWN;
+        }
+        else {
+            return ACTIVE;
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ShutdownAction.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ShutdownAction.java
@@ -11,17 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.spi;
+package com.facebook.presto.server;
 
-import java.util.Set;
-
-public interface NodeManager
+public interface ShutdownAction
 {
-    Set<Node> getNodes(NodeState state);
-
-    Set<Node> getActiveDatasourceNodes(String datasourceName);
-
-    Node getCurrentNode();
-
-    Set<Node> getCoordinators();
+    void onShutdown();
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -15,6 +15,7 @@ package com.facebook.presto.server.testing;
 
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.TaskManager;
 import com.facebook.presto.memory.ClusterMemoryManager;
 import com.facebook.presto.memory.LocalMemoryManager;
 import com.facebook.presto.metadata.AllNodes;
@@ -22,8 +23,10 @@ import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.security.AccessControlManager;
+import com.facebook.presto.server.GracefulShutdownHandler;
 import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.ServerMainModule;
+import com.facebook.presto.server.ShutdownAction;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.split.SplitManager;
@@ -56,6 +59,8 @@ import io.airlift.node.testing.TestingNodeModule;
 import io.airlift.tracetoken.TraceTokenModule;
 import org.weakref.jmx.guice.MBeanModule;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import java.io.Closeable;
 import java.net.URI;
 import java.nio.file.Files;
@@ -67,11 +72,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 
 import static com.facebook.presto.server.testing.FileUtils.deleteRecursively;
 import static com.google.common.base.Strings.nullToEmpty;
 import static io.airlift.discovery.client.ServiceAnnouncement.serviceAnnouncement;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class TestingPrestoServer
         implements Closeable
@@ -90,6 +97,37 @@ public class TestingPrestoServer
     private final ServiceSelectorManager serviceSelectorManager;
     private final Announcer announcer;
     private final QueryManager queryManager;
+    private final TaskManager taskManager;
+    private final GracefulShutdownHandler gracefulShutdownHandler;
+    private final ShutdownAction shutdownAction;
+    private final boolean coordinator;
+
+    public static class TestShutdownAction
+            implements ShutdownAction
+    {
+        private final CountDownLatch shutdownCalled = new CountDownLatch(1);
+
+        @GuardedBy("this")
+        private boolean isWorkerShutdown = false;
+
+        @Override
+        public synchronized void onShutdown()
+        {
+            isWorkerShutdown = true;
+            shutdownCalled.countDown();
+        }
+
+        public void waitForShutdownComplete(long millis)
+                throws InterruptedException
+        {
+            shutdownCalled.await(millis, MILLISECONDS);
+        }
+
+        public synchronized boolean isWorkerShutdown()
+        {
+            return isWorkerShutdown;
+        }
+    }
 
     public TestingPrestoServer()
             throws Exception
@@ -106,6 +144,7 @@ public class TestingPrestoServer
     public TestingPrestoServer(boolean coordinator, Map<String, String> properties, String environment, URI discoveryUri, List<Module> additionalModules)
             throws Exception
     {
+        this.coordinator = coordinator;
         baseDataDir = Files.createTempDirectory("PrestoTest");
 
         ImmutableMap.Builder<String, String> serverProperties = ImmutableMap.<String, String>builder()
@@ -143,6 +182,15 @@ public class TestingPrestoServer
                         binder.bind(TestingAccessControlManager.class).in(Scopes.SINGLETON);
                         binder.bind(AccessControlManager.class).to(TestingAccessControlManager.class).in(Scopes.SINGLETON);
                         binder.bind(AccessControl.class).to(AccessControlManager.class).in(Scopes.SINGLETON);
+                    }
+                })
+                .add(new Module()
+                {
+                    @Override
+                    public void configure(Binder binder)
+                    {
+                        binder.bind(ShutdownAction.class).to(TestShutdownAction.class).in(Scopes.SINGLETON);
+                        binder.bind(GracefulShutdownHandler.class).in(Scopes.SINGLETON);
                     }
                 });
 
@@ -189,6 +237,9 @@ public class TestingPrestoServer
         localMemoryManager = injector.getInstance(LocalMemoryManager.class);
         nodeManager = injector.getInstance(InternalNodeManager.class);
         serviceSelectorManager = injector.getInstance(ServiceSelectorManager.class);
+        gracefulShutdownHandler = injector.getInstance(GracefulShutdownHandler.class);
+        taskManager = injector.getInstance(TaskManager.class);
+        shutdownAction = injector.getInstance(ShutdownAction.class);
         announcer = injector.getInstance(Announcer.class);
 
         announcer.forceAnnounce();
@@ -276,6 +327,26 @@ public class TestingPrestoServer
     public ClusterMemoryManager getClusterMemoryManager()
     {
         return clusterMemoryManager;
+    }
+
+    public GracefulShutdownHandler getGracefulShutdownHandler()
+    {
+        return gracefulShutdownHandler;
+    }
+
+    public TaskManager getTaskManager()
+    {
+        return taskManager;
+    }
+
+    public ShutdownAction getShutdownAction()
+    {
+        return shutdownAction;
+    }
+
+    public boolean isCoordinator()
+    {
+        return coordinator;
     }
 
     public final AllNodes refreshNodes()

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestDiscoveryNodeManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestDiscoveryNodeManager.java
@@ -17,12 +17,16 @@ import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.server.NoOpFailureDetector;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.airlift.discovery.client.ServiceDescriptor;
 import io.airlift.discovery.client.ServiceSelector;
 import io.airlift.discovery.client.testing.StaticServiceSelector;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.testing.TestingHttpClient;
+import io.airlift.http.client.testing.TestingResponse;
 import io.airlift.node.NodeConfig;
 import io.airlift.node.NodeInfo;
 import org.testng.annotations.BeforeMethod;
@@ -34,7 +38,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.facebook.presto.spi.NodeState.ACTIVE;
+import static com.facebook.presto.spi.NodeState.INACTIVE;
 import static io.airlift.discovery.client.ServiceDescriptor.serviceDescriptor;
+import static io.airlift.http.client.HttpStatus.OK;
 import static io.airlift.testing.Assertions.assertEqualsIgnoreOrder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
@@ -48,10 +55,13 @@ public class TestDiscoveryNodeManager
     private List<PrestoNode> inactiveNodes;
     private PrestoNode coordinator;
     private ServiceSelector selector;
+    private HttpClient testHttpClient;
 
     @BeforeMethod
     public void setup()
     {
+        testHttpClient = new TestingHttpClient(input -> new TestingResponse(OK, ArrayListMultimap.create(), ACTIVE.name().getBytes()));
+
         expectedVersion = new NodeVersion("1");
         coordinator = new PrestoNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.8"), expectedVersion);
         activeNodes = ImmutableList.of(
@@ -81,7 +91,7 @@ public class TestDiscoveryNodeManager
     public void testGetAllNodes()
             throws Exception
     {
-        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion);
+        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion, testHttpClient);
         AllNodes allNodes = manager.getAllNodes();
 
         Set<Node> activeNodes = allNodes.getActiveNodes();
@@ -93,6 +103,8 @@ public class TestDiscoveryNodeManager
             }
         }
 
+        assertEqualsIgnoreOrder(activeNodes, manager.getNodes(ACTIVE));
+
         Set<Node> inactiveNodes = allNodes.getInactiveNodes();
         assertEqualsIgnoreOrder(inactiveNodes, this.inactiveNodes);
 
@@ -101,6 +113,8 @@ public class TestDiscoveryNodeManager
                 assertNotSame(actual, expected);
             }
         }
+
+        assertEqualsIgnoreOrder(inactiveNodes, manager.getNodes(INACTIVE));
     }
 
     @Test
@@ -112,7 +126,7 @@ public class TestDiscoveryNodeManager
                 .setEnvironment("test")
                 .setNodeId(expected.getNodeIdentifier()));
 
-        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion);
+        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion, testHttpClient);
 
         assertEquals(manager.getCurrentNode(), expected);
     }
@@ -121,7 +135,7 @@ public class TestDiscoveryNodeManager
     public void testGetCoordinators()
             throws Exception
     {
-        NodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion);
+        NodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion, testHttpClient);
         assertEquals(manager.getCoordinators(), ImmutableSet.of(coordinator));
     }
 
@@ -129,6 +143,6 @@ public class TestDiscoveryNodeManager
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".* current node not returned .*")
     public void testGetCurrentNodeRequired()
     {
-        new DiscoveryNodeManager(selector, new NodeInfo("test"), new NoOpFailureDetector(), expectedVersion);
+        new DiscoveryNodeManager(selector, new NodeInfo("test"), new NoOpFailureDetector(), expectedVersion, testHttpClient);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
@@ -15,12 +15,14 @@ package com.facebook.presto.server;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.configuration.testing.ConfigAssertions;
+import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class TestServerConfig
 {
@@ -31,7 +33,8 @@ public class TestServerConfig
                 .setCoordinator(true)
                 .setPrestoVersion(null)
                 .setDataSources(null)
-                .setIncludeExceptionInResponse(true));
+                .setIncludeExceptionInResponse(true)
+                .setGracePeriod(new Duration(2, MINUTES)));
     }
 
     @Test
@@ -42,13 +45,15 @@ public class TestServerConfig
                 .put("presto.version", "test")
                 .put("datasources", "jmx")
                 .put("http.include-exception-in-response", "false")
+                .put("shutdown.grace-period", "5m")
                 .build();
 
         ServerConfig expected = new ServerConfig()
                 .setCoordinator(false)
                 .setPrestoVersion("test")
                 .setDataSources("jmx")
-                .setIncludeExceptionInResponse(false);
+                .setIncludeExceptionInResponse(false)
+                .setGracePeriod(new Duration(5, MINUTES));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplitManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplitManager.java
@@ -50,6 +50,7 @@ import java.util.function.Supplier;
 
 import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_NO_HOST_FOR_SHARD;
 import static com.facebook.presto.raptor.util.Types.checkType;
+import static com.facebook.presto.spi.NodeState.ACTIVE;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -138,7 +139,7 @@ public class RaptorSplitManager
     private class RaptorSplitSource
             implements ConnectorSplitSource
     {
-        private final Map<String, Node> nodesById = uniqueIndex(nodeManager.getActiveNodes(), Node::getNodeIdentifier);
+        private final Map<String, Node> nodesById = uniqueIndex(nodeManager.getNodes(ACTIVE), Node::getNodeIdentifier);
         private final long tableId;
         private final TupleDomain<RaptorColumnHandle> effectivePredicate;
         private final OptionalLong transactionId;

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardEjector.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardEjector.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.facebook.presto.spi.NodeState.ACTIVE;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Maps.filterKeys;
@@ -166,7 +167,7 @@ public class ShardEjector
         // get the size of assigned shards for each node
         Map<String, Long> nodes = shardManager.getNodeBytes();
 
-        Set<String> activeNodes = nodeManager.getActiveNodes().stream()
+        Set<String> activeNodes = nodeManager.getNodes(ACTIVE).stream()
                 .map(Node::getNodeIdentifier)
                 .collect(toSet());
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardEjector.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardEjector.java
@@ -23,6 +23,7 @@ import com.facebook.presto.raptor.metadata.ShardMetadata;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.NodeState;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -205,7 +206,7 @@ public class TestShardEjector
         }
 
         @Override
-        public Set<Node> getActiveNodes()
+        public Set<Node> getNodes(NodeState state)
         {
             return nodes;
         }

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisPlugin.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisPlugin.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.ConnectorFactory;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.NodeState;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
@@ -91,7 +92,7 @@ public class TestRedisPlugin
         private static final Node LOCAL_NODE = new TestingNode();
 
         @Override
-        public Set<Node> getActiveNodes()
+        public Set<Node> getNodes(NodeState state)
         {
             return ImmutableSet.of(LOCAL_NODE);
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/NodeState.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/NodeState.java
@@ -13,15 +13,9 @@
  */
 package com.facebook.presto.spi;
 
-import java.util.Set;
-
-public interface NodeManager
+public enum NodeState
 {
-    Set<Node> getNodes(NodeState state);
-
-    Set<Node> getActiveDatasourceNodes(String datasourceName);
-
-    Node getCurrentNode();
-
-    Set<Node> getCoordinators();
+    ACTIVE,
+    INACTIVE,
+    SHUTTING_DOWN
 }

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -262,7 +262,7 @@ public class TestMemoryManager
         executor.shutdownNow();
     }
 
-    private static DistributedQueryRunner createQueryRunner(Session session, Map<String, String> properties)
+    public static DistributedQueryRunner createQueryRunner(Session session, Map<String, String> properties)
             throws Exception
     {
         DistributedQueryRunner queryRunner = new DistributedQueryRunner(session, 2, properties);

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestGracefulShutdown.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestGracefulShutdown.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.QueryInfo;
+import com.facebook.presto.execution.TaskManager;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.server.testing.TestingPrestoServer.TestShutdownAction;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.execution.QueryState.FINISHED;
+import static com.facebook.presto.memory.TestMemoryManager.createQueryRunner;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestGracefulShutdown
+{
+    private static final long SHUTDOWN_TIMEOUT_MILLIS = 240_000;
+    private static final Session TINY_SESSION = testSessionBuilder()
+            .setCatalog("tpch")
+            .setSchema("tiny")
+            .build();
+
+    private final ListeningExecutorService executor = MoreExecutors.listeningDecorator(newCachedThreadPool());
+
+    @Test(timeOut = SHUTDOWN_TIMEOUT_MILLIS)
+    public void testShutdown()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("node-scheduler.include-coordinator", "false")
+                .put("shutdown.grace-period", "10s")
+                .build();
+
+        try (DistributedQueryRunner queryRunner = createQueryRunner(TINY_SESSION, properties)) {
+            List<ListenableFuture<?>> queryFutures = new ArrayList<>();
+            for (int i = 0; i < 5; i++) {
+                queryFutures.add(executor.submit(() -> queryRunner.execute("SELECT COUNT(*), clerk FROM orders GROUP BY clerk")));
+            }
+
+            TestingPrestoServer worker = queryRunner.getServers()
+                    .stream()
+                    .filter(server -> !server.isCoordinator())
+                    .findFirst()
+                    .get();
+
+            TaskManager taskManager = worker.getTaskManager();
+
+            // wait until tasks show up on the worker
+            while (taskManager.getAllTaskInfo().isEmpty()) {
+                MILLISECONDS.sleep(500);
+            }
+
+            worker.getGracefulShutdownHandler().requestShutdown();
+
+            Futures.allAsList(queryFutures).get();
+
+            List<QueryInfo> queryInfos = queryRunner.getCoordinator().getQueryManager().getAllQueryInfo();
+            for (QueryInfo info : queryInfos) {
+                assertEquals(info.getState(), FINISHED);
+            }
+
+            TestShutdownAction shutdownAction = (TestShutdownAction) worker.getShutdownAction();
+            shutdownAction.waitForShutdownComplete(SHUTDOWN_TIMEOUT_MILLIS);
+            assertTrue(shutdownAction.isWorkerShutdown());
+        }
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void shutdown()
+    {
+        executor.shutdownNow();
+    }
+}


### PR DESCRIPTION
This is the initial version of the graceful worker shutdown functionality (tested with automated randomized query submissions + shutdown requests). \cc @martint @cberner @dain 

**Note:** In this version due to a network glitch a worker can go from "shutting down" state to the "failed" state and then back to the "active" state (as that node will be removed from the known node states when it gets marked as "failed" -- see `DiscoveryNodeManager`.`nodeStates` map). And in the "active" state the coordinator will submit tasks to that shutting down worker and it is possible that these tasks may be received after the worker registers the task completion listeners, eventually causing those tasks to fail ungracefully. One possible way to prevent this is to reject these tasks at the workers (in `TaskResource`.`createOrUpdateTask()` if a worker is in the "shutting down" state) and let the coordinator re-schedule them (not sure whether this is easy to implement with the current scheduling code).