### PR TITLE
Set the max response size for exchange client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <air.java.version>1.8.0-40</air.java.version>
 
         <dep.antlr.version>4.5.1</dep.antlr.version>
-        <dep.airlift.version>0.118</dep.airlift.version>
+        <dep.airlift.version>0.119</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.15</dep.slice.version>
 

--- a/presto-docs/src/main/sphinx/release/release-0.126.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.126.rst
@@ -28,6 +28,9 @@ General Changes
 * Enable connector predicate push down for all comparable and equatable types.
 * Fix query planning failure when using certain operations such as ``GROUP BY``,
   ``DISTINCT``, etc. on the output columns of ``UNNEST``.
+* In ``ExchangeClient`` set ``maxResponseSize`` to be slightly smaller than
+  the configured value. This reduces the possibility of encountering
+  ``PageTooLargeException``.
 
 Hive Changes
 ------------

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientConfig.java
@@ -18,6 +18,7 @@ import io.airlift.http.client.HttpClientConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
 import io.airlift.units.Duration;
+import io.airlift.units.MinDataSize;
 import io.airlift.units.MinDuration;
 
 import javax.validation.constraints.Min;
@@ -74,6 +75,7 @@ public class ExchangeClientConfig
     }
 
     @NotNull
+    @MinDataSize("1MB")
     public DataSize getMaxResponseSize()
     {
         return maxResponseSize;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClientConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClientConfig.java
@@ -47,7 +47,7 @@ public class TestExchangeClientConfig
                 .put("exchange.max-buffer-size", "1GB")
                 .put("exchange.concurrent-request-multiplier", "13")
                 .put("exchange.min-error-duration", "13s")
-                .put("exchange.max-response-size", "1kB")
+                .put("exchange.max-response-size", "1MB")
                 .put("exchange.client-threads", "2")
                 .build();
 
@@ -55,7 +55,7 @@ public class TestExchangeClientConfig
                 .setMaxBufferSize(new DataSize(1, Unit.GIGABYTE))
                 .setConcurrentRequestMultiplier(13)
                 .setMinErrorDuration(new Duration(13, TimeUnit.SECONDS))
-                .setMaxResponseSize(new DataSize(1, Unit.KILOBYTE))
+                .setMaxResponseSize(new DataSize(1, Unit.MEGABYTE))
                 .setClientThreads(2);
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
Currently the exchange max response size is set to the max content
length of the http client. When we extract pages from the SharedBuffer
we do not account for the additional bytes that are included in the
block encodings. In some cases this can cause the response size to go
over the max allowed response size. Mitigate this by asking for only
half response size. This leaves enough room for additional bytes added
by the block encodings.