### PR TITLE
Feature parametric types

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.client;
 
+import com.facebook.presto.spi.type.NamedTypeSignature;
 import com.facebook.presto.spi.type.ParameterKind;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -40,6 +41,8 @@ public class ClientTypeSignatureParameter
             case LONG_LITERAL:
                 value = typeParameterSignature.getLongLiteral();
                 break;
+            case NAMED_TYPE_SIGNATURE:
+                value = typeParameterSignature.getNamedTypeSignature();
             default:
                 throw new UnsupportedOperationException(format("Unknown kind [%s]", kind));
         }
@@ -82,6 +85,11 @@ public class ClientTypeSignatureParameter
     public Long getLongLiteral()
     {
         return getValue(ParameterKind.LONG_LITERAL, Long.class);
+    }
+
+    public NamedTypeSignature getNamedTypeSignature()
+    {
+        return getValue(ParameterKind.NAMED_TYPE_SIGNATURE, NamedTypeSignature.class);
     }
 
     @Override

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import com.facebook.presto.spi.type.ParameterKind;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+@Immutable
+public class ClientTypeSignatureParameter
+{
+    private final ParameterKind kind;
+    private final Object value;
+
+    public ClientTypeSignatureParameter(TypeSignatureParameter typeParameterSignature)
+    {
+        this.kind = typeParameterSignature.getKind();
+        switch (kind) {
+            case TYPE_SIGNATURE:
+                value = new ClientTypeSignature(typeParameterSignature.getTypeSignature());
+                break;
+            case LONG_LITERAL:
+                value = typeParameterSignature.getLongLiteral();
+                break;
+            default:
+                throw new UnsupportedOperationException(format("Unknown kind [%s]", kind));
+        }
+    }
+
+    @JsonCreator
+    public ClientTypeSignatureParameter(
+            @JsonProperty("kind") ParameterKind kind,
+            @JsonProperty("value") Object value)
+    {
+        this.kind = kind;
+        this.value = value;
+    }
+
+    @JsonProperty
+    public ParameterKind getKind()
+    {
+        return kind;
+    }
+
+    @JsonProperty
+    public Object getValue()
+    {
+        return value;
+    }
+
+    public <A> A getValue(ParameterKind expectedParameterKind, Class<A> target)
+    {
+        if (kind != expectedParameterKind) {
+            throw new IllegalArgumentException(format("ParameterKind is [%s] but expected [%s]", kind, expectedParameterKind));
+        }
+        return target.cast(value);
+    }
+
+    public ClientTypeSignature getTypeSignature()
+    {
+        return getValue(ParameterKind.TYPE_SIGNATURE, ClientTypeSignature.class);
+    }
+
+    public Long getLongLiteral()
+    {
+        return getValue(ParameterKind.LONG_LITERAL, Long.class);
+    }
+
+    @Override
+    public String toString()
+    {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ClientTypeSignatureParameter other = (ClientTypeSignatureParameter) o;
+
+        return Objects.equals(this.kind, other.kind) &&
+                Objects.equals(this.value, other.value);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(kind, value);
+    }
+}

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
@@ -224,13 +224,13 @@ public class QueryResults
         if (signature.getBase().equals(ARRAY)) {
             List<Object> fixedValue = new ArrayList<>();
             for (Object object : List.class.cast(value)) {
-                fixedValue.add(fixValue(signature.getParameters().get(0).toString(), object));
+                fixedValue.add(fixValue(signature.getTypeParametersAsTypeSignatures().get(0).toString(), object));
             }
             return fixedValue;
         }
         if (signature.getBase().equals(MAP)) {
-            String keyType = signature.getParameters().get(0).toString();
-            String valueType = signature.getParameters().get(1).toString();
+            String keyType = signature.getTypeParametersAsTypeSignatures().get(0).toString();
+            String valueType = signature.getTypeParametersAsTypeSignatures().get(1).toString();
             Map<Object, Object> fixedValue = new HashMap<>();
             for (Map.Entry<?, ?> entry : (Set<Map.Entry<?, ?>>) Map.class.cast(value).entrySet()) {
                 fixedValue.put(fixValue(keyType, entry.getKey()), fixValue(valueType, entry.getValue()));
@@ -243,7 +243,7 @@ public class QueryResults
             checkArgument(listValue.size() == signature.getLiteralParameters().size(), "Mismatched data values and row type");
             for (int i = 0; i < listValue.size(); i++) {
                 String key = (String) signature.getLiteralParameters().get(i);
-                fixedValue.put(key, fixValue(signature.getParameters().get(i).toString(), listValue.get(i)));
+                fixedValue.put(key, fixValue(signature.getTypeParametersAsTypeSignatures().get(i).toString(), listValue.get(i)));
             }
             return fixedValue;
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -149,8 +149,8 @@ public final class HiveWriteUtils
         }
         else if (isRowType(type)) {
             return ObjectInspectorFactory.getStandardStructObjectInspector(
-                    type.getTypeSignature().getLiteralParameters().stream()
-                            .map(String.class::cast)
+                    type.getTypeSignature().getParameters().stream()
+                            .map(parameter -> parameter.getNamedTypeSignature().getName())
                             .collect(toList()),
                     type.getTypeParameters().stream()
                             .map(HiveWriteUtils::getJavaObjectInspector)

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ColumnInfo.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ColumnInfo.java
@@ -161,11 +161,11 @@ class ColumnInfo
 
     private static int getType(TypeSignatureParameter typeParameter)
     {
-        if (typeParameter.getTypeSignature().isPresent()) {
-            return getType(typeParameter.getTypeSignature().get());
-        }
-        else {
-            return Types.JAVA_OBJECT;
+        switch (typeParameter.getKind()) {
+            case TYPE_SIGNATURE:
+                return getType(typeParameter.getTypeSignature());
+            default:
+                return Types.JAVA_OBJECT;
         }
     }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ColumnInfo.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ColumnInfo.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.jdbc;
 
 import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.google.common.collect.ImmutableList;
 
 import java.sql.Types;
@@ -88,7 +89,7 @@ class ColumnInfo
     {
         builder.setColumnType(getType(type));
         ImmutableList.Builder<Integer> parameterTypes = ImmutableList.builder();
-        for (TypeSignature parameter : type.getParameters()) {
+        for (TypeSignatureParameter parameter : type.getParameters()) {
             parameterTypes.add(getType(parameter));
         }
         builder.setColumnParameterTypes(parameterTypes.build());
@@ -155,6 +156,16 @@ class ColumnInfo
             case "interval day to second":
                 builder.setColumnDisplaySize(TIMESTAMP_MAX);
                 break;
+        }
+    }
+
+    private static int getType(TypeSignatureParameter typeParameter)
+    {
+        if (typeParameter.getTypeSignature().isPresent()) {
+            return getType(typeParameter.getTypeSignature().get());
+        }
+        else {
+            return Types.JAVA_OBJECT;
         }
     }
 

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.NodeState;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -70,6 +71,12 @@ public class TestKafkaPlugin
     {
         @Override
         public Type getType(TypeSignature signature)
+        {
+            return null;
+        }
+
+        @Override
+        public Type getParameterizedType(String baseTypeName, List<TypeSignatureParameter> typeParameters)
         {
             return null;
         }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
@@ -82,7 +82,7 @@ public class TestKafkaPlugin
         }
 
         @Override
-        public Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<Object> literalParameters)
+        public Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<String> literalParameters)
         {
             return null;
         }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -453,7 +453,7 @@ public class FunctionRegistry
             expectedParameters.add(format("%s(%s) %s",
                                     name,
                                     Joiner.on(", ").join(function.getSignature().getArgumentTypes()),
-                                    Joiner.on(", ").join(function.getSignature().getTypeParameters())));
+                                    Joiner.on(", ").join(function.getSignature().getTypeParameterRequirements())));
         }
         String parameters = Joiner.on(", ").join(parameterTypes);
         String message = format("Function %s not registered", name);
