### PR TITLE
Do not escape schemaName in MySqlClient#getTables()

### DIFF
--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -91,7 +91,7 @@ public class MySqlClient
         DatabaseMetaData metadata = connection.getMetaData();
         String escape = metadata.getSearchStringEscape();
         return metadata.getTables(
-                escapeNamePattern(schemaName, escape),
+                schemaName,
                 null,
                 escapeNamePattern(tableName, escape),
                 new String[] {"TABLE"});


### PR DESCRIPTION
Do not escape schemaName in MySqlClient#getTables()

In MySqlClient#getTables() schemaName is passed as catalog parameter of
DatabaseMetaData#getTables(). It is because MySql do not have schemas.
DatabaseMetaData#getTables() requires that catalog parameter to match
catalog name. There should be no wildcards escaping there, as it does
not accept pattern as it does for tableName or schemaName.

Fixes #3763.
