### PR TITLE
Replace deprecated JsonFactory API calls

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/JsonBenchmarkResultWriter.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/JsonBenchmarkResultWriter.java
@@ -33,7 +33,7 @@ public class JsonBenchmarkResultWriter
     {
         requireNonNull(outputStream, "outputStream is null");
         try {
-            jsonGenerator = new JsonFactory().createJsonGenerator(outputStream, JsonEncoding.UTF8);
+            jsonGenerator = new JsonFactory().createGenerator(outputStream, JsonEncoding.UTF8);
             jsonGenerator.writeStartObject();
             jsonGenerator.writeArrayFieldStart("samples");
         }

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/OdsBenchmarkResultWriter.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/OdsBenchmarkResultWriter.java
@@ -36,7 +36,7 @@ public class OdsBenchmarkResultWriter
         requireNonNull(outputStream, "outputStream is null");
         this.entity = entity;
         try {
-            jsonGenerator = new JsonFactory().createJsonGenerator(outputStream, JsonEncoding.UTF8);
+            jsonGenerator = new JsonFactory().createGenerator(outputStream, JsonEncoding.UTF8);
             jsonGenerator.writeStartArray();
         }
         catch (IOException e) {

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraType.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraType.java
@@ -47,7 +47,7 @@ public class TestCassandraType
         boolean valid = false;
         try {
             JsonParser parser = new ObjectMapper().getFactory()
-                    .createJsonParser(json);
+                    .createParser(json);
             continueWhileNotNull(parser, parser.nextToken());
             valid = true;
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonExtract.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonExtract.java
@@ -125,7 +125,7 @@ public final class JsonExtract
     {
         requireNonNull(jsonInput, "jsonInput is null");
         try {
-            try (JsonParser jsonParser = JSON_FACTORY.createJsonParser(jsonInput.getInput())) {
+            try (JsonParser jsonParser = JSON_FACTORY.createParser(jsonInput.getInput())) {
                 // Initialize by advancing to first token and make sure it exists
                 if (jsonParser.nextToken() == null) {
                     throw new JsonParseException("Missing starting token", jsonParser.getCurrentLocation());
@@ -288,7 +288,7 @@ public final class JsonExtract
             }
 
             DynamicSliceOutput dynamicSliceOutput = new DynamicSliceOutput(ESTIMATED_JSON_OUTPUT_SIZE);
-            try (JsonGenerator jsonGenerator = JSON_FACTORY.createJsonGenerator(dynamicSliceOutput)) {
+            try (JsonGenerator jsonGenerator = JSON_FACTORY.createGenerator(dynamicSliceOutput)) {
                 jsonGenerator.copyCurrentStructure(jsonParser);
             }
             return dynamicSliceOutput.slice();

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
@@ -124,7 +124,7 @@ public final class JsonFunctions
     @SqlType(StandardTypes.BIGINT)
     public static Long jsonArrayLength(@SqlType(StandardTypes.JSON) Slice json)
     {
-        try (JsonParser parser = JSON_FACTORY.createJsonParser(json.getInput())) {
+        try (JsonParser parser = JSON_FACTORY.createParser(json.getInput())) {
             if (parser.nextToken() != START_ARRAY) {
                 return null;
             }
@@ -161,7 +161,7 @@ public final class JsonFunctions
     @SqlType(StandardTypes.BOOLEAN)
     public static Boolean jsonArrayContains(@SqlType(StandardTypes.JSON) Slice json, @SqlType(StandardTypes.BOOLEAN) boolean value)
     {
-        try (JsonParser parser = JSON_FACTORY.createJsonParser(json.getInput())) {
+        try (JsonParser parser = JSON_FACTORY.createParser(json.getInput())) {
             if (parser.nextToken() != START_ARRAY) {
                 return null;
             }
@@ -200,7 +200,7 @@ public final class JsonFunctions
     @SqlType(StandardTypes.BOOLEAN)
     public static Boolean jsonArrayContains(@SqlType(StandardTypes.JSON) Slice json, @SqlType(StandardTypes.BIGINT) long value)
     {
-        try (JsonParser parser = JSON_FACTORY.createJsonParser(json.getInput())) {
+        try (JsonParser parser = JSON_FACTORY.createParser(json.getInput())) {
             if (parser.nextToken() != START_ARRAY) {
                 return null;
             }
@@ -244,7 +244,7 @@ public final class JsonFunctions
             return false;
         }
 
-        try (JsonParser parser = JSON_FACTORY.createJsonParser(json.getInput())) {
+        try (JsonParser parser = JSON_FACTORY.createParser(json.getInput())) {
             if (parser.nextToken() != START_ARRAY) {
                 return null;
             }
@@ -286,7 +286,7 @@ public final class JsonFunctions
     {
         String valueString = value.toString(UTF_8);
 
-        try (JsonParser parser = JSON_FACTORY.createJsonParser(json.getInput())) {
+        try (JsonParser parser = JSON_FACTORY.createParser(json.getInput())) {
             if (parser.nextToken() != START_ARRAY) {
                 return null;
             }
@@ -324,7 +324,7 @@ public final class JsonFunctions
     @SqlType(StandardTypes.JSON)
     public static Slice jsonArrayGet(@SqlType(StandardTypes.JSON) Slice json, @SqlType(StandardTypes.BIGINT) long index)
     {
-        try (JsonParser parser = MAPPING_JSON_FACTORY.createJsonParser(json.getInput())) {
+        try (JsonParser parser = MAPPING_JSON_FACTORY.createParser(json.getInput())) {
             if (parser.nextToken() != START_ARRAY) {
                 return null;
             }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
@@ -321,7 +321,7 @@ public class TestJsonExtract
             throws IOException
     {
         JsonFactory jsonFactory = new JsonFactory();
-        JsonParser jsonParser = jsonFactory.createJsonParser(json);
+        JsonParser jsonParser = jsonFactory.createParser(json);
         jsonParser.nextToken(); // Advance to the first token
         Slice extract = jsonExtractor.extract(jsonParser);
         return (extract == null) ? null : extract.toString(UTF_8);


### PR DESCRIPTION
This PR replaces the deprecated `JsonFactory` API calls `createJsonGenerator()` and `createJsonParser()`.