### PR TITLE
Remove trailing whitepace in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ benchmark_outputs
 *.class
 .checkstyle
 *-local.yaml
-.mvn/timing.properties 
+.mvn/timing.properties


### PR DESCRIPTION
This is required because older versions of git fail to match lines with trailing whitespace in .gitignore