### PR TITLE
Close statement client after consuming the current results

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
@@ -101,6 +101,8 @@ Parallelism: 2.5
                         partialCancel();
                     }
                     else if (key == CTRL_C) {
+                        updateScreen();
+                        update = false;
                         client.close();
                     }
                     else if (toUpperCase(key) == 'D') {
@@ -111,8 +113,7 @@ Parallelism: 2.5
 
                     // update screen
                     if (update) {
-                        console.repositionCursor();
-                        printQueryInfo(client.current());
+                        updateScreen();
                         lastPrint = System.nanoTime();
                     }
 
@@ -127,6 +128,12 @@ Parallelism: 2.5
         finally {
             console.resetScreen();
         }
+    }
+
+    private void updateScreen()
+    {
+        console.repositionCursor();
+        printQueryInfo(client.current());
     }
 
     public void printFinalInfo()


### PR DESCRIPTION
This PR fixes the issue that the presto-cli sometimes does not clear the console properly on Ctrl-C as the statement client was closed immediately and the current results could not be consumed (which basically made `console.resetScreen()` in the finally block a noop).

<pre>
<b>presto:nyigitbasi></b> ... my query ...;

Query 20151118_194430_00070_5qcf7, RUNNING, 1 node, 102 splits
http://localhost:8080/v1/query/20151118_194430_00070_5qcf7?pretty
Splits: 102 total, 0 done (0.00%)0 done
CPU Time: 0.0s total,     0 rows/s,     0B/s, 0% active
Per Node: 0.0 parallelism,     0 rows/s,     0B/s
Parallelism: 0.0
0:03 [0 rows, 0B] [0 rows/s, 0B/s]ows/s,     0B/s] [  <=>                                     ]

Query aborted by userOWS/s  BYTES  BYTES/s  QUEUED    RUN   DONE
<b>presto:nyigitbasi></b>       0     0B       0B       0      1      0
  1.......R      0       0     0B       0B       0      1      0
    2.....S      0       0     0B       0B      68     32      0
</pre>