### PR TITLE
Add limited support for cube, rollup and grouping set to grammar

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -59,7 +59,7 @@ public class Analysis
     private final IdentityHashMap<Expression, Integer> resolvedNames = new IdentityHashMap<>();
 
     private final IdentityHashMap<QuerySpecification, List<FunctionCall>> aggregates = new IdentityHashMap<>();
-    private final IdentityHashMap<QuerySpecification, List<FieldOrExpression>> groupByExpressions = new IdentityHashMap<>();
+    private final IdentityHashMap<QuerySpecification, List<List<FieldOrExpression>>> groupByExpressions = new IdentityHashMap<>();
     private final IdentityHashMap<Node, Expression> where = new IdentityHashMap<>();
     private final IdentityHashMap<QuerySpecification, Expression> having = new IdentityHashMap<>();
     private final IdentityHashMap<Node, List<FieldOrExpression>> orderByExpressions = new IdentityHashMap<>();
@@ -172,12 +172,12 @@ public class Analysis
         return coercions.get(expression);
     }
 
-    public void setGroupByExpressions(QuerySpecification node, List<FieldOrExpression> expressions)
+    public void setGroupingSets(QuerySpecification node, List<List<FieldOrExpression>> expressions)
     {
         groupByExpressions.put(node, expressions);
     }
 