@@ -509,7 +509,7 @@ public class FunctionRegistry
     public WindowFunctionSupplier getWindowFunctionImplementation(Signature signature)
     {
         checkArgument(signature.getKind() == WINDOW || signature.getKind() == AGGREGATE, "%s is not a window function", signature);
-        checkArgument(signature.getTypeParameters().isEmpty(), "%s has unbound type parameters", signature);
+        checkArgument(signature.getTypeParameterRequirements().isEmpty(), "%s has unbound type parameters", signature);
         Iterable<SqlFunction> candidates = functions.get(QualifiedName.of(signature.getName()));
         // search for exact match
         for (SqlFunction operator : candidates) {
@@ -531,7 +531,7 @@ public class FunctionRegistry
     public InternalAggregationFunction getAggregateFunctionImplementation(Signature signature)
     {
         checkArgument(signature.getKind() == AGGREGATE || signature.getKind() == APPROXIMATE_AGGREGATE, "%s is not an aggregate function", signature);
-        checkArgument(signature.getTypeParameters().isEmpty(), "%s has unbound type parameters", signature);
+        checkArgument(signature.getTypeParameterRequirements().isEmpty(), "%s has unbound type parameters", signature);
         Iterable<SqlFunction> candidates = functions.get(QualifiedName.of(signature.getName()));
         // search for exact match
         for (SqlFunction operator : candidates) {
@@ -553,7 +553,7 @@ public class FunctionRegistry
     public ScalarFunctionImplementation getScalarFunctionImplementation(Signature signature)
     {
         checkArgument(signature.getKind() == SCALAR, "%s is not a scalar function", signature);
-        checkArgument(signature.getTypeParameters().isEmpty(), "%s has unbound type parameters", signature);
+        checkArgument(signature.getTypeParameterRequirements().isEmpty(), "%s has unbound type parameters", signature);
         Iterable<SqlFunction> candidates = functions.get(QualifiedName.of(signature.getName()));
         // search for exact match
         Type returnType = typeManager.getType(signature.getReturnType());

--- a/presto-main/src/main/java/com/facebook/presto/metadata/OperatorType.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/OperatorType.java
@@ -158,11 +158,11 @@ public enum OperatorType
                     checkArgument(argumentTypes.get(0).getBase().equals(StandardTypes.ARRAY) || argumentTypes.get(0).getBase().equals(StandardTypes.MAP), "First argument must be an ARRAY or MAP");
                     if (argumentTypes.get(0).getBase().equals(StandardTypes.ARRAY)) {
                         checkArgument(argumentTypes.get(1).getBase().equals(StandardTypes.BIGINT), "Second argument must be a BIGINT");
-                        TypeSignature elementType = argumentTypes.get(0).getParameters().get(0);
+                        TypeSignature elementType = argumentTypes.get(0).getTypeParametersAsTypeSignatures().get(0);
                         checkArgument(returnType.equals(elementType), "[] return type does not match ARRAY element type");
                     }
                     else {
-                        TypeSignature valueType = argumentTypes.get(0).getParameters().get(1);
+                        TypeSignature valueType = argumentTypes.get(0).getTypeParametersAsTypeSignatures().get(1);
                         checkArgument(returnType.equals(valueType), "[] return type does not match MAP value type");
                     }
                 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
@@ -45,7 +45,7 @@ public final class Signature
 {
     private final String name;
     private final FunctionKind kind;
-    private final List<TypeParameter> typeParameters;
+    private final List<TypeParameterRequirement> typeParameterRequirements;
     private final TypeSignature returnType;
     private final List<TypeSignature> argumentTypes;
     private final boolean variableArity;
@@ -54,30 +54,30 @@ public final class Signature
     public Signature(
             @JsonProperty("name") String name,
             @JsonProperty("kind") FunctionKind kind,
-            @JsonProperty("typeParameters") List<TypeParameter> typeParameters,
+            @JsonProperty("typeParameterRequirements") List<TypeParameterRequirement> typeParameterRequirements,
             @JsonProperty("returnType") TypeSignature returnType,
             @JsonProperty("argumentTypes") List<TypeSignature> argumentTypes,
             @JsonProperty("variableArity") boolean variableArity)
     {
         requireNonNull(name, "name is null");
-        requireNonNull(typeParameters, "typeParameters is null");
+        requireNonNull(typeParameterRequirements, "typeParameters is null");
 
         this.name = name;
         this.kind = requireNonNull(kind, "type is null");
-        this.typeParameters = ImmutableList.copyOf(typeParameters);
+        this.typeParameterRequirements = ImmutableList.copyOf(typeParameterRequirements);
         this.returnType = requireNonNull(returnType, "returnType is null");
         this.argumentTypes = ImmutableList.copyOf(requireNonNull(argumentTypes, "argumentTypes is null"));
         this.variableArity = variableArity;
     }
 
-    public Signature(String name, FunctionKind kind, List<TypeParameter> typeParameters, String returnType, List<String> argumentTypes, boolean variableArity)
+    public Signature(String name, FunctionKind kind, List<TypeParameterRequirement> typeParameterRequirements, String returnType, List<String> argumentTypes, boolean variableArity)
     {
-        this(name, kind, typeParameters, parseTypeSignature(returnType), Lists.transform(argumentTypes, TypeSignature::parseTypeSignature), variableArity);
+        this(name, kind, typeParameterRequirements, parseTypeSignature(returnType), Lists.transform(argumentTypes, TypeSignature::parseTypeSignature), variableArity);
     }
 
     public Signature(String name, FunctionKind kind, String returnType, List<String> argumentTypes)
     {
-        this(name, kind, ImmutableList.<TypeParameter>of(), parseTypeSignature(returnType), Lists.transform(argumentTypes, TypeSignature::parseTypeSignature), false);
+        this(name, kind, ImmutableList.<TypeParameterRequirement>of(), parseTypeSignature(returnType), Lists.transform(argumentTypes, TypeSignature::parseTypeSignature), false);
     }
 
     public Signature(String name, FunctionKind kind, String returnType, String... argumentTypes)
@@ -87,7 +87,7 @@ public final class Signature
 
     public Signature(String name, FunctionKind kind, TypeSignature returnType, List<TypeSignature> argumentTypes)
     {
-        this(name, kind, ImmutableList.<TypeParameter>of(), returnType, argumentTypes, false);
+        this(name, kind, ImmutableList.<TypeParameterRequirement>of(), returnType, argumentTypes, false);
     }
 
     public Signature(String name, FunctionKind kind, TypeSignature returnType, TypeSignature... argumentTypes)
@@ -117,7 +117,7 @@ public final class Signature
 
     public static Signature internalScalarFunction(String name, String returnType, List<String> argumentTypes)
     {
-        return new Signature(name, SCALAR, ImmutableList.<TypeParameter>of(), returnType, argumentTypes, false);
+        return new Signature(name, SCALAR, ImmutableList.<TypeParameterRequirement>of(), returnType, argumentTypes, false);
     }
 
     public static Signature internalScalarFunction(String name, TypeSignature returnType, TypeSignature... argumentTypes)
@@ -127,7 +127,7 @@ public final class Signature
 
     public static Signature internalScalarFunction(String name, TypeSignature returnType, List<TypeSignature> argumentTypes)
     {
-        return new Signature(name, SCALAR, ImmutableList.<TypeParameter>of(), returnType, argumentTypes, false);
+        return new Signature(name, SCALAR, ImmutableList.<TypeParameterRequirement>of(), returnType, argumentTypes, false);
     }
 
     @JsonProperty
@@ -161,20 +161,20 @@ public final class Signature
     }
 
     @JsonProperty
-    public List<TypeParameter> getTypeParameters()
+    public List<TypeParameterRequirement> getTypeParameterRequirements()
     {
-        return typeParameters;
+        return typeParameterRequirements;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, kind, typeParameters, returnType, argumentTypes, variableArity);
+        return Objects.hash(name, kind, typeParameterRequirements, returnType, argumentTypes, variableArity);
     }
 
     Signature withAlias(String name)
     {
-        return new Signature(name, kind, typeParameters, getReturnType(), getArgumentTypes(), variableArity);
+        return new Signature(name, kind, typeParameterRequirements, getReturnType(), getArgumentTypes(), variableArity);
     }
 
     @Override
@@ -189,7 +189,7 @@ public final class Signature
         Signature other = (Signature) obj;
         return Objects.equals(this.name, other.name) &&
                 Objects.equals(this.kind, other.kind) &&
-                Objects.equals(this.typeParameters, other.typeParameters) &&
+                Objects.equals(this.typeParameterRequirements, other.typeParameterRequirements) &&
                 Objects.equals(this.returnType, other.returnType) &&
                 Objects.equals(this.argumentTypes, other.argumentTypes) &&
                 Objects.equals(this.variableArity, other.variableArity);
@@ -198,19 +198,19 @@ public final class Signature
     @Override
     public String toString()
     {
-        return name + (typeParameters.isEmpty() ? "" : "<" + Joiner.on(",").join(typeParameters) + ">") + "(" + Joiner.on(",").join(argumentTypes) + "):" + returnType;
+        return name + (typeParameterRequirements.isEmpty() ? "" : "<" + Joiner.on(",").join(typeParameterRequirements) + ">") + "(" + Joiner.on(",").join(argumentTypes) + "):" + returnType;
     }
 
     @Nullable
     public Map<String, Type> bindTypeParameters(Type returnType, List<? extends Type> types, boolean allowCoercion, TypeManager typeManager)
     {
         Map<String, Type> boundParameters = new HashMap<>();
-        ImmutableMap.Builder<String, TypeParameter> builder = ImmutableMap.builder();
-        for (TypeParameter parameter : typeParameters) {
+        ImmutableMap.Builder<String, TypeParameterRequirement> builder = ImmutableMap.builder();
+        for (TypeParameterRequirement parameter : typeParameterRequirements) {
             builder.put(parameter.getName(), parameter);
         }
 
-        ImmutableMap<String, TypeParameter> parameters = builder.build();
+        ImmutableMap<String, TypeParameterRequirement> parameters = builder.build();
         if (!matchAndBind(boundParameters, parameters, this.returnType, returnType, allowCoercion, typeManager)) {
             return null;
         }
@@ -232,12 +232,12 @@ public final class Signature
     public Map<String, Type> bindTypeParameters(List<? extends Type> types, boolean allowCoercion, TypeManager typeManager)
     {
         Map<String, Type> boundParameters = new HashMap<>();
-        ImmutableMap.Builder<String, TypeParameter> builder = ImmutableMap.builder();
-        for (TypeParameter parameter : typeParameters) {
+        ImmutableMap.Builder<String, TypeParameterRequirement> builder = ImmutableMap.builder();
+        for (TypeParameterRequirement parameter : typeParameterRequirements) {
             builder.put(parameter.getName(), parameter);
         }
 
-        ImmutableMap<String, TypeParameter> parameters = builder.build();
+        ImmutableMap<String, TypeParameterRequirement> parameters = builder.build();
         if (!matchArguments(boundParameters, parameters, argumentTypes, types, allowCoercion, variableArity, typeManager)) {
             return null;
         }
@@ -249,7 +249,7 @@ public final class Signature
 
     private static boolean matchArguments(
             Map<String, Type> boundParameters,
-            Map<String, TypeParameter> parameters,
+            Map<String, TypeParameterRequirement> parameters,
             List<TypeSignature> argumentTypes,
             List<? extends Type> types,
             boolean allowCoercion,
@@ -290,7 +290,7 @@ public final class Signature
         return true;
     }
 
-    private static boolean matchAndBind(Map<String, Type> boundParameters, Map<String, TypeParameter> typeParameters, TypeSignature parameter, Type type, boolean allowCoercion, TypeManager typeManager)
+    private static boolean matchAndBind(Map<String, Type> boundParameters, Map<String, TypeParameterRequirement> typeParameters, TypeSignature parameter, Type type, boolean allowCoercion, TypeManager typeManager)
     {
         // TODO: add literals to Types and switch to TypeSignatureParameter so boundParameters map includes also literal parameter bindings
         List<TypeSignature> typeSignatures = parameter.getTypeParametersAsTypeSignatures();
@@ -329,8 +329,8 @@ public final class Signature
 
         // Bind parameter, if this is a free type parameter
         if (typeParameters.containsKey(parameter.getBase())) {
-            TypeParameter typeParameter = typeParameters.get(parameter.getBase());
-            if (!typeParameter.canBind(type)) {
+            TypeParameterRequirement typeParameterRequirement = typeParameters.get(parameter.getBase());
+            if (!typeParameterRequirement.canBind(type)) {
                 return false;
             }
             boundParameters.put(parameter.getBase(), type);
@@ -354,28 +354,28 @@ public final class Signature
     /*
      * similar to T extends MyClass<?...>, if Java supported varargs wildcards
      */
-    public static TypeParameter withVariadicBound(String name, String variadicBound)
+    public static TypeParameterRequirement withVariadicBound(String name, String variadicBound)
     {
-        return new TypeParameter(name, false, false, variadicBound);
+        return new TypeParameterRequirement(name, false, false, variadicBound);
     }
 
-    public static TypeParameter comparableWithVariadicBound(String name, String variadicBound)
+    public static TypeParameterRequirement comparableWithVariadicBound(String name, String variadicBound)
     {
-        return new TypeParameter(name, true, false, variadicBound);
+        return new TypeParameterRequirement(name, true, false, variadicBound);
     }
 
-    public static TypeParameter typeParameter(String name)
+    public static TypeParameterRequirement typeParameter(String name)
     {
-        return new TypeParameter(name, false, false, null);
+        return new TypeParameterRequirement(name, false, false, null);
     }
 
-    public static TypeParameter comparableTypeParameter(String name)
+    public static TypeParameterRequirement comparableTypeParameter(String name)
     {
-        return new TypeParameter(name, true, false, null);
+        return new TypeParameterRequirement(name, true, false, null);
     }
 
-    public static TypeParameter orderableTypeParameter(String name)
+    public static TypeParameterRequirement orderableTypeParameter(String name)
     {
-        return new TypeParameter(name, false, true, null);
+        return new TypeParameterRequirement(name, false, true, null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Signature.java
@@ -292,9 +292,11 @@ public final class Signature
 
     private static boolean matchAndBind(Map<String, Type> boundParameters, Map<String, TypeParameter> typeParameters, TypeSignature parameter, Type type, boolean allowCoercion, TypeManager typeManager)
     {
+        // TODO: add literals to Types and switch to TypeSignatureParameter so boundParameters map includes also literal parameter bindings
+        List<TypeSignature> typeSignatures = parameter.getTypeParametersAsTypeSignatures();
         // If this parameter is already bound, then match (with coercion)
         if (boundParameters.containsKey(parameter.getBase())) {
-            checkArgument(parameter.getParameters().isEmpty(), "Unexpected parameteric type");
+            checkArgument(typeSignatures.isEmpty(), "Unexpected parameteric type");
             if (allowCoercion) {
                 if (canCoerce(type, boundParameters.get(parameter.getBase()))) {
                     return true;
@@ -312,13 +314,13 @@ public final class Signature
         }
 
         // Recurse into component types
-        if (!parameter.getParameters().isEmpty()) {
-            if (type.getTypeParameters().size() != parameter.getParameters().size()) {
+        if (!typeSignatures.isEmpty()) {
+            if (type.getTypeParameters().size() != typeSignatures.size()) {
                 return false;
             }
-            for (int i = 0; i < parameter.getParameters().size(); i++) {
+            for (int i = 0; i < typeSignatures.size(); i++) {
                 Type componentType = type.getTypeParameters().get(i);
-                TypeSignature componentSignature = parameter.getParameters().get(i);
+                TypeSignature componentSignature = typeSignatures.get(i);
                 if (!matchAndBind(boundParameters, typeParameters, componentSignature, componentType, allowCoercion, typeManager)) {
                     return false;
                 }
@@ -336,7 +338,7 @@ public final class Signature
         }
 
         // We've already checked all the components, so just match the base type
-        if (!parameter.getParameters().isEmpty()) {
+        if (!typeSignatures.isEmpty()) {
             return type.getTypeSignature().getBase().equals(parameter.getBase());
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SqlAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SqlAggregationFunction.java
@@ -38,19 +38,19 @@ public abstract class SqlAggregationFunction
         return new SimpleSqlAggregationFunction(name, description, function);
     }
 
-    protected SqlAggregationFunction(String name, List<TypeParameter> typeParameters, String returnType, List<String> argumentTypes)
+    protected SqlAggregationFunction(String name, List<TypeParameterRequirement> typeParameterRequirements, String returnType, List<String> argumentTypes)
     {
-        this(name, typeParameters, returnType, argumentTypes, AGGREGATE);
+        this(name, typeParameterRequirements, returnType, argumentTypes, AGGREGATE);
     }
 
-    protected SqlAggregationFunction(String name, List<TypeParameter> typeParameters, String returnType, List<String> argumentTypes, FunctionKind kind)
+    protected SqlAggregationFunction(String name, List<TypeParameterRequirement> typeParameterRequirements, String returnType, List<String> argumentTypes, FunctionKind kind)
     {
         requireNonNull(name, "name is null");
-        requireNonNull(typeParameters, "typeParameters is null");
+        requireNonNull(typeParameterRequirements, "typeParameters is null");
         requireNonNull(returnType, "returnType is null");
         requireNonNull(argumentTypes, "argumentTypes is null");
         checkArgument(kind == AGGREGATE || kind == APPROXIMATE_AGGREGATE, "kind must be an aggregate");
-        this.signature = new Signature(name, kind, ImmutableList.copyOf(typeParameters), returnType, ImmutableList.copyOf(argumentTypes), false);
+        this.signature = new Signature(name, kind, ImmutableList.copyOf(typeParameterRequirements), returnType, ImmutableList.copyOf(argumentTypes), false);
     }
 
     @Override
@@ -85,7 +85,7 @@ public abstract class SqlAggregationFunction
                 InternalAggregationFunction function)
         {
             super(name,
-                    ImmutableList.<TypeParameter>of(),
+                    ImmutableList.<TypeParameterRequirement>of(),
                     function.getFinalType().getTypeSignature().toString(),
                     function.getParameterTypes().stream()
                             .map(Type::getTypeSignature)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SqlOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SqlOperator.java
@@ -43,9 +43,9 @@ public abstract class SqlOperator
         return new SimpleSqlOperator(operatorType, argumentTypes, returnType, methodHandle, instanceFactory, nullable, nullableArguments);
     }
 
-    protected SqlOperator(OperatorType operatorType, List<TypeParameter> typeParameters, String returnType, List<String> argumentTypes)
+    protected SqlOperator(OperatorType operatorType, List<TypeParameterRequirement> typeParameterRequirements, String returnType, List<String> argumentTypes)
     {
-        super(mangleOperatorName(operatorType), typeParameters, returnType, argumentTypes);
+        super(mangleOperatorName(operatorType), typeParameterRequirements, returnType, argumentTypes);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SqlScalarFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SqlScalarFunction.java
@@ -47,18 +47,18 @@ public abstract class SqlScalarFunction
         return new SimpleSqlScalarFunction(signature, description, hidden, methodHandle, instanceFactory, deterministic, nullable, nullableArguments);
     }
 
-    protected SqlScalarFunction(String name, List<TypeParameter> typeParameters, String returnType, List<String> argumentTypes)
+    protected SqlScalarFunction(String name, List<TypeParameterRequirement> typeParameterRequirements, String returnType, List<String> argumentTypes)
     {
-        this(name, typeParameters, returnType, argumentTypes, false);
+        this(name, typeParameterRequirements, returnType, argumentTypes, false);
     }
 
-    protected SqlScalarFunction(String name, List<TypeParameter> typeParameters, String returnType, List<String> argumentTypes, boolean variableArity)
+    protected SqlScalarFunction(String name, List<TypeParameterRequirement> typeParameterRequirements, String returnType, List<String> argumentTypes, boolean variableArity)
     {
         requireNonNull(name, "name is null");
-        requireNonNull(typeParameters, "typeParameters is null");
+        requireNonNull(typeParameterRequirements, "typeParameters is null");
         requireNonNull(returnType, "returnType is null");
         requireNonNull(argumentTypes, "argumentTypes is null");
-        this.signature = new Signature(name, SCALAR, ImmutableList.copyOf(typeParameters), returnType, ImmutableList.copyOf(argumentTypes), variableArity);
+        this.signature = new Signature(name, SCALAR, ImmutableList.copyOf(typeParameterRequirements), returnType, ImmutableList.copyOf(argumentTypes), variableArity);
     }
 
     @Override
@@ -96,7 +96,7 @@ public abstract class SqlScalarFunction
                     signature.getArgumentTypes().stream()
                             .map(TypeSignature::toString)
                             .collect(ImmutableCollectors.toImmutableList()));
-            checkArgument(signature.getTypeParameters().isEmpty(), "%s is parametric", signature);
+            checkArgument(signature.getTypeParameterRequirements().isEmpty(), "%s is parametric", signature);
             this.description = description;
             this.hidden = hidden;
             this.methodHandle = requireNonNull(methodHandle, "methodHandle is null");

--- a/presto-main/src/main/java/com/facebook/presto/metadata/TypeParameterRequirement.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/TypeParameterRequirement.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
-public final class TypeParameter
+public final class TypeParameterRequirement
 {
     private final String name;
     private final boolean comparableRequired;
@@ -31,7 +31,7 @@ public final class TypeParameter
     private final String variadicBound;
 
     @JsonCreator
-    public TypeParameter(
+    public TypeParameterRequirement(
             @JsonProperty("name") String name,
             @JsonProperty("comparableRequired") boolean comparableRequired,
             @JsonProperty("orderableRequired") boolean orderableRequired,
@@ -107,7 +107,7 @@ public final class TypeParameter
             return false;
         }
 
-        TypeParameter other = (TypeParameter) o;
+        TypeParameterRequirement other = (TypeParameterRequirement) o;
 
         return Objects.equals(this.name, other.name) &&
                 Objects.equals(this.comparableRequired, other.comparableRequired) &&

--- a/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
@@ -361,7 +361,7 @@ public class StatementResource
                     exchangeClient.close();
 
                     // Return a single value for clients that require a result.
-                    columns = ImmutableList.of(new Column("result", "boolean", new ClientTypeSignature(StandardTypes.BOOLEAN, ImmutableList.<ClientTypeSignature>of(), ImmutableList.of())));
+                    columns = ImmutableList.of(new Column("result", "boolean", new ClientTypeSignature(StandardTypes.BOOLEAN, ImmutableList.of(), ImmutableList.of())));
                     data = ImmutableSet.<List<Object>>of(ImmutableList.<Object>of(true));
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
@@ -361,7 +361,7 @@ public class StatementResource
                     exchangeClient.close();
 
                     // Return a single value for clients that require a result.
-                    columns = ImmutableList.of(new Column("result", "boolean", new ClientTypeSignature(StandardTypes.BOOLEAN, ImmutableList.of(), ImmutableList.of())));
+                    columns = ImmutableList.of(new Column("result", "boolean", new ClientTypeSignature(StandardTypes.BOOLEAN, ImmutableList.of())));
                     data = ImmutableSet.<List<Object>>of(ImmutableList.<Object>of(true));
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/type/ArrayParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/ArrayParametricType.java
@@ -13,8 +13,10 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.spi.type.ParameterKind;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeParameter;
 
 import java.util.List;
 
@@ -36,10 +38,13 @@ public final class ArrayParametricType
     }
 
     @Override
-    public ArrayType createType(List<Type> types, List<Object> literals)
+    public Type createType(List<TypeParameter> parameters)
     {
-        checkArgument(types.size() == 1, "Expected only one type, got %s", types);
-        checkArgument(literals.isEmpty(), "Unexpected literals: %s", literals);
-        return new ArrayType(types.get(0));
+        checkArgument(parameters.size() == 1, "Array type expects exactly one type as a parameter, got %s", parameters);
+        checkArgument(
+                parameters.get(0).getKind() == ParameterKind.TYPE_SIGNATURE,
+                "Array expects type as a parameter, got %s",
+                parameters);
+        return new ArrayType(parameters.get(0).getType());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/FunctionParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/FunctionParametricType.java
@@ -13,12 +13,15 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.spi.type.ParameterKind;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeParameter;
 
 import java.util.List;
 
 import static com.facebook.presto.type.FunctionType.NAME;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.stream.Collectors.toList;
 
 public final class FunctionParametricType
         implements ParametricType
@@ -36,10 +39,15 @@ public final class FunctionParametricType
     }
 
     @Override
-    public FunctionType createType(List<Type> types, List<Object> literals)
+    public Type createType(List<TypeParameter> parameters)
     {
-        checkArgument(types.size() >= 1, "Function type must have at least one parameter, got %s", types);
-        checkArgument(literals.isEmpty(), "Unexpected literals: %s", literals);
+        checkArgument(parameters.size() >= 1, "Function type must have at least one parameter, got %s", parameters);
+        checkArgument(
+                parameters.stream().allMatch(parameter -> parameter.getKind() == ParameterKind.TYPE_SIGNATURE),
+                "Expected only types as a parameters, got %s",
+                parameters);
+        List<Type> types = parameters.stream().map(parameter -> parameter.getType()).collect(toList());
+
         return new FunctionType(types.subList(0, types.size() - 1), types.get(types.size() - 1));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/MapParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/MapParametricType.java
@@ -13,8 +13,10 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.spi.type.ParameterKind;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeParameter;
 
 import java.util.List;
 
@@ -36,10 +38,15 @@ public final class MapParametricType
     }
 
     @Override
-    public MapType createType(List<Type> types, List<Object> literals)
+    public Type createType(List<TypeParameter> parameters)
     {
-        checkArgument(types.size() == 2, "Expected two types");
-        checkArgument(literals.isEmpty(), "Unexpected literals: %s", literals);
-        return new MapType(types.get(0), types.get(1));
+        checkArgument(parameters.size() == 2, "Expected two parameters, got %s", parameters);
+        TypeParameter firstParameter = parameters.get(0);
+        TypeParameter secondParameter = parameters.get(1);
+        checkArgument(
+                firstParameter.getKind() == ParameterKind.TYPE_SIGNATURE && secondParameter.getKind() == ParameterKind.TYPE_SIGNATURE,
+                "Expected key and type to be types, got %s",
+                parameters);
+        return new MapType(firstParameter.getType(), secondParameter.getType());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/ParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/ParametricType.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.type;
 
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeParameter;
 
 import java.util.List;
 
@@ -21,5 +22,5 @@ public interface ParametricType
 {
     String getName();
 
-    Type createType(List<Type> types, List<Object> literals);
+    Type createType(List<TypeParameter> parameters);
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/RowType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RowType.java
@@ -50,7 +50,6 @@ public class RowType
                         "row",
                         Lists.transform(fieldTypes, Type::getTypeSignature),
                         fieldNames.orElse(ImmutableList.of()).stream()
-                                .map(Object.class::cast)
                                 .collect(toImmutableList())),
                 Block.class);
 

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.type.FixedWidthType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
@@ -112,7 +113,11 @@ public final class TypeUtils
 
     public static TypeSignature parameterizedTypeName(String base, TypeSignature... argumentNames)
     {
-        return new TypeSignature(base, ImmutableList.copyOf(argumentNames), ImmutableList.of());
+        ImmutableList.Builder<TypeSignatureParameter> parameters = ImmutableList.builder();
+        for (TypeSignature signature : argumentNames) {
+            parameters.add(TypeSignatureParameter.of(signature));
+        }
+        return new TypeSignature(base, parameters.build());
     }
 
     public static int getHashPosition(List<? extends Type> hashTypes, Block[] hashBlocks, int position)

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionRegistry.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionRegistry.java
@@ -63,7 +63,7 @@ public class TestFunctionRegistry
             if (operatorType == OperatorType.CAST) {
                 continue;
             }
-            if (!function.getSignature().getTypeParameters().isEmpty()) {
+            if (!function.getSignature().getTypeParameterRequirements().isEmpty()) {
                 continue;
             }
             Signature exactOperator = registry.resolveOperator(operatorType, resolveTypes(function.getSignature().getArgumentTypes(), typeManager));

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestSignature.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestSignature.java
@@ -79,7 +79,7 @@ public class TestSignature
             throws Exception
     {
         TypeManager typeManager = new TypeRegistry();
-        Signature signature = new Signature("foo", SCALAR, ImmutableList.<TypeParameter>of(), "boolean", ImmutableList.of("bigint"), false);
+        Signature signature = new Signature("foo", SCALAR, ImmutableList.<TypeParameterRequirement>of(), "boolean", ImmutableList.of("bigint"), false);
         assertNotNull(signature.bindTypeParameters(ImmutableList.of(BIGINT), true, typeManager));
         assertNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR), true, typeManager));
         assertNull(signature.bindTypeParameters(ImmutableList.of(VARCHAR, BIGINT), true, typeManager));

--- a/presto-main/src/test/java/com/facebook/presto/server/TestExecuteResource.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestExecuteResource.java
@@ -59,8 +59,8 @@ public class TestExecuteResource
             throws Exception
     {
         String expected = "{\"columns\":[" +
-                "{\"name\":\"foo\",\"type\":\"bigint\",\"typeSignature\":{\"rawType\":\"bigint\",\"typeArguments\":[],\"literalArguments\":[]}}," +
-                "{\"name\":\"bar\",\"type\":\"varchar\",\"typeSignature\":{\"rawType\":\"varchar\",\"typeArguments\":[],\"literalArguments\":[]}}]," +
+                "{\"name\":\"foo\",\"type\":\"bigint\",\"typeSignature\":{\"rawType\":\"bigint\",\"typeArguments\":[]}}," +
+                "{\"name\":\"bar\",\"type\":\"varchar\",\"typeSignature\":{\"rawType\":\"varchar\",\"typeArguments\":[]}}]," +
                 "\"data\":[[123,\"abc\"]]}\n";
 
         StringResponse response = executeQuery("SELECT 123 foo, 'abc' bar");

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -48,7 +48,8 @@ public class TestRowOperators
     {
         functionAssertions.getMetadata().getType(parseTypeSignature("row<bigint>('a')"));
         Type type = functionAssertions.getMetadata().getType(parseTypeSignature("row<bigint>('b')"));
-        assertEquals(type.getTypeSignature().getLiteralParameters(), ImmutableList.of("b"));
+        assertEquals(type.getTypeSignature().getParameters().size(), 1);
+        assertEquals(type.getTypeSignature().getParameters().get(0).getNamedTypeSignature().getName(), "b");
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTypeRegistry.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTypeRegistry.java
@@ -67,9 +67,6 @@ public class TestTypeRegistry
         assertFalse(TypeRegistry.canCoerce(parseTypeSignature("array<double>"), parseTypeSignature("array<bigint>")));
         assertTrue(TypeRegistry.canCoerce(parseTypeSignature("map<bigint,double>"), parseTypeSignature("map<bigint,double>")));
         assertFalse(TypeRegistry.canCoerce(parseTypeSignature("map<bigint,double>"), parseTypeSignature("map<double,double>"))); // map covariant cast is not supported yet
-        assertTrue(TypeRegistry.canCoerce(parseTypeSignature("row<bigint,double,varchar>"), parseTypeSignature("row<bigint,double,varchar>")));
-        assertFalse(TypeRegistry.canCoerce(parseTypeSignature("row<bigint,double,varchar>('a','b','c')"), parseTypeSignature("row<bigint,double,varchar>")));
-        assertFalse(TypeRegistry.canCoerce(parseTypeSignature("row<bigint,double,varchar>"), parseTypeSignature("row<bigint,double,varchar>('a','b','c')")));
         assertTrue(TypeRegistry.canCoerce(parseTypeSignature("row<bigint,double,varchar>('a','b','c')"), parseTypeSignature("row<bigint,double,varchar>('a','b','c')")));
     }
 
@@ -97,8 +94,6 @@ public class TestTypeRegistry
         assertCommonSuperType("array<bigint>", "array<unknown>", "array<bigint>");
         assertCommonSuperType("map<bigint,double>", "map<bigint,double>", "map<bigint,double>");
         assertCommonSuperType("map<bigint,double>", "map<double,double>", null); // map covariant cast is not supported yet
-        assertCommonSuperType("row<bigint,double,varchar>", "row<bigint,double,varchar>", "row<bigint,double,varchar>");
-        assertCommonSuperType("row<bigint,double,varchar>('a','b','c')", "row<bigint,double,varchar>", null);
         assertCommonSuperType("row<bigint,double,varchar>('a','b','c')", "row<bigint,double,varchar>('a','b','c')", "row<bigint,double,varchar>('a','b','c')");
     }
 

--- a/presto-ml/src/main/java/com/facebook/presto/ml/type/ClassifierParametricType.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/type/ClassifierParametricType.java
@@ -13,7 +13,9 @@
  */
 package com.facebook.presto.ml.type;
 
+import com.facebook.presto.spi.type.ParameterKind;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeParameter;
 import com.facebook.presto.type.ParametricType;
 
 import java.util.List;
@@ -32,9 +34,13 @@ public class ClassifierParametricType
     }
 
     @Override
-    public Type createType(List<Type> types, List<Object> literals)
+    public Type createType(List<TypeParameter> parameters)
     {
-        checkArgument(types.size() == 1, "expected 1 type parameter");
-        return new ClassifierType(types.get(0));
+        checkArgument(parameters.size() == 1, "Expected only one type, got %s", parameters);
+        checkArgument(
+                parameters.get(0).getKind() == ParameterKind.TYPE_SIGNATURE,
+                "Expected type as a parameter, got %s",
+                parameters);
+        return new ClassifierType(parameters.get(0).getType());
     }
 }

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -238,7 +238,7 @@ valueExpression
 primaryExpression
     : NULL                                                                           #nullLiteral
     | interval                                                                       #intervalLiteral
-    | identifier STRING                                                              #typeConstructor
+    | type STRING                                                                    #typeConstructor
     | number                                                                         #numericLiteral
     | booleanValue                                                                   #booleanLiteral
     | STRING                                                                         #stringLiteral
@@ -295,10 +295,14 @@ type
     : type ARRAY
     | ARRAY '<' type '>'
     | MAP '<' type ',' type '>'
-    | simpleType
+    | baseType ('(' typeParameter (',' typeParameter)* ')')?
     ;
 
-simpleType
+typeParameter
+    : INTEGER_VALUE | type
+    ;
+
+baseType
     : TIME_WITH_TIME_ZONE
     | TIMESTAMP_WITH_TIME_ZONE
     | identifier
@@ -360,7 +364,7 @@ number
 nonReserved
     : SHOW | TABLES | COLUMNS | COLUMN | PARTITIONS | FUNCTIONS | SCHEMAS | CATALOGS | SESSION
     | ADD
-    | OVER | PARTITION | RANGE | ROWS | PRECEDING | FOLLOWING | CURRENT | ROW | MAP
+    | OVER | PARTITION | RANGE | ROWS | PRECEDING | FOLLOWING | CURRENT | ROW | MAP | ARRAY
     | DATE | TIME | TIMESTAMP | INTERVAL | ZONE
     | YEAR | MONTH | DAY | HOUR | MINUTE | SECOND
     | EXPLAIN | FORMAT | TYPE | TEXT | GRAPHVIZ | LOGICAL | DISTRIBUTED

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -130,6 +130,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -1087,7 +1088,7 @@ class AstBuilder
     @Override
     public Node visitTypeConstructor(SqlBaseParser.TypeConstructorContext context)
     {
-        String type = context.identifier().getText();
+        String type = getType(context.type());
         String value = unquote(context.STRING().getText());
 
         if (type.equalsIgnoreCase("time")) {
@@ -1392,19 +1393,39 @@ class AstBuilder
 
     private static String getType(SqlBaseParser.TypeContext type)
     {
-        if (type.simpleType() != null) {
-            return type.simpleType().getText();
+        if (type.baseType() != null) {
+            String signature = type.baseType().getText();
+            if (!type.typeParameter().isEmpty()) {
+                String typeParameterSignature = type
+                        .typeParameter()
+                        .stream()
+                        .map(AstBuilder::typeParameterToString)
+                        .collect(Collectors.joining(","));
+                signature += "(" + typeParameterSignature + ")";
+            }
+            return signature;
         }
 
         if (type.ARRAY() != null) {
-            return "ARRAY<" + getType(type.type(0)) + ">";
+            return "ARRAY(" + getType(type.type(0)) + ")";
         }
 
         if (type.MAP() != null) {
-            return "MAP<" + getType(type.type(0)) + "," + getType(type.type(1)) + ">";
+            return "MAP(" + getType(type.type(0)) + "," + getType(type.type(1)) + ")";
         }
 
         throw new IllegalArgumentException("Unsupported type specification: " + type.getText());
+    }
+
+    private static String typeParameterToString(SqlBaseParser.TypeParameterContext typeParameter)
+    {
+        if (typeParameter.INTEGER_VALUE() != null) {
+            return typeParameter.INTEGER_VALUE().toString();
+        }
+        if (typeParameter.type() != null) {
+            return getType(typeParameter.type());
+        }
+        throw new IllegalArgumentException("Unsupported typeParameter: " + typeParameter.getText());
     }
 
     private static void check(boolean condition, String message, ParserRuleContext context)

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -144,6 +144,17 @@ public class TestSqlParser
         assertGenericLiteral("BOOLEAN");
         assertGenericLiteral("DATE");
         assertGenericLiteral("foo");
+
+        assertExpression("VARCHAR(42)" + " 'abc'", new GenericLiteral("VARCHAR(42)", "abc"));
+        assertExpression("FOO(42, 55)" + " 'abc'", new GenericLiteral("FOO(42,55)", "abc"));
+
+        assertExpression("ARRAY(BIGINT)" + " 'abc'", new GenericLiteral("ARRAY(BIGINT)", "abc"));
+        assertExpression(
+                "MAP(BIGINT, VARCHAR)" + " 'abc'",
+                new GenericLiteral("MAP(BIGINT,VARCHAR)", "abc"));
+        assertExpression(
+                "FOO(VARCHAR(42), ARRAY(BIGINT))" + " 'abc'",
+                new GenericLiteral("FOO(VARCHAR(42),ARRAY(BIGINT))", "abc"));
     }
 
     @Test
@@ -233,6 +244,7 @@ public class TestSqlParser
     public void testCast()
             throws Exception
     {
+        assertCast("foo(42, 55) ARRAY", "ARRAY(foo(42,55))");
         assertCast("varchar");
         assertCast("bigint");
         assertCast("BIGINT");
@@ -247,15 +259,34 @@ public class TestSqlParser
         assertCast("foo");
         assertCast("FOO");
 
-        assertCast("ARRAY<bigint>");
-        assertCast("ARRAY<BIGINT>");
-        assertCast("array<bigint>");
-        assertCast("array < bigint  >", "ARRAY<bigint>");
-        assertCast("array<array<bigint>>");
-        assertCast("foo ARRAY", "ARRAY<foo>");
-        assertCast("boolean array  array ARRAY", "ARRAY<ARRAY<ARRAY<boolean>>>");
-        assertCast("boolean ARRAY ARRAY ARRAY", "ARRAY<ARRAY<ARRAY<boolean>>>");
-        assertCast("ARRAY<boolean> ARRAY ARRAY", "ARRAY<ARRAY<ARRAY<boolean>>>");
+        assertCast("ARRAY<bigint>", "ARRAY(bigint)");
+        assertCast("ARRAY<BIGINT>", "ARRAY(BIGINT)");
+        assertCast("array<bigint>", "array(bigint)");
+        assertCast("array < bigint  >", "ARRAY(bigint)");
+
+        assertCast("ARRAY(bigint)");
+        assertCast("ARRAY(BIGINT)");
+        assertCast("array(bigint)");
+        assertCast("array ( bigint  )", "ARRAY(bigint)");
+
+        assertCast("array<array<bigint>>", "array(array(bigint))");
+        assertCast("array(array(bigint))");
+
+        assertCast("foo ARRAY", "ARRAY(foo)");
+        assertCast("boolean array  array ARRAY", "ARRAY(ARRAY(ARRAY(boolean)))");
+        assertCast("boolean ARRAY ARRAY ARRAY", "ARRAY(ARRAY(ARRAY(boolean)))");
+        assertCast("ARRAY<boolean> ARRAY ARRAY", "ARRAY(ARRAY(ARRAY(boolean)))");
+
+        assertCast("map(BIGINT,array(VARCHAR))");
+        assertCast("map<BIGINT,array<VARCHAR>>", "map(BIGINT,array(VARCHAR))");
+
+        assertCast("varchar(42)");
+        assertCast("foo(42,55)");
+        assertCast("foo(BIGINT,array(VARCHAR))");
+        assertCast("ARRAY<varchar(42)>", "ARRAY(varchar(42))");
+        assertCast("ARRAY<foo(42,55)>", "ARRAY(foo(42,55))");
+        assertCast("varchar(42) ARRAY", "ARRAY(varchar(42))");
+        assertCast("foo(42, 55) ARRAY", "ARRAY(foo(42,55))");
     }
 
     @Test

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisPlugin.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisPlugin.java
@@ -82,7 +82,7 @@ public class TestRedisPlugin
         }
 
         @Override
-        public Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<Object> literalParameters)
+        public Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<String> literalParameters)
         {
             return null;
         }

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisPlugin.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisPlugin.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.NodeState;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -70,6 +71,12 @@ public class TestRedisPlugin
     {
         @Override
         public Type getType(TypeSignature signature)
+        {
+            return null;
+        }
+
+        @Override
+        public Type getParameterizedType(String baseTypeName, List<TypeSignatureParameter> typeParameters)
         {
             return null;
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/NamedType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/NamedType.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.type;
+
+import java.util.Objects;
+
+public class NamedType
+{
+    private final String name;
+    private final Type type;
+
+    public NamedType(String name, Type type)
+    {
+        this.name = name;
+        this.type = type;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        NamedType other = (NamedType) o;
+
+        return Objects.equals(this.name, other.name) &&
+                Objects.equals(this.type, other.type);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, type);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/NamedTypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/NamedTypeSignature.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+public class NamedTypeSignature
+{
+    private final String name;
+    private final TypeSignature typeSignature;
+
+    @JsonCreator
+    public NamedTypeSignature(
+            @JsonProperty("name") String name,
+            @JsonProperty("typeSignature") TypeSignature typeSignature)
+    {
+        this.name = name;
+        this.typeSignature = typeSignature;
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public TypeSignature getTypeSignature()
+    {
+        return typeSignature;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        NamedTypeSignature other = (NamedTypeSignature) o;
+
+        return Objects.equals(this.name, other.name) &&
+                Objects.equals(this.typeSignature, other.typeSignature);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("%s %s", name, typeSignature);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, typeSignature);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ParameterKind.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ParameterKind.java
@@ -17,5 +17,6 @@ package com.facebook.presto.spi.type;
 public enum ParameterKind
 {
     TYPE_SIGNATURE,
+    NAMED_TYPE_SIGNATURE,
     LONG_LITERAL
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ParameterKind.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ParameterKind.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.type;
+
+public enum ParameterKind
+{
+    TYPE_SIGNATURE,
+    LONG_LITERAL
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/Type.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/Type.java
@@ -51,7 +51,7 @@ public interface Type
      * expression execution. This value is used to determine which method should
      * be called on Cursor, RecordSet or RandomAccessBlock to fetch a value of
      * this type.
-     *
+     * <p/>
      * Currently, this must be boolean, long, double, or Slice.
      */
     Class<?> getJavaType();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeManager.java
@@ -34,7 +34,7 @@ public interface TypeManager
      * This method is deprecated and above generalized version should be used.
      */
     @Deprecated
-    Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<Object> literalParameters);
+    Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<String> literalParameters);
 
     /**
      * Gets a list of all registered types.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeManager.java
@@ -26,6 +26,14 @@ public interface TypeManager
     /**
      * Gets the type with the specified base type, and the given parameters, or null if not found.
      */
+    Type getParameterizedType(String baseTypeName, List<TypeSignatureParameter> typeParameters);
+
+    /**
+     * Gets the type with the specified base type, and the given parameters, or null if not found.
+     *
+     * This method is deprecated and above generalized version should be used.
+     */
+    @Deprecated
     Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<Object> literalParameters);
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeParameter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeParameter.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.type;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+public class TypeParameter
+{
+    private final ParameterKind kind;
+    private final Object value;
+
+    private TypeParameter(ParameterKind kind, Object value)
+    {
+        this.kind = kind;
+        this.value = value;
+    }
+
+    public static TypeParameter of(Type type)
+    {
+        return new TypeParameter(ParameterKind.TYPE_SIGNATURE, type);
+    }
+
+    public static TypeParameter of(long longLiteral)
+    {
+        return new TypeParameter(ParameterKind.LONG_LITERAL, longLiteral);
+    }
+
+    public static TypeParameter of(NamedType namedType)
+    {
+        return new TypeParameter(ParameterKind.NAMED_TYPE_SIGNATURE, namedType);
+    }
+
+    public static TypeParameter of(TypeSignatureParameter parameter, TypeManager typeManager)
+    {
+        switch (parameter.getKind()) {
+            case TYPE_SIGNATURE: {
+                Type type = typeManager.getType(parameter.getTypeSignature());
+                if (type == null) {
+                    return null;
+                }
+                return of(type);
+            }
+            case LONG_LITERAL:
+                return of(parameter.getLongLiteral());
+            case NAMED_TYPE_SIGNATURE: {
+                Type type = typeManager.getType(parameter.getNamedTypeSignature().getTypeSignature());
+                if (type == null) {
+                    return null;
+                }
+                return of(new NamedType(
+                        parameter.getNamedTypeSignature().getName(),
+                        type));
+            }
+            default:
+                throw new UnsupportedOperationException(format("Unsupported parameter [%s]", parameter));
+        }
+    }
+
+    public ParameterKind getKind()
+    {
+        return kind;
+    }
+
+    public <A> A getValue(ParameterKind expectedParameterKind, Class<A> target)
+    {
+        if (kind != expectedParameterKind) {
+            throw new AssertionError(format("ParameterKind is [%s] but expected [%s]", kind, expectedParameterKind));
+        }
+        return target.cast(value);
+    }
+
+    public Type getType()
+    {
+        return getValue(ParameterKind.TYPE_SIGNATURE, Type.class);
+    }
+
+    public Long getLongLiteral()
+    {
+        return getValue(ParameterKind.LONG_LITERAL, Long.class);
+    }
+
+    public NamedType getNamedType()
+    {
+        return getValue(ParameterKind.NAMED_TYPE_SIGNATURE, NamedType.class);
+    }
+
+    @Override
+    public String toString()
+    {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TypeParameter other = (TypeParameter) o;
+
+        return Objects.equals(this.kind, other.kind) &&
+                Objects.equals(this.value, other.value);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(kind, value);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
@@ -19,79 +19,80 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableList;
+import static java.util.stream.Collectors.toList;
 
 public class TypeSignature
 {
     private final String base;
-    private final List<TypeSignature> parameters;
+    private final List<TypeSignatureParameter> parameters;
     private final List<Object> literalParameters;
 
-    public TypeSignature(String base, List<TypeSignature> parameters, List<Object> literalParameters)
+    public TypeSignature(String base, List<TypeSignatureParameter> parameters)
     {
         checkArgument(base != null, "base is null");
         this.base = base;
         checkArgument(!base.isEmpty(), "base is empty");
         checkArgument(validateName(base), "Bad characters in base type: %s", base);
         checkArgument(parameters != null, "parameters is null");
+        this.parameters = unmodifiableList(new ArrayList<>(parameters));
+        this.literalParameters = unmodifiableList(new ArrayList<>());
+    }
+
+    // TODO: merge literalParameters for Row with TypeSignatureParameter
+    @Deprecated
+    public TypeSignature(String base, List<TypeSignature> typeSignatureParameters, List<Object> literalParameters)
+    {
+        checkArgument(base != null, "base is null");
+        this.base = base;
+        checkArgument(!base.isEmpty(), "base is empty");
+        checkArgument(validateName(base), "Bad characters in base type: %s", base);
+        checkArgument(typeSignatureParameters != null, "parameters is null");
         checkArgument(literalParameters != null, "literalParameters is null");
         for (Object literal : literalParameters) {
             checkArgument(literal instanceof String || literal instanceof Long, "Unsupported literal type: %s", literal.getClass());
         }
-        this.parameters = unmodifiableList(new ArrayList<>(parameters));
+
+        List<TypeSignatureParameter> typeParameters =
+                typeSignatureParameters.stream().map(TypeSignatureParameter::of).collect(toList());
+
+        this.parameters = unmodifiableList(typeParameters);
         this.literalParameters = unmodifiableList(new ArrayList<>(literalParameters));
     }
 
-    private static boolean validateName(String name)
+    public TypeSignature bindParameters(Map<String, Type> boundParameters)
     {
-        for (int i = 0; i < name.length(); i++) {
-            char c = name.charAt(i);
-            if (c == '<' || c == '>' || c == ',') {
-                return false;
+        if (boundParameters.containsKey(base)) {
+            if (!getLiteralParameters().isEmpty() || !getParameters().isEmpty()) {
+                throw new IllegalStateException("Type parameters cannot have parameters");
             }
+            return boundParameters.get(base).getTypeSignature();
         }
-        return true;
+
+        if (base.equals(StandardTypes.ROW)) {
+            List<TypeSignature> parameters = getTypeParametersAsTypeSignatures().stream().map(signature -> signature.bindParameters(boundParameters)).collect(toList());
+            return new TypeSignature(base, parameters, getLiteralParameters());
+        }
+        else {
+            List<TypeSignatureParameter> parameters = getParameters().stream().map(signature -> signature.bindParameters(boundParameters)).collect(toList());
+            return new TypeSignature(base, parameters);
+        }
     }
 
     @Override
     @JsonValue
     public String toString()
     {
-        StringBuilder typeName = new StringBuilder(base);
-        if (!parameters.isEmpty()) {
-            typeName.append("<");
-            boolean first = true;
-            for (TypeSignature parameter : parameters) {
-                if (!first) {
-                    typeName.append(",");
-                }
-                first = false;
-                typeName.append(parameter.toString());
-            }
-            typeName.append(">");
+        if (base.equals(StandardTypes.ROW)) {
+            return rowToString();
         }
-        if (!literalParameters.isEmpty()) {
-            typeName.append("(");
-            boolean first = true;
-            for (Object parameter : literalParameters) {
-                if (!first) {
-                    typeName.append(",");
-                }
-                first = false;
-                if (parameter instanceof String) {
-                    typeName.append("'").append(parameter).append("'");
-                }
-                else {
-                    typeName.append(parameter.toString());
-                }
-            }
-            typeName.append(")");
+        else {
+            return toString("(", ")");
         }
-
-        return typeName.toString();
     }
 
     public String getBase()
@@ -99,9 +100,22 @@ public class TypeSignature
         return base;
     }
 
-    public List<TypeSignature> getParameters()
+    public List<TypeSignatureParameter> getParameters()
     {
         return parameters;
+    }
+
+    public List<TypeSignature> getTypeParametersAsTypeSignatures()
+    {
+        List<TypeSignature> result = new ArrayList<>();
+        for (TypeSignatureParameter parameter : parameters) {
+            if (parameter.getKind() != ParameterKind.TYPE_SIGNATURE) {
+                throw new IllegalStateException(
+                        format("Expected all parameters to be TypeSignatures but [%s] was found", parameter.toString()));
+            }
+            result.add(parameter.getTypeSignature());
+        }
+        return result;
     }
 
     public List<Object> getLiteralParameters()
@@ -113,9 +127,58 @@ public class TypeSignature
     public static TypeSignature parseTypeSignature(String signature)
     {
         if (!signature.contains("<") && !signature.contains("(")) {
-            return new TypeSignature(signature, new ArrayList<TypeSignature>(), new ArrayList<>());
+            return new TypeSignature(signature, new ArrayList<>());
+        }
+        if (signature.startsWith(StandardTypes.ROW)) {
+            return parseRowTypeSignature(signature);
         }
 
+        String baseName = null;
+        List<TypeSignatureParameter> parameters = new ArrayList<>();
+        int parameterStart = -1;
+        int bracketCount = 0;
+
+        for (int i = 0; i < signature.length(); i++) {
+            char c = signature.charAt(i);
+            // TODO: remove angle brackets support once ROW<TYPE>(name) will be dropped
+            // Angel brackets here are checked not for the support of ARRAY<> and MAP<>
+            // but to correctly parse ARRAY(row<BIGINT, BIGINT>('a','b'))
+            if (c == '(' || c == '<') {
+                if (bracketCount == 0) {
+                    verify(baseName == null, "Expected baseName to be null");
+                    verify(parameterStart == -1, "Expected parameter start to be -1");
+                    baseName = signature.substring(0, i);
+                    parameterStart = i + 1;
+                }
+                bracketCount++;
+            }
+            else if (c == ')' || c == '>') {
+                bracketCount--;
+                checkArgument(bracketCount >= 0, "Bad type signature: '%s'", signature);
+                if (bracketCount == 0) {
+                    checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
+                    parseTypeSignatureParameter(signature, parameterStart, i, parameters);
+                    parameterStart = i + 1;
+                    if (i == signature.length() - 1) {
+                        return new TypeSignature(baseName, parameters);
+                    }
+                }
+            }
+            else if (c == ',') {
+                if (bracketCount == 1) {
+                    checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
+                    parseTypeSignatureParameter(signature, parameterStart, i, parameters);
+                    parameterStart = i + 1;
+                }
+            }
+        }
+
+        throw new IllegalArgumentException(format("Bad type signature: '%s'", signature));
+    }
+
+    @Deprecated
+    private static TypeSignature parseRowTypeSignature(String signature)
+    {
         String baseName = null;
         List<TypeSignature> parameters = new ArrayList<>();
         List<Object> literalParameters = new ArrayList<>();
@@ -147,21 +210,22 @@ public class TypeSignature
                 }
             }
             else if (c == ',') {
-                if (bracketCount == 1 && !inLiteralParameters) {
-                    checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
-                    parameters.add(parseTypeSignature(signature.substring(parameterStart, i)));
-                    parameterStart = i + 1;
-                }
-                else if (bracketCount == 0 && inLiteralParameters) {
-                    checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
-                    literalParameters.add(parseLiteral(signature.substring(parameterStart, i)));
-                    parameterStart = i + 1;
+                if (bracketCount == 1) {
+                    if (!inLiteralParameters) {
+                        checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
+                        parameters.add(parseTypeSignature(signature.substring(parameterStart, i)));
+                        parameterStart = i + 1;
+                    }
+                    else {
+                        checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
+                        literalParameters.add(parseLiteral(signature.substring(parameterStart, i)));
+                        parameterStart = i + 1;
+                    }
                 }
             }
             else if (c == '(') {
-                checkArgument(!inLiteralParameters, "Bad type signature: '%s'", signature);
-                inLiteralParameters = true;
                 if (bracketCount == 0) {
+                    inLiteralParameters = true;
                     if (baseName == null) {
                         verify(parameters.isEmpty(), "Expected no parameters");
                         verify(parameterStart == -1, "Expected parameter start to be -1");
@@ -169,11 +233,13 @@ public class TypeSignature
                     }
                     parameterStart = i + 1;
                 }
+                bracketCount++;
             }
             else if (c == ')') {
-                checkArgument(inLiteralParameters, "Bad type signature: '%s'", signature);
-                inLiteralParameters = false;
+                bracketCount--;
                 if (bracketCount == 0) {
+                    checkArgument(inLiteralParameters, "Bad type signature: '%s'", signature);
+                    inLiteralParameters = false;
                     checkArgument(i == signature.length() - 1, "Bad type signature: '%s'", signature);
                     checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
                     literalParameters.add(parseLiteral(signature.substring(parameterStart, i)));
@@ -185,6 +251,20 @@ public class TypeSignature
         throw new IllegalArgumentException(format("Bad type signature: '%s'", signature));
     }
 
+    private static void parseTypeSignatureParameter(
+            String signature,
+            int begin,
+            int end,
+            List<TypeSignatureParameter> parameters)
+    {
+        if (Character.isDigit(signature.charAt(begin))) {
+            parameters.add(TypeSignatureParameter.of(Long.parseLong(signature.substring(begin, end))));
+        }
+        else {
+            parameters.add(TypeSignatureParameter.of(parseTypeSignature(signature.substring(begin, end))));
+        }
+    }
+
     private static Object parseLiteral(String literal)
     {
         if (literal.startsWith("'") || literal.endsWith("'")) {
@@ -194,6 +274,48 @@ public class TypeSignature
         else {
             return Long.parseLong(literal);
         }
+    }
+
+    @Deprecated
+    private String rowToString()
+    {
+        return toString("<", ">");
+    }
+
+    private String toString(String leftParameterBracket, String rightParameterBracket)
+    {
+        StringBuilder typeName = new StringBuilder(base);
+        if (!parameters.isEmpty()) {
+            typeName.append(leftParameterBracket);
+            boolean first = true;
+            for (TypeSignatureParameter parameter : parameters) {
+                if (!first) {
+                    typeName.append(",");
+                }
+                first = false;
+                typeName.append(parameter.toString());
+            }
+            typeName.append(rightParameterBracket);
+        }
+        if (!literalParameters.isEmpty()) {
+            typeName.append("(");
+            boolean first = true;
+            for (Object parameter : literalParameters) {
+                if (!first) {
+                    typeName.append(",");
+                }
+                first = false;
+                if (parameter instanceof String) {
+                    typeName.append("'").append(parameter).append("'");
+                }
+                else {
+                    typeName.append(parameter.toString());
+                }
+            }
+            typeName.append(")");
+        }
+
+        return typeName.toString();
     }
 
     @Override
@@ -219,7 +341,7 @@ public class TypeSignature
         return Objects.hash(base.toLowerCase(Locale.ENGLISH), parameters, literalParameters);
     }
 
-    private static void checkArgument(boolean argument, String format, Object...args)
+    private static void checkArgument(boolean argument, String format, Object... args)
     {
         if (!argument) {
             throw new IllegalArgumentException(format(format, args));
@@ -231,5 +353,16 @@ public class TypeSignature
         if (!argument) {
             throw new AssertionError(message);
         }
+    }
+
+    private static boolean validateName(String name)
+    {
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (c == '<' || c == '>' || c == ',') {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableList;
@@ -30,7 +31,6 @@ public class TypeSignature
 {
     private final String base;
     private final List<TypeSignatureParameter> parameters;
-    private final List<Object> literalParameters;
 
     public TypeSignature(String base, List<TypeSignatureParameter> parameters)
     {
@@ -40,59 +40,25 @@ public class TypeSignature
         checkArgument(validateName(base), "Bad characters in base type: %s", base);
         checkArgument(parameters != null, "parameters is null");
         this.parameters = unmodifiableList(new ArrayList<>(parameters));
-        this.literalParameters = unmodifiableList(new ArrayList<>());
     }
 
     // TODO: merge literalParameters for Row with TypeSignatureParameter
     @Deprecated
-    public TypeSignature(String base, List<TypeSignature> typeSignatureParameters, List<Object> literalParameters)
+    public TypeSignature(String base, List<TypeSignature> typeSignatureParameters, List<String> literalParameters)
     {
-        checkArgument(base != null, "base is null");
-        this.base = base;
-        checkArgument(!base.isEmpty(), "base is empty");
-        checkArgument(validateName(base), "Bad characters in base type: %s", base);
-        checkArgument(typeSignatureParameters != null, "parameters is null");
-        checkArgument(literalParameters != null, "literalParameters is null");
-        for (Object literal : literalParameters) {
-            checkArgument(literal instanceof String || literal instanceof Long, "Unsupported literal type: %s", literal.getClass());
-        }
-
-        List<TypeSignatureParameter> typeParameters =
-                typeSignatureParameters.stream().map(TypeSignatureParameter::of).collect(toList());
-
-        this.parameters = unmodifiableList(typeParameters);
-        this.literalParameters = unmodifiableList(new ArrayList<>(literalParameters));
+        this(base, createNamedTypeParameters(typeSignatureParameters, literalParameters));
     }
 
     public TypeSignature bindParameters(Map<String, Type> boundParameters)
     {
         if (boundParameters.containsKey(base)) {
-            if (!getLiteralParameters().isEmpty() || !getParameters().isEmpty()) {
+            if (!getParameters().isEmpty()) {
                 throw new IllegalStateException("Type parameters cannot have parameters");
             }
             return boundParameters.get(base).getTypeSignature();
         }
-
-        if (base.equals(StandardTypes.ROW)) {
-            List<TypeSignature> parameters = getTypeParametersAsTypeSignatures().stream().map(signature -> signature.bindParameters(boundParameters)).collect(toList());
-            return new TypeSignature(base, parameters, getLiteralParameters());
-        }
-        else {
-            List<TypeSignatureParameter> parameters = getParameters().stream().map(signature -> signature.bindParameters(boundParameters)).collect(toList());
-            return new TypeSignature(base, parameters);
-        }
-    }
-
-    @Override
-    @JsonValue
-    public String toString()
-    {
-        if (base.equals(StandardTypes.ROW)) {
-            return rowToString();
-        }
-        else {
-            return toString("(", ")");
-        }
+        List<TypeSignatureParameter> parameters = getParameters().stream().map(signature -> signature.bindParameters(boundParameters)).collect(toList());
+        return new TypeSignature(base, parameters);
     }
 
     public String getBase()
@@ -116,11 +82,6 @@ public class TypeSignature
             result.add(parameter.getTypeSignature());
         }
         return result;
-    }
-
-    public List<Object> getLiteralParameters()
-    {
-        return literalParameters;
     }
 
     @JsonCreator
@@ -181,7 +142,7 @@ public class TypeSignature
     {
         String baseName = null;
         List<TypeSignature> parameters = new ArrayList<>();
-        List<Object> literalParameters = new ArrayList<>();
+        List<String> fieldNames = new ArrayList<>();
         int parameterStart = -1;
         int bracketCount = 0;
         boolean inLiteralParameters = false;
@@ -204,9 +165,7 @@ public class TypeSignature
                     checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
                     parameters.add(parseTypeSignature(signature.substring(parameterStart, i)));
                     parameterStart = i + 1;
-                    if (i == signature.length() - 1) {
-                        return new TypeSignature(baseName, parameters, literalParameters);
-                    }
+                    verify(i < signature.length() - 1, "Row's signature can not end with angle bracket");
                 }
             }
             else if (c == ',') {
@@ -218,7 +177,7 @@ public class TypeSignature
                     }
                     else {
                         checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
-                        literalParameters.add(parseLiteral(signature.substring(parameterStart, i)));
+                        fieldNames.add(parseFieldName(signature.substring(parameterStart, i)));
                         parameterStart = i + 1;
                     }
                 }
@@ -242,13 +201,26 @@ public class TypeSignature
                     inLiteralParameters = false;
                     checkArgument(i == signature.length() - 1, "Bad type signature: '%s'", signature);
                     checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
-                    literalParameters.add(parseLiteral(signature.substring(parameterStart, i)));
-                    return new TypeSignature(baseName, parameters, literalParameters);
+                    fieldNames.add(parseFieldName(signature.substring(parameterStart, i)));
+                    return new TypeSignature(baseName, createNamedTypeParameters(parameters, fieldNames));
                 }
             }
         }
 
         throw new IllegalArgumentException(format("Bad type signature: '%s'", signature));
+    }
+
+    private static List<TypeSignatureParameter> createNamedTypeParameters(List<TypeSignature> parameters, List<String> fieldNames)
+    {
+        checkArgument(parameters != null, "parameters is null");
+        checkArgument(fieldNames != null, "fieldNames is null");
+        verify(parameters.size() == fieldNames.size() || fieldNames.isEmpty(), "Number of parameters and fieldNames for ROW type doesn't match");
+        List<TypeSignatureParameter> result = new ArrayList<>();
+        for (int i = 0; i < parameters.size(); i++) {
+            String fieldName = fieldNames.isEmpty() ? format("field%d", i) : fieldNames.get(i);
+            result.add(TypeSignatureParameter.of(new NamedTypeSignature(fieldName, parameters.get(i))));
+        }
+        return result;
     }
 
     private static void parseTypeSignatureParameter(
@@ -265,80 +237,57 @@ public class TypeSignature
         }
     }
 
-    private static Object parseLiteral(String literal)
+    private static String parseFieldName(String fieldName)
     {
-        if (literal.startsWith("'") || literal.endsWith("'")) {
-            checkArgument(literal.startsWith("'") && literal.endsWith("'"), "Bad literal: '%s'", literal);
-            return literal.substring(1, literal.length() - 1);
+        checkArgument(fieldName != null && fieldName.length() >= 2, "Bad fieldName: '%s'", fieldName);
+        checkArgument(fieldName.startsWith("'") && fieldName.endsWith("'"), "Bad fieldName: '%s'", fieldName);
+        return fieldName.substring(1, fieldName.length() - 1);
+    }
+
+    @Override
+    @JsonValue
+    public String toString()
+    {
+        if (base.equals(StandardTypes.ROW)) {
+            return rowToString();
         }
         else {
-            return Long.parseLong(literal);
+            StringBuilder typeName = new StringBuilder(base);
+            if (!parameters.isEmpty()) {
+                typeName.append("(");
+                boolean first = true;
+                for (TypeSignatureParameter parameter : parameters) {
+                    if (!first) {
+                        typeName.append(",");
+                    }
+                    first = false;
+                    typeName.append(parameter.toString());
+                }
+                typeName.append(")");
+            }
+            return typeName.toString();
         }
     }
 
     @Deprecated
     private String rowToString()
     {
-        return toString("<", ">");
-    }
+        verify(parameters.stream().allMatch(parameter -> parameter.getKind() == ParameterKind.NAMED_TYPE_SIGNATURE),
+                format("Incorrect parameters for row type %s", parameters));
 
-    private String toString(String leftParameterBracket, String rightParameterBracket)
-    {
-        StringBuilder typeName = new StringBuilder(base);
-        if (!parameters.isEmpty()) {
-            typeName.append(leftParameterBracket);
-            boolean first = true;
-            for (TypeSignatureParameter parameter : parameters) {
-                if (!first) {
-                    typeName.append(",");
-                }
-                first = false;
-                typeName.append(parameter.toString());
-            }
-            typeName.append(rightParameterBracket);
-        }
-        if (!literalParameters.isEmpty()) {
-            typeName.append("(");
-            boolean first = true;
-            for (Object parameter : literalParameters) {
-                if (!first) {
-                    typeName.append(",");
-                }
-                first = false;
-                if (parameter instanceof String) {
-                    typeName.append("'").append(parameter).append("'");
-                }
-                else {
-                    typeName.append(parameter.toString());
-                }
-            }
-            typeName.append(")");
-        }
+        String types = parameters.stream()
+                .map(TypeSignatureParameter::getNamedTypeSignature)
+                .map(NamedTypeSignature::getTypeSignature)
+                .map(TypeSignature::toString)
+                .collect(Collectors.joining(","));
 
-        return typeName.toString();
-    }
+        String fieldNames = parameters.stream()
+                .map(TypeSignatureParameter::getNamedTypeSignature)
+                .map(NamedTypeSignature::getName)
+                .map(name -> format("'%s'", name))
+                .collect(Collectors.joining(","));
 
-    @Override
-    public boolean equals(Object o)
-    {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        TypeSignature other = (TypeSignature) o;
-
-        return Objects.equals(this.base.toLowerCase(Locale.ENGLISH), other.base.toLowerCase(Locale.ENGLISH)) &&
-                Objects.equals(this.parameters, other.parameters) &&
-                Objects.equals(this.literalParameters, other.literalParameters);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(base.toLowerCase(Locale.ENGLISH), parameters, literalParameters);
+        return format("row<%s>(%s)", types, fieldNames);
     }
 
     private static void checkArgument(boolean argument, String format, Object... args)
@@ -364,5 +313,27 @@ public class TypeSignature
             }
         }
         return true;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TypeSignature other = (TypeSignature) o;
+
+        return Objects.equals(this.base.toLowerCase(Locale.ENGLISH), other.base.toLowerCase(Locale.ENGLISH)) &&
+                Objects.equals(this.parameters, other.parameters);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(base.toLowerCase(Locale.ENGLISH), parameters);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignatureParameter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignatureParameter.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.type;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -34,6 +35,11 @@ public class TypeSignatureParameter
         return new TypeSignatureParameter(ParameterKind.LONG_LITERAL, longLiteral);
     }
 
+    public static TypeSignatureParameter of(NamedTypeSignature namedTypeSignature)
+    {
+        return new TypeSignatureParameter(ParameterKind.NAMED_TYPE_SIGNATURE, namedTypeSignature);
+    }
+
     private TypeSignatureParameter(ParameterKind kind, Object value)
     {
         this.kind = requireNonNull(kind);
@@ -51,6 +57,21 @@ public class TypeSignatureParameter
         return kind;
     }
 
+    public boolean isTypeSignature()
+    {
+        return kind == ParameterKind.TYPE_SIGNATURE;
+    }
+
+    public boolean isLongLiteral()
+    {
+        return kind == ParameterKind.LONG_LITERAL;
+    }
+
+    public boolean isNamedTypeSignature()
+    {
+        return kind == ParameterKind.NAMED_TYPE_SIGNATURE;
+    }
+
     public <A> A getValue(ParameterKind expectedParameterKind, Class<A> target)
     {
         verify(kind == expectedParameterKind, format("ParameterKind is [%s] but expected [%s]", kind, expectedParameterKind));
@@ -65,6 +86,23 @@ public class TypeSignatureParameter
     public Long getLongLiteral()
     {
         return getValue(ParameterKind.LONG_LITERAL, Long.class);
+    }
+
+    public NamedTypeSignature getNamedTypeSignature()
+    {
+        return getValue(ParameterKind.NAMED_TYPE_SIGNATURE, NamedTypeSignature.class);
+    }
+
+    public Optional<TypeSignature> getTypeSignatureOrNamedTypeSignature()
+    {
+        switch (kind) {
+            case TYPE_SIGNATURE:
+                return Optional.of(getTypeSignature());
+            case NAMED_TYPE_SIGNATURE:
+                return Optional.of(getNamedTypeSignature().getTypeSignature());
+            default:
+                return Optional.empty();
+        }
     }
 
     @Override
@@ -94,6 +132,10 @@ public class TypeSignatureParameter
         switch (kind) {
             case TYPE_SIGNATURE:
                 return TypeSignatureParameter.of(getTypeSignature().bindParameters(boundParameters));
+            case NAMED_TYPE_SIGNATURE:
+                return TypeSignatureParameter.of(new NamedTypeSignature(
+                        getNamedTypeSignature().getName(),
+                        getNamedTypeSignature().getTypeSignature().bindParameters(boundParameters)));
             default:
                 return this;
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignatureParameter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignatureParameter.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.type;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class TypeSignatureParameter
+{
+    private final ParameterKind kind;
+    private final Object value;
+
+    public static TypeSignatureParameter of(TypeSignature typeSignature)
+    {
+        return new TypeSignatureParameter(ParameterKind.TYPE_SIGNATURE, typeSignature);
+    }
+
+    public static TypeSignatureParameter of(long longLiteral)
+    {
+        return new TypeSignatureParameter(ParameterKind.LONG_LITERAL, longLiteral);
+    }
+
+    private TypeSignatureParameter(ParameterKind kind, Object value)
+    {
+        this.kind = requireNonNull(kind);
+        this.value = requireNonNull(value);
+    }
+
+    @Override
+    public String toString()
+    {
+        return value.toString();
+    }
+
+    public ParameterKind getKind()
+    {
+        return kind;
+    }
+
+    public <A> A getValue(ParameterKind expectedParameterKind, Class<A> target)
+    {
+        verify(kind == expectedParameterKind, format("ParameterKind is [%s] but expected [%s]", kind, expectedParameterKind));
+        return target.cast(value);
+    }
+
+    public TypeSignature getTypeSignature()
+    {
+        return getValue(ParameterKind.TYPE_SIGNATURE, TypeSignature.class);
+    }
+
+    public Long getLongLiteral()
+    {
+        return getValue(ParameterKind.LONG_LITERAL, Long.class);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TypeSignatureParameter other = (TypeSignatureParameter) o;
+
+        return Objects.equals(this.kind, other.kind) &&
+                Objects.equals(this.value, other.value);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(kind, value);
+    }
+
+    public TypeSignatureParameter bindParameters(Map<String, Type> boundParameters)
+    {
+        switch (kind) {
+            case TYPE_SIGNATURE:
+                return TypeSignatureParameter.of(getTypeSignature().bindParameters(boundParameters));
+            default:
+                return this;
+        }
+    }
+
+    private static void verify(boolean argument, String message)
+    {
+        if (!argument) {
+            throw new AssertionError(message);
+        }
+    }
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -68,28 +68,23 @@ public class TestTypeSignature
         assertRowSignature(
                 "row<bigint,varchar>('a','b')",
                 "row",
-                ImmutableList.of("bigint", "varchar"),
-                ImmutableList.of("a", "b"));
+                ImmutableList.of("a bigint", "b varchar"));
         assertRowSignature(
                 "row<bigint,array(bigint),row<bigint>('a')>('a','b','c')",
                 "row",
-                ImmutableList.of("bigint", "array(bigint)", "row<bigint>('a')"),
-                ImmutableList.of("a", "b", "c"));
+                ImmutableList.of("a bigint", "b array(bigint)", "c row<bigint>('a')"));
         assertRowSignature(
                 "row<varchar(10),row<bigint>('a')>('a','b')",
                 "row",
-                ImmutableList.of("varchar(10)", "row<bigint>('a')"),
-                ImmutableList.of("a", "b"));
+                ImmutableList.of("a varchar(10)", "b row<bigint>('a')"));
         assertRowSignature(
                 "array(row<bigint,double>('col0','col1'))",
                 "array",
-                ImmutableList.of("row<bigint,double>('col0','col1')"),
-                ImmutableList.of());
+                ImmutableList.of("row<bigint,double>('col0','col1')"));
         assertRowSignature(
                 "row<array(row<bigint,double>('col0','col1'))>('col0')",
                 "row",
-                ImmutableList.of("array(row<bigint,double>('col0','col1'))"),
-                ImmutableList.of("col0"));
+                ImmutableList.of("col0 array(row<bigint,double>('col0','col1'))"));
     }
 
     @Test
@@ -134,22 +129,20 @@ public class TestTypeSignature
     private static void assertRowSignature(
             String typeName,
             String base,
-            List<String> parameters,
-            List<Object> literalParameters)
+            List<String> parameters)
     {
-        assertSignature(typeName, base, parameters, literalParameters, typeName);
+        assertSignature(typeName, base, parameters, typeName);
     }
 
     private static void assertSignature(String typeName, String base, List<String> parameters)
     {
-        assertSignature(typeName, base, parameters, ImmutableList.of(), typeName.replace("<", "(").replace(">", ")"));
+        assertSignature(typeName, base, parameters, typeName.replace("<", "(").replace(">", ")"));
     }
 
     private static void assertSignature(
             String typeName,
             String base,
             List<String> parameters,
-            List<Object> literalParameters,
             String expectedTypeName)
     {
         TypeSignature signature = parseTypeSignature(typeName);
@@ -158,7 +151,6 @@ public class TestTypeSignature
         for (int i = 0; i < signature.getParameters().size(); i++) {
             assertEquals(signature.getParameters().get(i).toString(), parameters.get(i));
         }
-        assertEquals(signature.getLiteralParameters(), literalParameters);
         assertEquals(signature.toString(), expectedTypeName);
     }
 

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -13,75 +13,145 @@
  */
 package com.facebook.presto.spi.type;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static java.util.Locale.ENGLISH;
-import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 public class TestTypeSignature
 {
     @Test
-    public void test()
+    public void testBindParameters()
             throws Exception
     {
-        assertSignature("bigint", ImmutableList.<String>of());
-        assertSignature("boolean", ImmutableList.<String>of());
-        assertSignature("varchar", ImmutableList.<String>of());
-        assertSignature("array", ImmutableList.of("bigint"));
-        assertSignature("array", ImmutableList.of("array<bigint>"));
-        assertSignature("map", ImmutableList.of("bigint", "bigint"));
-        assertSignature("map", ImmutableList.of("bigint", "array<bigint>"));
-        assertSignature("map", ImmutableList.of("bigint", "map<bigint,map<varchar,bigint>>"));
-        assertSignature("array", ImmutableList.of("timestamp with time zone"));
-        assertSignature("row", ImmutableList.of("bigint", "varchar"), ImmutableList.<Object>of("a", "b"));
-        assertSignature("row", ImmutableList.of("bigint", "array<bigint>", "row<bigint>('a')"), ImmutableList.<Object>of("a", "b", "c"));
-        assertSignature("row", ImmutableList.of("varchar(10)", "row<bigint>('a')"), ImmutableList.<Object>of("a", "b"));
-        assertSignature("foo", ImmutableList.<String>of(), ImmutableList.<Object>of("a"));
-        assertSignature("varchar", ImmutableList.<String>of(), ImmutableList.<Object>of(10L));
+        Map<String, Type> boundParameters = ImmutableMap.of("T1", VarcharType.VARCHAR, "T2", BigintType.BIGINT);
+
+        assertBindSignature("bigint", boundParameters, "bigint");
+        assertBindSignature("T1", boundParameters, "varchar");
+        assertBindSignature("T2", boundParameters, "bigint");
+        assertBindSignature("array(T1)", boundParameters, "array(varchar)");
+        assertBindSignature("array<T1>", boundParameters, "array(varchar)");
+        assertBindSignature("map(T1,T2)", boundParameters, "map(varchar,bigint)");
+        assertBindSignature("map<T1,T2>", boundParameters, "map(varchar,bigint)");
+        assertBindSignature("row<T1,T2>('a','b')", boundParameters, "row<varchar,bigint>('a','b')");
+        assertBindSignature("bla(T1,42,T2)", boundParameters, "bla(varchar,42,bigint)");
+
+        assertBindSignatureFails("T1(bigint)", boundParameters, "Unbounded parameters can not have parameters");
+    }
+
+    private void assertBindSignatureFails(String typeName, Map<String, Type> boundParameters, String reason)
+    {
         try {
-            parseTypeSignature("blah<>");
-            fail("Type signatures with zero parameters should fail to parse");
-        }
-        catch (RuntimeException e) {
-            // Expected
-        }
-        try {
-            parseTypeSignature("blah()");
-            fail("Type signatures with zero literal parameters should fail to parse");
+            parseTypeSignature(typeName).bindParameters(boundParameters);
+            fail(reason);
         }
         catch (RuntimeException e) {
             // Expected
         }
     }
 
-    private static void assertSignature(String base, List<String> parameters)
+    private void assertBindSignature(String typeName, Map<String, Type> boundParameters, String expectedTypeName)
     {
-        assertSignature(base, parameters, ImmutableList.of());
+        assertEquals(parseTypeSignature(typeName).bindParameters(boundParameters).toString(), expectedTypeName);
     }
 
-    private static void assertSignature(String base, List<String> parameters, List<Object> literalParameters)
+    @Test
+    public void parseRowSignature()
+            throws Exception
     {
-        List<String> lowerCaseTypeNames = parameters.stream()
-                .map(value -> value.toLowerCase(ENGLISH))
-                .collect(toList());
+        assertRowSignature(
+                "row<bigint,varchar>('a','b')",
+                "row",
+                ImmutableList.of("bigint", "varchar"),
+                ImmutableList.of("a", "b"));
+        assertRowSignature(
+                "row<bigint,array(bigint),row<bigint>('a')>('a','b','c')",
+                "row",
+                ImmutableList.of("bigint", "array(bigint)", "row<bigint>('a')"),
+                ImmutableList.of("a", "b", "c"));
+        assertRowSignature(
+                "row<varchar(10),row<bigint>('a')>('a','b')",
+                "row",
+                ImmutableList.of("varchar(10)", "row<bigint>('a')"),
+                ImmutableList.of("a", "b"));
+        assertRowSignature(
+                "array(row<bigint,double>('col0','col1'))",
+                "array",
+                ImmutableList.of("row<bigint,double>('col0','col1')"),
+                ImmutableList.of());
+        assertRowSignature(
+                "row<array(row<bigint,double>('col0','col1'))>('col0')",
+                "row",
+                ImmutableList.of("array(row<bigint,double>('col0','col1'))"),
+                ImmutableList.of("col0"));
+    }
 
-        String typeName = base.toLowerCase(ENGLISH);
-        if (!parameters.isEmpty()) {
-            typeName += "<" + Joiner.on(",").join(lowerCaseTypeNames) + ">";
-        }
-        if (!literalParameters.isEmpty()) {
-            List<String> transform = literalParameters.stream()
-                    .map(TestTypeSignature::convertParameter)
-                    .collect(toList());
-            typeName += "(" + Joiner.on(",").join(transform) + ")";
-        }
+    @Test
+    public void parseSignature()
+            throws Exception
+    {
+        assertSignature("bigint", "bigint", ImmutableList.<String>of());
+        assertSignature("boolean", "boolean", ImmutableList.<String>of());
+        assertSignature("varchar", "varchar", ImmutableList.<String>of());
+
+        assertSignature("array(bigint)", "array", ImmutableList.of("bigint"));
+        assertSignature("array(array(bigint))", "array", ImmutableList.of("array(bigint)"));
+        assertSignature(
+                "array(timestamp with time zone)",
+                "array",
+                ImmutableList.of("timestamp with time zone"));
+
+        assertSignature(
+                "map(bigint,bigint)",
+                "map",
+                ImmutableList.of("bigint", "bigint"));
+        assertSignature(
+                "map(bigint,array(bigint))",
+                "map", ImmutableList.of("bigint", "array(bigint)"));
+        assertSignature(
+                "map(bigint,map(bigint,map(varchar,bigint)))",
+                "map",
+                ImmutableList.of("bigint", "map(bigint,map(varchar,bigint))"));
+
+        assertSignatureFail("blah()");
+        assertSignatureFail("array()");
+        assertSignatureFail("map()");
+    }
+
+    @Test
+    public void parseWithLiteralParameters()
+    {
+        assertSignature("foo(42)", "foo", ImmutableList.<String>of("42"));
+        assertSignature("varchar(10)", "varchar", ImmutableList.<String>of("10"));
+    }
+
+    private static void assertRowSignature(
+            String typeName,
+            String base,
+            List<String> parameters,
+            List<Object> literalParameters)
+    {
+        assertSignature(typeName, base, parameters, literalParameters, typeName);
+    }
+
+    private static void assertSignature(String typeName, String base, List<String> parameters)
+    {
+        assertSignature(typeName, base, parameters, ImmutableList.of(), typeName.replace("<", "(").replace(">", ")"));
+    }
+
+    private static void assertSignature(
+            String typeName,
+            String base,
+            List<String> parameters,
+            List<Object> literalParameters,
+            String expectedTypeName)
+    {
         TypeSignature signature = parseTypeSignature(typeName);
         assertEquals(signature.getBase(), base);
         assertEquals(signature.getParameters().size(), parameters.size());
@@ -89,14 +159,17 @@ public class TestTypeSignature
             assertEquals(signature.getParameters().get(i).toString(), parameters.get(i));
         }
         assertEquals(signature.getLiteralParameters(), literalParameters);
-        assertEquals(typeName, signature.toString());
+        assertEquals(signature.toString(), expectedTypeName);
     }
 
-    private static String convertParameter(Object value)
+    private void assertSignatureFail(String typeName)
     {
-        if (value instanceof String) {
-            return "'" + value + "'";
+        try {
+            parseTypeSignature(typeName);
+            fail("Type signatures with zero parameters should fail to parse");
         }
-        return value.toString();
+        catch (RuntimeException e) {
+            // Expected
+        }
     }
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingTypeManager.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingTypeManager.java
@@ -27,6 +27,7 @@ import static com.facebook.presto.spi.type.TestingIdType.ID;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static java.util.stream.Collectors.toList;
 
 public class TestingTypeManager
         implements TypeManager
@@ -49,8 +50,13 @@ public class TestingTypeManager
     }
 
     @Override
-    public Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<Object> literalParameters)
+    public Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<String> literalParameters)
     {
+        if (literalParameters.isEmpty()) {
+            return getParameterizedType(
+                    baseTypeName,
+                    typeParameters.stream().map(TypeSignatureParameter::of).collect(toList()));
+        }
         return getType(new TypeSignature(baseTypeName, typeParameters, literalParameters));
     }
 

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingTypeManager.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingTypeManager.java
@@ -43,6 +43,12 @@ public class TestingTypeManager
     }
 
     @Override
+    public Type getParameterizedType(String baseTypeName, List<TypeSignatureParameter> typeParameters)
+    {
+        return getType(new TypeSignature(baseTypeName, typeParameters));
+    }
+
+    @Override
     public Type getParameterizedType(String baseTypeName, List<TypeSignature> typeParameters, List<Object> literalParameters)
     {
         return getType(new TypeSignature(baseTypeName, typeParameters, literalParameters));

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4895,7 +4895,7 @@ public abstract class AbstractTestQueries
         computeActual("SELECT 1 <> 'x'");
     }
 
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "\\Qline 1:8: Unknown type: ARRAY<FOO>\\E")
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "\\Qline 1:8: Unknown type: ARRAY(FOO)\\E")
     public void testInvalidType()
     {
         computeActual("SELECT CAST(null AS array<foo>)");


### PR DESCRIPTION
This is part of the work for the following issue: https://github.com/facebook/presto/issues/3938
- generailized parametric types
- deprecated literalParameters
- added parser support for BIGINT typeParameter
- propagated TypeParameterSignature to most of previous TypeSignature uses

TODO/Questions:
- check/add backward compatibility with old clients (changes in ClientTypeSignature)
- move parseSignature to presto-main and base it on antlr