### PR TITLE
Generalized parametric types

### DIFF
--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeParameterSignature;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -68,6 +69,12 @@ public class TestKafkaPlugin
     {
         @Override
         public Type getType(TypeSignature signature)
+        {
+            return null;
+        }
+
+        @Override
+        public Type getParameterizedType(String baseTypeName, List<TypeParameterSignature> typeParameters)
         {
             return null;
         }

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -15,6 +15,7 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeParameterSignature;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -115,6 +116,13 @@ public final class TypeRegistry
     }
 
     @Override
+    public Type getParameterizedType(String baseTypeName, List<TypeParameterSignature> typeParameters)
+    {
+        return getType(new TypeSignature(baseTypeName, typeParameters));
+    }
+
+    @Override
+    @Deprecated
     public Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<Object> literalParameters)
     {
         return getType(new TypeSignature(baseTypeName, typeParameters, literalParameters));

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -221,7 +221,7 @@ valueExpression
 primaryExpression
     : NULL                                                                           #nullLiteral
     | interval                                                                       #intervalLiteral
-    | identifier STRING                                                              #typeConstructor
+    | type STRING                                                                    #typeConstructor
     | number                                                                         #numericLiteral
     | booleanValue                                                                   #booleanLiteral
     | STRING                                                                         #stringLiteral
@@ -277,10 +277,14 @@ type
     : type ARRAY
     | ARRAY '<' type '>'
     | MAP '<' type ',' type '>'
-    | simpleType
+    | parametrizedType ('(' typeParameter (',' typeParameter)* ')')?
     ;
 
-simpleType
+typeParameter
+    : INTEGER_VALUE | type
+    ;
+
+parametrizedType
     : TIME_WITH_TIME_ZONE
     | TIMESTAMP_WITH_TIME_ZONE
     | identifier
@@ -342,7 +346,7 @@ number
 nonReserved
     : SHOW | TABLES | COLUMNS | COLUMN | PARTITIONS | FUNCTIONS | SCHEMAS | CATALOGS | SESSION
     | ADD
-    | OVER | PARTITION | RANGE | ROWS | PRECEDING | FOLLOWING | CURRENT | ROW | MAP
+    | OVER | PARTITION | RANGE | ROWS | PRECEDING | FOLLOWING | CURRENT | ROW | MAP | ARRAY
     | DATE | TIME | TIMESTAMP | INTERVAL | ZONE
     | YEAR | MONTH | DAY | HOUR | MINUTE | SECOND
     | EXPLAIN | FORMAT | TYPE | TEXT | GRAPHVIZ | LOGICAL | DISTRIBUTED

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -138,6 +138,17 @@ public class TestSqlParser
         assertGenericLiteral("BOOLEAN");
         assertGenericLiteral("DATE");
         assertGenericLiteral("foo");
+
+        assertExpression("VARCHAR(42)" + " 'abc'", new GenericLiteral("VARCHAR(42)", "abc"));
+        assertExpression("FOO(42, 55)" + " 'abc'", new GenericLiteral("FOO(42,55)", "abc"));
+
+        assertExpression("ARRAY(BIGINT)" + " 'abc'", new GenericLiteral("ARRAY(BIGINT)", "abc"));
+        assertExpression(
+                "MAP(BIGINT, VARCHAR)" + " 'abc'",
+                new GenericLiteral("MAP(BIGINT,VARCHAR)", "abc"));
+        assertExpression(
+                "FOO(VARCHAR(42), ARRAY(BIGINT))" + " 'abc'",
+                new GenericLiteral("FOO(VARCHAR(42),ARRAY(BIGINT))", "abc"));
     }
 
     public static void assertGenericLiteral(String type)
@@ -229,11 +240,30 @@ public class TestSqlParser
         assertCast("ARRAY<BIGINT>");
         assertCast("array<bigint>");
         assertCast("array < bigint  >", "ARRAY<bigint>");
+
+        assertCast("ARRAY(bigint)");
+        assertCast("ARRAY(BIGINT)");
+        assertCast("array(bigint)");
+        assertCast("array ( bigint  )", "ARRAY(bigint)");
+
         assertCast("array<array<bigint>>");
