### PR TITLE
Use less conflict json field name

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/index/IndexHandleJacksonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/index/IndexHandleJacksonModule.java
@@ -28,7 +28,7 @@ public class IndexHandleJacksonModule
     @Inject
     public IndexHandleJacksonModule(HandleResolver handleResolver)
     {
-        super(ConnectorIndexHandle.class, "type", new IndexHandleJsonTypeIdResolver(handleResolver));
+        super(ConnectorIndexHandle.class, "_type", new IndexHandleJsonTypeIdResolver(handleResolver));
     }
 
     private static class IndexHandleJsonTypeIdResolver

--- a/presto-main/src/main/java/com/facebook/presto/metadata/ColumnHandleJacksonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/ColumnHandleJacksonModule.java
@@ -25,7 +25,7 @@ public class ColumnHandleJacksonModule
     @Inject
     public ColumnHandleJacksonModule(HandleResolver handleResolver)
     {
-        super(ColumnHandle.class, "type", new ColumnHandleJsonTypeIdResolver(handleResolver));
+        super(ColumnHandle.class, "_type", new ColumnHandleJsonTypeIdResolver(handleResolver));
     }
 
     private static class ColumnHandleJsonTypeIdResolver

--- a/presto-main/src/main/java/com/facebook/presto/metadata/InsertTableHandleJacksonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/InsertTableHandleJacksonModule.java
@@ -25,7 +25,7 @@ public class InsertTableHandleJacksonModule
     @Inject
     public InsertTableHandleJacksonModule(HandleResolver handleResolver)
     {
-        super(ConnectorInsertTableHandle.class, "type", new InsertTableHandleJsonTypeIdResolver(handleResolver));
+        super(ConnectorInsertTableHandle.class, "_type", new InsertTableHandleJsonTypeIdResolver(handleResolver));
     }
 
     private static class InsertTableHandleJsonTypeIdResolver

--- a/presto-main/src/main/java/com/facebook/presto/metadata/OutputTableHandleJacksonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/OutputTableHandleJacksonModule.java
@@ -25,7 +25,7 @@ public class OutputTableHandleJacksonModule
     @Inject
     public OutputTableHandleJacksonModule(HandleResolver handleResolver)
     {
-        super(ConnectorOutputTableHandle.class, "type", new OutputTableHandleJsonTypeIdResolver(handleResolver));
+        super(ConnectorOutputTableHandle.class, "_type", new OutputTableHandleJsonTypeIdResolver(handleResolver));
     }
 
     private static class OutputTableHandleJsonTypeIdResolver

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SplitJacksonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SplitJacksonModule.java
@@ -25,7 +25,7 @@ public class SplitJacksonModule
     @Inject
     public SplitJacksonModule(HandleResolver handleResolver)
     {
-        super(ConnectorSplit.class, "type", new SplitJsonTypeIdResolver(handleResolver));
+        super(ConnectorSplit.class, "_type", new SplitJsonTypeIdResolver(handleResolver));
     }
 
     private static class SplitJsonTypeIdResolver

--- a/presto-main/src/main/java/com/facebook/presto/metadata/TableHandleJacksonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/TableHandleJacksonModule.java
@@ -25,7 +25,7 @@ public class TableHandleJacksonModule
     @Inject
     public TableHandleJacksonModule(HandleResolver handleResolver)
     {
-        super(ConnectorTableHandle.class, "type", new TableHandleJsonTypeIdResolver(handleResolver));
+        super(ConnectorTableHandle.class, "_type", new TableHandleJsonTypeIdResolver(handleResolver));
     }
 
     private static class TableHandleJsonTypeIdResolver

--- a/presto-main/src/main/java/com/facebook/presto/metadata/TableLayoutHandleJacksonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/TableLayoutHandleJacksonModule.java
@@ -25,7 +25,7 @@ public class TableLayoutHandleJacksonModule
     @Inject
     public TableLayoutHandleJacksonModule(HandleResolver handleResolver)
     {
-        super(ConnectorTableLayoutHandle.class, "type", new TableLayoutHandleJsonTypeIdResolver(handleResolver));
+        super(ConnectorTableLayoutHandle.class, "_type", new TableLayoutHandleJsonTypeIdResolver(handleResolver));
     }
 
     private static class TableLayoutHandleJsonTypeIdResolver

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNode.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
-        property = "type")
+        property = "_type")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = OutputNode.class, name = "output"),
         @JsonSubTypes.Type(value = ProjectNode.class, name = "project"),

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestJsonTableHandle.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestJsonTableHandle.java
@@ -43,12 +43,12 @@ import static org.testng.Assert.assertTrue;
 @Test(singleThreaded = true)
 public class TestJsonTableHandle
 {
-    private static final Map<String, Object> SYSTEM_AS_MAP = ImmutableMap.<String, Object>of("type", "system",
+    private static final Map<String, Object> SYSTEM_AS_MAP = ImmutableMap.<String, Object>of("_type", "system",
             "schemaName", "system_schema",
             "tableName", "system_table");
 
     private static final Map<String, Object> INFORMATION_SCHEMA_AS_MAP = ImmutableMap.<String, Object>of(
-            "type", "information_schema",
+            "_type", "information_schema",
             "catalogName", "information_schema_catalog",
             "schemaName", "information_schema_schema",
             "tableName", "information_schema_table"


### PR DESCRIPTION
I found some cases same json field names were being used in the same object.

`PlanNode.type` and `JoinNode` type have some property name. And the following is the capture of JSON  
```
                    "source" : {
                      "type" : "join”,             <==
                      "id" : "34",
                      "type" : "INNER”,         <==
                      "left" : { … }
                      “right” : { … }
                    }
```
`TpchColumnHandle.type` has similar issue with `ColumnHandleJacksonModule.type`. But the jackson seems to be smart enough to handle it. But once before, when I used `@JsonProperty("type")` in one of `ColumnHandle`, Presto didn't find correct resolver. So I had to rename it into `@JsonProperty("columnType")`

And another problem is when I build a simple tool which directly use json from `/v1/query/{query_id}`. Other json parser could not handle the conflicted key correctly.