### PR TITLE
Hide release notes from main table of contents

### DIFF
--- a/presto-docs/src/main/sphinx/index.rst
+++ b/presto-docs/src/main/sphinx/index.rst
@@ -16,3 +16,5 @@ Presto Documentation
     migration
     develop
     release
+
+.. Note: If "release" is not the last item, the CSS must be updated.

--- a/presto-docs/src/main/sphinx/themes/presto/static/presto.css_t
+++ b/presto-docs/src/main/sphinx/themes/presto/static/presto.css_t
@@ -112,3 +112,8 @@ tt.docutils.literal, code.docutils.literal {
     border-radius: 3px;
     white-space: nowrap;
 }
+
+/* hide children of Release Notes */
+div.toctree-wrapper > ul > li:last-child > ul {
+    display: none;
+}


### PR DESCRIPTION
The ever-growing list of release notes makes the table of contents harder
read, such as when scrolling to the end to see the SQL statement syntax.