-    public List<FieldOrExpression> getGroupByExpressions(QuerySpecification node)
+    public List<List<FieldOrExpression>> getGroupingSets(QuerySpecification node)
     {
         return groupByExpressions.get(node);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -75,6 +75,7 @@ import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Objects.requireNonNull;
 
 class QueryPlanner
@@ -339,10 +340,16 @@ class QueryPlanner
 
     private PlanBuilder aggregate(PlanBuilder subPlan, QuerySpecification node)
     {
-        if (analysis.getAggregates(node).isEmpty() && analysis.getGroupByExpressions(node).isEmpty()) {
+        List<List<FieldOrExpression>> groupingSets = analysis.getGroupingSets(node);
+        if (groupingSets.isEmpty()) {
             return subPlan;
         }
 
+        return aggregateGroupingSet(getOnlyElement(groupingSets), subPlan, node);
+    }
+
+    private PlanBuilder aggregateGroupingSet(List<FieldOrExpression> groupingSet, PlanBuilder subPlan, QuerySpecification node)
+    {
         List<FieldOrExpression> arguments = analysis.getAggregates(node).stream()
                 .map(FunctionCall::getArguments)
                 .flatMap(List::stream)
@@ -350,7 +357,7 @@ class QueryPlanner
                 .collect(toImmutableList());
 
         // 1. Pre-project all scalar inputs (arguments and non-trivial group by expressions)
-        Iterable<FieldOrExpression> inputs = Iterables.concat(analysis.getGroupByExpressions(node), arguments);
+        Iterable<FieldOrExpression> inputs = Iterables.concat(groupingSet, arguments);
         if (!Iterables.isEmpty(inputs)) { // avoid an empty projection if the only aggregation is COUNT (which has no arguments)
             subPlan = project(subPlan, inputs);
         }
@@ -380,7 +387,7 @@ class QueryPlanner
 
         // 2.b. Rewrite group by expressions in terms of pre-projected inputs
         Set<Symbol> groupBySymbols = new LinkedHashSet<>();
-        for (FieldOrExpression fieldOrExpression : analysis.getGroupByExpressions(node)) {
+        for (FieldOrExpression fieldOrExpression : groupingSet) {
             Symbol symbol = subPlan.translate(fieldOrExpression);
             groupBySymbols.add(symbol);
             translations.put(fieldOrExpression, symbol);
@@ -397,7 +404,7 @@ class QueryPlanner
             Symbol aggregateSymbol = translations.get(aggregate);
             if (marker == null) {
                 if (args.size() == 1) {
-                    marker = symbolAllocator.newSymbol(Iterables.getOnlyElement(args), BOOLEAN, "distinct");
+                    marker = symbolAllocator.newSymbol(getOnlyElement(args), BOOLEAN, "distinct");
                 }
                 else {
                     marker = symbolAllocator.newSymbol(aggregateSymbol.getName(), BOOLEAN, "distinct");
@@ -445,7 +452,7 @@ class QueryPlanner
         // Add back the implicit casts that we removed in 2.a
         // TODO: this is a hack, we should change type coercions to coerce the inputs to functions/operators instead of coercing the output
         if (needPostProjectionCoercion) {
-            return explicitCoercionFields(subPlan, analysis.getGroupByExpressions(node), analysis.getAggregates(node));
+            return explicitCoercionFields(subPlan, groupingSet, analysis.getAggregates(node));
         }
         return subPlan;
     }
@@ -630,7 +637,7 @@ class QueryPlanner
         SubqueryExpression subqueryExpression = (SubqueryExpression) inPredicate.getValueList();
         RelationPlanner relationPlanner = new RelationPlanner(analysis, symbolAllocator, idAllocator, metadata, session);
         RelationPlan valueListRelation = relationPlanner.process(subqueryExpression.getQuery(), null);
-        Symbol filteringSourceJoinSymbol = Iterables.getOnlyElement(valueListRelation.getRoot().getOutputSymbols());
+        Symbol filteringSourceJoinSymbol = getOnlyElement(valueListRelation.getRoot().getOutputSymbols());
 
         Symbol semiJoinOutputSymbol = symbolAllocator.newSymbol("semijoinresult", BOOLEAN);
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -669,6 +669,17 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testSingleGroupingSet()
+            throws Exception
+    {
+        // TODO: validate output
+        analyze("SELECT SUM(b) FROM t1 GROUP BY ()");
+        analyze("SELECT SUM(b) FROM t1 GROUP BY GROUPING SETS (())");
+        analyze("SELECT a, SUM(b) FROM t1 GROUP BY GROUPING SETS (a)");
+        analyze("SELECT a, SUM(b) FROM t1 GROUP BY GROUPING SETS ((a, b))");
+    }
+
+    @Test
     public void testAggregateWithWildcard()
             throws Exception
     {

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -111,8 +111,25 @@ querySpecification
     : SELECT setQuantifier? selectItem (',' selectItem)*
       (FROM relation (',' relation)*)?
       (WHERE where=booleanExpression)?
-      (GROUP BY groupBy+=expression (',' groupBy+=expression)*)?
+      (GROUP BY groupingElement (',' groupingElement)*)?
       (HAVING having=booleanExpression)?
+    ;
+
+groupingElement
+    : groupingExpressions                                               #singleGroupingSet
+    | ROLLUP '(' (qualifiedName (',' qualifiedName)*)? ')'              #rollup
+    | CUBE '(' (qualifiedName (',' qualifiedName)*)? ')'                #cube
+    | GROUPING SETS '(' groupingSet (',' groupingSet)* ')'              #multipleGroupingSets
+    ;
+
+groupingExpressions
+    : '(' (expression (',' expression)*)? ')'
+    | expression
+    ;
+
+groupingSet
+    : '(' (qualifiedName (',' qualifiedName)*)? ')'
+    | qualifiedName
     ;
 
 namedQuery
@@ -371,6 +388,10 @@ DISTINCT: 'DISTINCT';
 WHERE: 'WHERE';
 GROUP: 'GROUP';
 BY: 'BY';
+GROUPING: 'GROUPING';
+SETS: 'SETS';
+CUBE: 'CUBE';
+ROLLUP: 'ROLLUP';
 ORDER: 'ORDER';
 HAVING: 'HAVING';
 LIMIT: 'LIMIT';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.GroupingElement;
 import com.facebook.presto.sql.tree.IfExpression;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -179,13 +180,13 @@ public final class QueryUtil
         return simpleQuery(select, from, where, ImmutableList.of(), Optional.empty(), ordering, Optional.empty());
     }
 
-    public static Query simpleQuery(Select select, Relation from, Optional<Expression> where, List<Expression> grouping, Optional<Expression> having, List<SortItem> ordering, Optional<String> limit)
+    public static Query simpleQuery(Select select, Relation from, Optional<Expression> where, List<GroupingElement> groupBy, Optional<Expression> having, List<SortItem> ordering, Optional<String> limit)
     {
         return query(new QuerySpecification(
                 select,
                 Optional.of(from),
                 where,
-                grouping,
+                groupBy,
                 having,
                 ordering,
                 limit));

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -70,6 +70,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static com.facebook.presto.sql.ExpressionFormatter.formatExpression;
+import static com.facebook.presto.sql.ExpressionFormatter.formatGroupBy;
 import static com.facebook.presto.sql.ExpressionFormatter.formatSortItems;
 import static com.facebook.presto.sql.ExpressionFormatter.formatStringLiteral;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -194,8 +195,7 @@ public final class SqlFormatter
             }
 
             if (!node.getGroupBy().isEmpty()) {
-                append(indent, "GROUP BY " + Joiner.on(", ").join(transform(node.getGroupBy(), ExpressionFormatter::formatExpression)))
-                        .append('\n');
+                append(indent, "GROUP BY " + formatGroupBy(node.getGroupBy())).append('\n');
             }
 
             if (node.getHaving().isPresent()) {

--- a/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
@@ -19,10 +19,13 @@ import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.GroupingElement;
+import com.facebook.presto.sql.tree.GroupingSets;
 import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
@@ -32,9 +35,11 @@ import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QuerySpecification;
+import com.facebook.presto.sql.tree.Rollup;
 import com.facebook.presto.sql.tree.Row;
 import com.facebook.presto.sql.tree.SampledRelation;
 import com.facebook.presto.sql.tree.Select;
+import com.facebook.presto.sql.tree.SimpleGroupBy;
 import com.facebook.presto.sql.tree.SingleColumn;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.StringLiteral;
@@ -47,6 +52,7 @@ import com.google.common.base.Strings;
 
 import java.io.PrintStream;
 import java.util.IdentityHashMap;
+import java.util.Set;
 
 public class TreePrinter
 {
@@ -115,9 +121,35 @@ public class TreePrinter
                 }
 
                 if (!node.getGroupBy().isEmpty()) {
-                    print(indentLevel, "GroupBy");
-                    for (Expression expression : node.getGroupBy()) {
-                        process(expression, indentLevel + 1);
+                    for (GroupingElement groupingElement : node.getGroupBy()) {
+                        print(indentLevel, "GroupBy");
+                        if (groupingElement instanceof SimpleGroupBy) {
+                            for (Expression column : ((SimpleGroupBy) groupingElement).getColumnExpressions()) {
+                                process(column, indentLevel + 1);
+                            }
+                        }
+                        else if (groupingElement instanceof GroupingSets) {
+                            print(indentLevel + 1, "GroupingSets");
+                            for (Set<Expression> column : groupingElement.enumerateGroupingSets()) {
+                                print(indentLevel + 2, "GroupingSet[");
+                                for (Expression expression : column) {
+                                    process(expression, indentLevel + 3);
+                                }
+                                print(indentLevel + 2, "]");
+                            }
+                        }
+                        else if (groupingElement instanceof Cube) {
+                            print(indentLevel + 1, "Cube");
+                            for (QualifiedName column : ((Cube) groupingElement).getColumns()) {
+                                print(indentLevel + 1, column.toString());
+                            }
+                        }
+                        else if (groupingElement instanceof Rollup) {
+                            print(indentLevel + 1, "Rollup");
+                            for (QualifiedName column : ((Rollup) groupingElement).getColumns()) {
+                                print(indentLevel + 1, column.toString());
+                            }
+                        }
                     }
                 }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.Sets;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toSet;
+
+public class Cube
+        extends GroupingElement
+{
+    private final List<QualifiedName> columns;
+
+    public Cube(List<QualifiedName> columns)
+    {
+        this(Optional.empty(), columns);
+    }
+
+    public Cube(NodeLocation location, List<QualifiedName> columns)
+    {
+        this(Optional.of(location), columns);
+    }
+
+    private Cube(Optional<NodeLocation> location, List<QualifiedName> columns)
+    {
+        super(location);
+        requireNonNull(columns, "columns is null");
+        this.columns = columns;
+    }
+
+    public List<QualifiedName> getColumns()
+    {
+        return columns;
+    }
+
+    @Override
+    public Set<Set<Expression>> enumerateGroupingSets()
+    {
+        return Sets.powerSet(columns.stream()
+                .map(QualifiedNameReference::new)
+                .collect(toSet()));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Cube cube = (Cube) o;
+        return Objects.equals(columns, cube.columns);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(columns);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("columns", columns)
+                .toString();
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -335,8 +335,8 @@ public abstract class DefaultTraversalVisitor<R, C>
         if (node.getWhere().isPresent()) {
             process(node.getWhere().get(), context);
         }
-        for (Expression expression : node.getGroupBy()) {
-            process(expression, context);
+        for (GroupingElement groupingElement : node.getGroupBy()) {
+            process(groupingElement, context);
         }
         if (node.getHaving().isPresent()) {
             process(node.getHaving().get(), context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingElement.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingElement.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Optional;
+import java.util.Set;
+
+public abstract class GroupingElement
+        extends Node
+{
+    public GroupingElement(Optional<NodeLocation> location)
+    {
+        super(location);
+    }
+
+    public abstract Set<Set<Expression>> enumerateGroupingSets();
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.stream.Collectors.collectingAndThen;
+
+public class GroupingSets
+        extends GroupingElement
+{
+    private final List<List<QualifiedName>> sets;
+
+    public GroupingSets(List<List<QualifiedName>> groupingSetList)
+    {
+        this(Optional.empty(), groupingSetList);
+    }
+
+    public GroupingSets(NodeLocation location, List<List<QualifiedName>> sets)
+    {
+        this(Optional.of(location), sets);
+    }
+
+    private GroupingSets(Optional<NodeLocation> location, List<List<QualifiedName>> sets)
+    {
+        super(location);
+        this.sets = sets;
+    }
+
+    @Override
+    public Set<Set<Expression>> enumerateGroupingSets()
+    {
+        return sets.stream()
+                .map(groupingSet -> groupingSet.stream()
+                        .map(QualifiedNameReference::new)
+                        .collect(Collectors.<Expression>toSet()))
+                .collect(collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GroupingSets groupingSets = (GroupingSets) o;
+        return Objects.equals(sets, groupingSets.sets);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sets);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("sets", sets)
+                .toString();
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/QuerySpecification.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/QuerySpecification.java
@@ -26,7 +26,7 @@ public class QuerySpecification
     private final Select select;
     private final Optional<Relation> from;
     private final Optional<Expression> where;
-    private final List<Expression> groupBy;
+    private final List<GroupingElement> groupBy;
     private final Optional<Expression> having;
     private final List<SortItem> orderBy;
     private final Optional<String> limit;
@@ -35,7 +35,7 @@ public class QuerySpecification
             Select select,
             Optional<Relation> from,
             Optional<Expression> where,
-            List<Expression> groupBy,
+            List<GroupingElement> groupBy,
             Optional<Expression> having,
             List<SortItem> orderBy,
             Optional<String> limit)
@@ -48,7 +48,7 @@ public class QuerySpecification
             Select select,
             Optional<Relation> from,
             Optional<Expression> where,
-            List<Expression> groupBy,
+            List<GroupingElement> groupBy,
             Optional<Expression> having,
             List<SortItem> orderBy,
             Optional<String> limit)
@@ -61,7 +61,7 @@ public class QuerySpecification
             Select select,
             Optional<Relation> from,
             Optional<Expression> where,
-            List<Expression> groupBy,
+            List<GroupingElement> groupBy,
             Optional<Expression> having,
             List<SortItem> orderBy,
             Optional<String> limit)
@@ -99,7 +99,7 @@ public class QuerySpecification
         return where;
     }
 
-    public List<Expression> getGroupBy()
+    public List<GroupingElement> getGroupBy()
     {
         return groupBy;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toSet;
+
+public class Rollup
+        extends GroupingElement
+{
+    private final List<QualifiedName> columns;
+
+    public Rollup(List<QualifiedName> columns)
+    {
+        this(Optional.empty(), columns);
+    }
+
+    public Rollup(NodeLocation location, List<QualifiedName> columns)
+    {
+        this(Optional.of(location), columns);
+    }
+
+    private Rollup(Optional<NodeLocation> location, List<QualifiedName> columns)
+    {
+        super(location);
+        requireNonNull(columns, "columns is null");
+        this.columns = columns;
+    }
+
+    public List<QualifiedName> getColumns()
+    {
+        return columns;
+    }
+
+    @Override
+    public Set<Set<Expression>> enumerateGroupingSets()
+    {
+        int numColumns = columns.size();
+        Set<Set<Expression>> enumeratedGroupingSets = IntStream.range(0, numColumns)
+                .mapToObj(i -> columns.subList(0, numColumns - i)
+                        .stream()
+                        .map(QualifiedNameReference::new)
+                        .map(Expression.class::cast)
+                        .collect(toSet()))
+                .collect(toSet());
+        enumeratedGroupingSets.add(ImmutableSet.of());
+        return enumeratedGroupingSets;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Rollup rollup = (Rollup) o;
+        return Objects.equals(columns, rollup.columns);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(columns);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("columns", columns)
+                .toString();
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleGroupBy.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleGroupBy.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class SimpleGroupBy
+    extends GroupingElement
+{
+    private final List<Expression> columns;
+
+    public SimpleGroupBy(List<Expression> simpleGroupByExpressions)
+    {
+        this(Optional.empty(), simpleGroupByExpressions);
+    }
+
+    public SimpleGroupBy(NodeLocation location, List<Expression> simpleGroupByExpressions)
+    {
+        this(Optional.of(location), simpleGroupByExpressions);
+    }
+
+    private SimpleGroupBy(Optional<NodeLocation> location, List<Expression> simpleGroupByExpressions)
+    {
+        super(location);
+        this.columns = simpleGroupByExpressions;
+    }
+
+    public List<Expression> getColumnExpressions()
+    {
+        return columns;
+    }
+
+    @Override
+    public Set<Set<Expression>> enumerateGroupingSets()
+    {
+        return ImmutableSet.of(ImmutableSet.copyOf(columns));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SimpleGroupBy that = (SimpleGroupBy) o;
+        return Objects.equals(columns, that.columns);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(columns);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("columns", columns)
+                .toString();
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -25,6 +25,7 @@ import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.CreateView;
+import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.CurrentTime;
 import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DereferenceExpression;
@@ -37,6 +38,7 @@ import com.facebook.presto.sql.tree.ExplainType;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GenericLiteral;
+import com.facebook.presto.sql.tree.GroupingSets;
 import com.facebook.presto.sql.tree.Insert;
 import com.facebook.presto.sql.tree.Intersect;
 import com.facebook.presto.sql.tree.IntervalLiteral;
@@ -59,12 +61,14 @@ import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.RenameColumn;
 import com.facebook.presto.sql.tree.RenameTable;
 import com.facebook.presto.sql.tree.ResetSession;
+import com.facebook.presto.sql.tree.Rollup;
 import com.facebook.presto.sql.tree.SetSession;
 import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
 import com.facebook.presto.sql.tree.ShowSession;
 import com.facebook.presto.sql.tree.ShowTables;
+import com.facebook.presto.sql.tree.SimpleGroupBy;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.sql.tree.StringLiteral;
@@ -762,6 +766,94 @@ public class TestSqlParser
                                 Optional.empty(),
                                 Optional.empty(),
                                 ImmutableList.of(),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty()),
+                        ImmutableList.<SortItem>of(),
+                        Optional.empty(),
+                        Optional.empty()));
+    }
+
+    @Test
+    public void testSelectWithGroupBy()
+        throws Exception
+    {
+        assertStatement("SELECT * FROM table1 GROUP BY a",
+                new Query(
+                        Optional.empty(),
+                        new QuerySpecification(
+                                selectList(new AllColumns()),
+                                Optional.of(new Table(QualifiedName.of("table1"))),
+                                Optional.empty(),
+                                ImmutableList.of(new SimpleGroupBy(ImmutableList.of(new QualifiedNameReference(QualifiedName.of("a"))))),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty()),
+                        ImmutableList.<SortItem>of(),
+                        Optional.empty(),
+                        Optional.empty()));
+
+        assertStatement("SELECT * FROM table1 GROUP BY a, b",
+                new Query(
+                        Optional.empty(),
+                        new QuerySpecification(
+                                selectList(new AllColumns()),
+                                Optional.of(new Table(QualifiedName.of("table1"))),
+                                Optional.empty(),
+                                ImmutableList.of(
+                                        new SimpleGroupBy(ImmutableList.of(new QualifiedNameReference(QualifiedName.of("a")))),
+                                        new SimpleGroupBy(ImmutableList.of(new QualifiedNameReference(QualifiedName.of("b"))))),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty()),
+                        ImmutableList.<SortItem>of(),
+                        Optional.empty(),
+                        Optional.empty()));
+
+        assertStatement("SELECT * FROM table1 GROUP BY ()",
+                new Query(
+                        Optional.empty(),
+                        new QuerySpecification(
+                                selectList(new AllColumns()),
+                                Optional.of(new Table(QualifiedName.of("table1"))),
+                                Optional.empty(),
+                                ImmutableList.of(new SimpleGroupBy(ImmutableList.of())),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty()),
+                        ImmutableList.<SortItem>of(),
+                        Optional.empty(),
+                        Optional.empty()));
+
+        assertStatement("SELECT * FROM table1 GROUP BY GROUPING SETS (a)",
+                new Query(
+                        Optional.empty(),
+                        new QuerySpecification(
+                                selectList(new AllColumns()),
+                                Optional.of(new Table(QualifiedName.of("table1"))),
+                                Optional.empty(),
+                                ImmutableList.of(new GroupingSets(ImmutableList.of(ImmutableList.of(QualifiedName.of("a"))))),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty()),
+                        ImmutableList.<SortItem>of(),
+                        Optional.empty(),
+                        Optional.empty()));
+
+        assertStatement("SELECT * FROM table1 GROUP BY GROUPING SETS ((a, b), (a), ()), CUBE (c), ROLLUP (d)",
+                new Query(
+                        Optional.empty(),
+                        new QuerySpecification(
+                                selectList(new AllColumns()),
+                                Optional.of(new Table(QualifiedName.of("table1"))),
+                                Optional.empty(),
+                                ImmutableList.of(
+                                        new GroupingSets(
+                                                ImmutableList.of(ImmutableList.of(QualifiedName.of("a"), QualifiedName.of("b")),
+                                                ImmutableList.of(QualifiedName.of("a")),
+                                                ImmutableList.of())),
+                                        new Cube(ImmutableList.of(QualifiedName.of("c"))),
+                                        new Rollup(ImmutableList.of(QualifiedName.of("d")))),
                                 Optional.empty(),
                                 ImmutableList.of(),
                                 Optional.empty()),

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1233,6 +1233,56 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testSingleEmptyGroupBy()
+            throws Exception
+    {
+        assertQuery(
+                "SELECT SUM(quantity) " +
+                        "FROM lineitem " +
+                        "GROUP BY ()",
+                "SELECT SUM(quantity) " +
+                        "FROM lineitem");
+    }
+
+    @Test
+    public void testSingleEmptyGroupingSet()
+            throws Exception
+    {
+        assertQuery(
+                "SELECT SUM(quantity) " +
+                        "FROM lineitem " +
+                        "GROUP BY GROUPING SETS (())",
+                "SELECT SUM(quantity) " +
+                        "FROM lineitem");
+    }
+
+    @Test
+    public void testSingleGroupingSet()
+            throws Exception
+    {
+        assertQuery(
+                "SELECT suppkey, SUM(quantity) " +
+                        "FROM lineitem " +
+                        "GROUP BY GROUPING SETS (suppkey) ",
+                "SELECT suppkey, SUM(quantity) " +
+                        "FROM lineitem " +
+                        "GROUP BY suppkey");
+    }
+
+    @Test
+    public void testSingleGroupingSetMultipleColumns()
+            throws Exception
+    {
+        assertQuery(
+                "SELECT linenumber, suppkey, SUM(quantity) " +
+                        "FROM lineitem " +
+                        "GROUP BY GROUPING SETS ((linenumber, suppkey)) ",
+                "SELECT linenumber, suppkey, SUM(quantity) " +
+                        "FROM lineitem " +
+                        "GROUP BY linenumber, suppkey");
+    }
+
+    @Test
     public void testCountAllWithComparison()
             throws Exception
     {


### PR DESCRIPTION
- Add CUBE, ROLLUP and simple GROUPING SETS (i.e. one-level of nesting)
to grammar.
- Add analyzer support for simple grouping sets.
- Add planning and execution support for queries with a single
grouping set (this is essentially a simple GROUP BY).