### PR TITLE
Fix two typos in session properties descriptions

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -53,7 +53,7 @@ public final class HiveSessionProperties
                         true),
                 dataSizeSessionProperty(
                         ORC_MAX_MERGE_DISTANCE,
-                        "ORC: Maximum size of gap between to reads to merge into a single read",
+                        "ORC: Maximum size of gap between two reads to merge into a single read",
                         config.getOrcMaxMergeDistance(),
                         false),
                 dataSizeSessionProperty(

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSessionProperties.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSessionProperties.java
@@ -48,7 +48,7 @@ public class RaptorSessionProperties
                         true),
                 dataSizeSessionProperty(
                         READER_MAX_MERGE_DISTANCE,
-                        "Reader: Maximum size of gap between to reads to merge into a single read",
+                        "Reader: Maximum size of gap between two reads to merge into a single read",
                         config.getOrcMaxMergeDistance(),
                         false),
                 dataSizeSessionProperty(


### PR DESCRIPTION
'to' should be 'two'