+        assertCast("array(array(bigint))");
+
         assertCast("foo ARRAY", "ARRAY<foo>");
         assertCast("boolean array  array ARRAY", "ARRAY<ARRAY<ARRAY<boolean>>>");
         assertCast("boolean ARRAY ARRAY ARRAY", "ARRAY<ARRAY<ARRAY<boolean>>>");
         assertCast("ARRAY<boolean> ARRAY ARRAY", "ARRAY<ARRAY<ARRAY<boolean>>>");
+
+        assertCast("map(BIGINT,array(VARCHAR))");
+        assertCast("map<BIGINT,array<VARCHAR>>");
+
+        assertCast("varchar(42)");
+        assertCast("foo(42,55)");
+        assertCast("foo(BIGINT,array(VARCHAR))");
+        assertCast("ARRAY<varchar(42)>");
+        assertCast("ARRAY<foo(42,55)>");
+        assertCast("varchar(42) ARRAY", "ARRAY<varchar(42)>");
+        assertCast("foo(42, 55) ARRAY", "ARRAY<foo(42,55)>");
     }
 
     @Test

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisPlugin.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisPlugin.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeParameterSignature;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -68,6 +69,12 @@ public class TestRedisPlugin
     {
         @Override
         public Type getType(TypeSignature signature)
+        {
+            return null;
+        }
+
+        @Override
+        public Type getParameterizedType(String baseTypeName, List<TypeParameterSignature> typeParameters)
         {
             return null;
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeManager.java
@@ -25,6 +25,12 @@ public interface TypeManager
     /**
      * Gets the type with the specified base type, and the given parameters, or null if not found.
      */
+    Type getParameterizedType(String baseTypeName, List<TypeParameterSignature> typeParameters);
+
+    /**
+     * Gets the type with the specified base type, and the given parameters, or null if not found.
+     */
+    @Deprecated
     Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<Object> literalParameters);
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeParameterSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeParameterSignature.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.type;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class TypeParameterSignature
+{
+    private final Optional<TypeSignature> typeSignature;
+    private final Optional<Long> longLiteral;
+
+    public static TypeParameterSignature of(TypeSignature typeSignature)
+    {
+        return new TypeParameterSignature(Optional.of(typeSignature), Optional.empty());
+    }
+
+    public static TypeParameterSignature of(long longLiteral)
+    {
+        return new TypeParameterSignature(Optional.empty(), Optional.of(longLiteral));
+    }
+
+    private TypeParameterSignature(Optional<TypeSignature> typeSignature, Optional<Long> longLiteral)
+    {
+        this.typeSignature = typeSignature;
+        this.longLiteral = longLiteral;
+    }
+
+    @Override
+    public String toString()
+    {
+        if (typeSignature.isPresent()) {
+            return typeSignature.get().toString();
+        }
+        else {
+            return longLiteral.get().toString();
+        }
+    }
+
+    public Optional<TypeSignature> getTypeSignature()
+    {
+        return typeSignature;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TypeParameterSignature other = (TypeParameterSignature) o;
+
+        return Objects.equals(this.typeSignature, other.typeSignature) &&
+                Objects.equals(this.longLiteral, other.longLiteral);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(typeSignature, longLiteral);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableList;
@@ -27,21 +28,38 @@ import static java.util.Collections.unmodifiableList;
 public class TypeSignature
 {
     private final String base;
-    private final List<TypeSignature> parameters;
+    private final List<TypeParameterSignature> parameters;
     private final List<Object> literalParameters;
 
-    public TypeSignature(String base, List<TypeSignature> parameters, List<Object> literalParameters)
+    public TypeSignature(String base, List<TypeParameterSignature> parameters)
     {
         checkArgument(base != null, "base is null");
         this.base = base;
         checkArgument(!base.isEmpty(), "base is empty");
         checkArgument(validateName(base), "Bad characters in base type: %s", base);
         checkArgument(parameters != null, "parameters is null");
+        this.parameters = unmodifiableList(new ArrayList<>(parameters));
+        this.literalParameters = new ArrayList<>();
+    }
+
+    // TODO: merge literalParameters for Row with TypeParameterSignature
+    @Deprecated
+    public TypeSignature(String base, List<TypeSignature> typeSignatureParameters, List<Object> literalParameters)
+    {
+        checkArgument(base != null, "base is null");
+        this.base = base;
+        checkArgument(!base.isEmpty(), "base is empty");
+        checkArgument(validateName(base), "Bad characters in base type: %s", base);
+        checkArgument(typeSignatureParameters != null, "parameters is null");
         checkArgument(literalParameters != null, "literalParameters is null");
         for (Object literal : literalParameters) {
             checkArgument(literal instanceof String || literal instanceof Long, "Unsupported literal type: %s", literal.getClass());
         }
-        this.parameters = unmodifiableList(new ArrayList<>(parameters));
+
+        List<TypeParameterSignature> typeParameters =
+                typeSignatureParameters.stream().map(TypeParameterSignature::of).collect(Collectors.toList());
+
+        this.parameters = unmodifiableList(typeParameters);
         this.literalParameters = unmodifiableList(new ArrayList<>(literalParameters));
     }
 
@@ -60,18 +78,26 @@ public class TypeSignature
     @JsonValue
     public String toString()
     {
+        if (base.equals("row")) {
+            return rowToString();
+        }
+        return toString("(", ")");
+    }
+
+    private String toString(String leftParamBracket, String rightParamBracket)
+    {
         StringBuilder typeName = new StringBuilder(base);
         if (!parameters.isEmpty()) {
-            typeName.append("<");
+            typeName.append(leftParamBracket);
             boolean first = true;
-            for (TypeSignature parameter : parameters) {
+            for (TypeParameterSignature parameter : parameters) {
                 if (!first) {
                     typeName.append(",");
                 }
                 first = false;
                 typeName.append(parameter.toString());
             }
-            typeName.append(">");
+            typeName.append(rightParamBracket);
         }
         if (!literalParameters.isEmpty()) {
             typeName.append("(");
@@ -94,14 +120,33 @@ public class TypeSignature
         return typeName.toString();
     }
 
+    @Deprecated
+    private String rowToString()
+    {
+        return toString("<", ">");
+    }
+
     public String getBase()
     {
         return base;
     }
 
-    public List<TypeSignature> getParameters()
+    public List<TypeParameterSignature> getTypeParameters()
     {
         return parameters;
+    }
+
+    public List<TypeSignature> getParameters()
+    {
+        List<TypeSignature> result = new ArrayList<>();
+        for (TypeParameterSignature parameter : parameters) {
+            if (!parameter.getTypeSignature().isPresent()) {
+                throw new IllegalStateException(
+                        format("Expected all parameters to be TypeSignatures but [%s] was found", parameter.toString()));
+            }
+            result.add(parameter.getTypeSignature().get());
+        }
+        return result;
     }
 
     public List<Object> getLiteralParameters()
@@ -113,9 +158,55 @@ public class TypeSignature
     public static TypeSignature parseTypeSignature(String signature)
     {
         if (!signature.contains("<") && !signature.contains("(")) {
-            return new TypeSignature(signature, new ArrayList<TypeSignature>(), new ArrayList<>());
+            return new TypeSignature(signature, new ArrayList<>());
+        }
+        if (signature.startsWith("row")) {
+            return parseRowTypeSignature(signature);
         }
 
+        String baseName = null;
+        List<TypeParameterSignature> parameters = new ArrayList<>();
+        int parameterStart = -1;
+        int bracketCount = 0;
+
+        for (int i = 0; i < signature.length(); i++) {
+            char c = signature.charAt(i);
+            if (c == '(' || c == '<') {
+                if (bracketCount == 0) {
+                    verify(baseName == null, "Expected baseName to be null");
+                    verify(parameterStart == -1, "Expected parameter start to be -1");
+                    baseName = signature.substring(0, i);
+                    parameterStart = i + 1;
+                }
+                bracketCount++;
+            }
+            else if (c == ')' || c == '>') {
+                bracketCount--;
+                checkArgument(bracketCount >= 0, "Bad type signature: '%s'", signature);
+                if (bracketCount == 0) {
+                    checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
+                    parseSignatureOrLiteral(signature, parameterStart, i, parameters);
+                    parameterStart = i + 1;
+                    if (i == signature.length() - 1) {
+                        return new TypeSignature(baseName, parameters);
+                    }
+                }
+            }
+            else if (c == ',') {
+                if (bracketCount == 1) {
+                    checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
+                    parseSignatureOrLiteral(signature, parameterStart, i, parameters);
+                    parameterStart = i + 1;
+                }
+            }
+        }
+
+        throw new IllegalArgumentException(format("Bad type signature: '%s'", signature));
+    }
+
+    @Deprecated
+    private static TypeSignature parseRowTypeSignature(String signature)
+    {
         String baseName = null;
         List<TypeSignature> parameters = new ArrayList<>();
         List<Object> literalParameters = new ArrayList<>();
@@ -147,21 +238,22 @@ public class TypeSignature
                 }
             }
             else if (c == ',') {
-                if (bracketCount == 1 && !inLiteralParameters) {
-                    checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
-                    parameters.add(parseTypeSignature(signature.substring(parameterStart, i)));
-                    parameterStart = i + 1;
-                }
-                else if (bracketCount == 0 && inLiteralParameters) {
-                    checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
-                    literalParameters.add(parseLiteral(signature.substring(parameterStart, i)));
-                    parameterStart = i + 1;
+                if (bracketCount == 1) {
+                    if (!inLiteralParameters) {
+                        checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
+                        parameters.add(parseTypeSignature(signature.substring(parameterStart, i)));
+                        parameterStart = i + 1;
+                    }
+                    else {
+                        checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
+                        literalParameters.add(parseLiteral(signature.substring(parameterStart, i)));
+                        parameterStart = i + 1;
+                    }
                 }
             }
             else if (c == '(') {
-                checkArgument(!inLiteralParameters, "Bad type signature: '%s'", signature);
-                inLiteralParameters = true;
                 if (bracketCount == 0) {
+                    inLiteralParameters = true;
                     if (baseName == null) {
                         verify(parameters.isEmpty(), "Expected no parameters");
                         verify(parameterStart == -1, "Expected parameter start to be -1");
@@ -169,11 +261,13 @@ public class TypeSignature
                     }
                     parameterStart = i + 1;
                 }
+                bracketCount++;
             }
             else if (c == ')') {
-                checkArgument(inLiteralParameters, "Bad type signature: '%s'", signature);
-                inLiteralParameters = false;
+                bracketCount--;
                 if (bracketCount == 0) {
+                    checkArgument(inLiteralParameters, "Bad type signature: '%s'", signature);
+                    inLiteralParameters = false;
                     checkArgument(i == signature.length() - 1, "Bad type signature: '%s'", signature);
                     checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
                     literalParameters.add(parseLiteral(signature.substring(parameterStart, i)));
@@ -183,6 +277,20 @@ public class TypeSignature
         }
 
         throw new IllegalArgumentException(format("Bad type signature: '%s'", signature));
+    }
+
+    private static void parseSignatureOrLiteral(
+            String signature,
+            int begin,
+            int end,
+            List<TypeParameterSignature> parameters)
+    {
+        if (Character.isDigit(signature.charAt(begin))) {
+            parameters.add(TypeParameterSignature.of(Long.parseLong(signature.substring(begin, end))));
+        }
+        else {
+            parameters.add(TypeParameterSignature.of(parseTypeSignature(signature.substring(begin, end))));
+        }
     }
 
     private static Object parseLiteral(String literal)
@@ -219,7 +327,7 @@ public class TypeSignature
         return Objects.hash(base.toLowerCase(Locale.ENGLISH), parameters, literalParameters);
     }
 
-    private static void checkArgument(boolean argument, String format, Object...args)
+    private static void checkArgument(boolean argument, String format, Object... args)
     {
         if (!argument) {
             throw new IllegalArgumentException(format(format, args));

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -13,45 +13,75 @@
  */
 package com.facebook.presto.spi.type;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import java.util.List;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static java.util.Locale.ENGLISH;
-import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 public class TestTypeSignature
 {
     @Test
+    public void testRow()
+            throws Exception
+    {
+        assertRowSignature(
+                "row<array(row<bigint,double>('col0','col1'))>('col0')",
+                "row",
+                ImmutableList.of("array(row<bigint,double>('col0','col1'))"),
+                ImmutableList.of("col0"));
+        assertRowSignature(
+                "row<bigint,varchar>('a','b')",
+                "row",
+                ImmutableList.of("bigint", "varchar"),
+                ImmutableList.of("a", "b"));
+        assertRowSignature(
+                "row<bigint,array(bigint),row<bigint>('a')>('a','b','c')",
+                "row",
+                ImmutableList.of("bigint", "array(bigint)", "row<bigint>('a')"),
+                ImmutableList.of("a", "b", "c"));
+        assertRowSignature(
+                "row<varchar(10),row<bigint>('a')>('a','b')",
+                "row",
+                ImmutableList.of("varchar(10)", "row<bigint>('a')"),
+                ImmutableList.of("a", "b"));
+        assertRowSignature(
+                "array(row<bigint,double>('col0','col1'))",
+                "array",
+                ImmutableList.of("row<bigint,double>('col0','col1')"),
+                ImmutableList.of());
+    }
+
+    @Test
     public void test()
             throws Exception
     {
-        assertSignature("bigint", ImmutableList.<String>of());
-        assertSignature("boolean", ImmutableList.<String>of());
-        assertSignature("varchar", ImmutableList.<String>of());
-        assertSignature("array", ImmutableList.of("bigint"));
-        assertSignature("array", ImmutableList.of("array<bigint>"));
-        assertSignature("map", ImmutableList.of("bigint", "bigint"));
-        assertSignature("map", ImmutableList.of("bigint", "array<bigint>"));
-        assertSignature("map", ImmutableList.of("bigint", "map<bigint,map<varchar,bigint>>"));
-        assertSignature("array", ImmutableList.of("timestamp with time zone"));
-        assertSignature("row", ImmutableList.of("bigint", "varchar"), ImmutableList.<Object>of("a", "b"));
-        assertSignature("row", ImmutableList.of("bigint", "array<bigint>", "row<bigint>('a')"), ImmutableList.<Object>of("a", "b", "c"));
-        assertSignature("row", ImmutableList.of("varchar(10)", "row<bigint>('a')"), ImmutableList.<Object>of("a", "b"));
-        assertSignature("foo", ImmutableList.<String>of(), ImmutableList.<Object>of("a"));
-        assertSignature("varchar", ImmutableList.<String>of(), ImmutableList.<Object>of(10L));
-        try {
-            parseTypeSignature("blah<>");
-            fail("Type signatures with zero parameters should fail to parse");
-        }
-        catch (RuntimeException e) {
-            // Expected
-        }
+        assertSignature("bigint", "bigint", ImmutableList.<String>of());
+        assertSignature("boolean", "boolean", ImmutableList.<String>of());
+        assertSignature("varchar", "varchar", ImmutableList.<String>of());
+
+        assertSignature("array(bigint)", "array", ImmutableList.of("bigint"));
+        assertSignature("array(array(bigint))", "array", ImmutableList.of("array(bigint)"));
+        assertSignature(
+                "array(timestamp with time zone)",
+                "array",
+                ImmutableList.of("timestamp with time zone"));
+
+        assertSignature(
+                "map(bigint,bigint)",
+                "map",
+                ImmutableList.of("bigint", "bigint"));
+        assertSignature(
+                "map(bigint,array(bigint))",
+                "map", ImmutableList.of("bigint", "array(bigint)"));
+        assertSignature(
+                "map(bigint,map(bigint,map(varchar,bigint)))",
+                "map",
+                ImmutableList.of("bigint", "map(bigint,map(varchar,bigint))"));
+
         try {
             parseTypeSignature("blah()");
             fail("Type signatures with zero literal parameters should fail to parse");
@@ -61,42 +91,67 @@ public class TestTypeSignature
         }
     }
 
-    private static void assertSignature(String base, List<String> parameters)
+    @Test
+    public void testLiteralParameters()
     {
-        assertSignature(base, parameters, ImmutableList.of());
+        assertSignature("foo(42)", "foo", ImmutableList.<String>of("42"));
+        assertSignature("varchar(10)", "varchar", ImmutableList.<String>of("10"));
     }
 
-    private static void assertSignature(String base, List<String> parameters, List<Object> literalParameters)
+    @Test
+    public void testDeprecatedArrayMap()
+            throws Exception
     {
-        List<String> lowerCaseTypeNames = parameters.stream()
-                .map(value -> value.toLowerCase(ENGLISH))
-                .collect(toList());
+        assertSignature("array<bigint>", "array", ImmutableList.of("bigint"));
+        assertSignature("array<array<bigint>>", "array", ImmutableList.of("array(bigint)"));
 
-        String typeName = base.toLowerCase(ENGLISH);
-        if (!parameters.isEmpty()) {
-            typeName += "<" + Joiner.on(",").join(lowerCaseTypeNames) + ">";
+        assertSignature(
+                "map<bigint,bigint>",
+                "map",
+                ImmutableList.of("bigint", "bigint"));
+        assertSignature(
+                "map<bigint,map<bigint,map<varchar,bigint>>>",
+                "map",
+                ImmutableList.of("bigint", "map(bigint,map(varchar,bigint))"));
+
+        try {
+            parseTypeSignature("blah<>");
+            fail("Type signatures with zero parameters should fail to parse");
         }
-        if (!literalParameters.isEmpty()) {
-            List<String> transform = literalParameters.stream()
-                    .map(TestTypeSignature::convertParameter)
-                    .collect(toList());
-            typeName += "(" + Joiner.on(",").join(transform) + ")";
+        catch (RuntimeException e) {
+            // Expected
         }
+
+    }
+
+    private static void assertRowSignature(
+            String typeName,
+            String base,
+            List<String> parameters,
+            List<Object> literalParameters)
+    {
+        assertSignature(typeName, base, parameters, literalParameters, typeName);
+    }
+
+    private static void assertSignature(String typeName, String base, List<String> parameters)
+    {
+        assertSignature(typeName, base, parameters, ImmutableList.of(), typeName.replace("<", "(").replace(">", ")"));
+    }
+
+    private static void assertSignature(
+            String typeName,
+            String base,
+            List<String> parameters,
+            List<Object> literalParameters,
+            String expectedTypeName)
+    {
         TypeSignature signature = parseTypeSignature(typeName);
         assertEquals(signature.getBase(), base);
-        assertEquals(signature.getParameters().size(), parameters.size());
-        for (int i = 0; i < signature.getParameters().size(); i++) {
-            assertEquals(signature.getParameters().get(i).toString(), parameters.get(i));
+        assertEquals(signature.getTypeParameters().size(), parameters.size());
+        for (int i = 0; i < signature.getTypeParameters().size(); i++) {
+            assertEquals(signature.getTypeParameters().get(i).toString(), parameters.get(i));
         }
         assertEquals(signature.getLiteralParameters(), literalParameters);
-        assertEquals(typeName, signature.toString());
-    }
-
-    private static String convertParameter(Object value)
-    {
-        if (value instanceof String) {
-            return "'" + value + "'";
-        }
-        return value.toString();
+        assertEquals(signature.toString(), expectedTypeName);
     }
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingTypeManager.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingTypeManager.java
@@ -42,6 +42,12 @@ public class TestingTypeManager
     }
 
     @Override
+    public Type getParameterizedType(String baseTypeName, List<TypeParameterSignature> typeParameters)
+    {
+        return getType(new TypeSignature(baseTypeName, typeParameters));
+    }
+
+    @Override
     public Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<Object> literalParameters)
     {
         return getType(new TypeSignature(baseTypeName, typeParameters, literalParameters));


### PR DESCRIPTION
- generailized parametric types
- deprecated literalParameters
- added parser support for BIGINT typeParameter

TODO/Questions:
- move parseSignature to presto-main and base it on antlr
- refactor code and drop/rename getParameters
- replace current getParameters usage with getter to TypeParameterSignature where appropriate