### PR TITLE
Disable parallel with Smart Builder by default

### DIFF
--- a/.mvn/README.md
+++ b/.mvn/README.md
@@ -1,0 +1,13 @@
+# Parallel Build with Smart Builder
+
+Add this line if you want to use the Smart Builder with 8 threads:
+
+`-T 8 -b smart`
+
+Enabling this by default causes issues with tests as it usually consumes more resources than a normal laptop has, and it also causes issues with the maven-release-plugin.
+
+If you are working in a mode where you are not running the tests than turning on this option may be more convenient.
+
+Note that you can still use this option from the command line and it will override the default single threaded builder listed the `.mvn/maven.config`.
+
+

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,1 @@
--T 8
---builder smart
+-b singlethreaded


### PR DESCRIPTION
There are issues with being aggressively parallel running tests for Presto. There are
generally not enough resources on a typical laptop to use the Smart Builder with 8 threads.
We are also seeing issues with the maven-release-plugin.