### PR TITLE
Create new SQL type P4HyperLogLog for dense LogLog

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/HyperLogLogOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/HyperLogLogOperators.java
@@ -16,6 +16,7 @@ package com.facebook.presto.type;
 import com.facebook.presto.operator.scalar.ScalarOperator;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
+import io.airlift.stats.cardinality.HyperLogLog;
 
 import static com.facebook.presto.metadata.OperatorType.CAST;
 
@@ -35,6 +36,22 @@ public final class HyperLogLogOperators
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.HYPER_LOG_LOG)
     public static Slice castFromVarbinary(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        return slice;
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.P4_HYPER_LOG_LOG)
+    public static Slice castToP4Hll(@SqlType(StandardTypes.HYPER_LOG_LOG) Slice slice)
+    {
+        HyperLogLog hll = HyperLogLog.newInstance(slice);
+        hll.makeDense();
+        return hll.serialize();
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.HYPER_LOG_LOG)
+    public static Slice castFromP4Hll(@SqlType(StandardTypes.P4_HYPER_LOG_LOG) Slice slice)
     {
         return slice;
     }

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -37,6 +37,7 @@ import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.spi.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
 import static com.facebook.presto.spi.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+import static com.facebook.presto.spi.type.P4HyperLogLogType.P4_HYPER_LOG_LOG;
 import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
@@ -92,6 +93,7 @@ public final class TypeRegistry
         addType(INTERVAL_YEAR_MONTH);
         addType(INTERVAL_DAY_TIME);
         addType(HYPER_LOG_LOG);
+        addType(P4_HYPER_LOG_LOG);
         addType(REGEXP);
         addType(LIKE_PATTERN);
         addType(JSON_PATH);
@@ -205,6 +207,8 @@ public final class TypeRegistry
                 return StandardTypes.TIMESTAMP_WITH_TIME_ZONE.equals(toTypeBase);
             case StandardTypes.VARCHAR:
                 return RegexpType.NAME.equals(toTypeBase) || LikePatternType.NAME.equals(toTypeBase) || JsonPathType.NAME.equals(toTypeBase);
+            case StandardTypes.P4_HYPER_LOG_LOG:
+                return StandardTypes.HYPER_LOG_LOG.equals(toTypeBase);
         }
         return false;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/P4HyperLogLogType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/P4HyperLogLogType.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.type;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.spi.type.HyperLogLogType.HYPER_LOG_LOG;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+
+public class P4HyperLogLogType
+    extends AbstractVariableWidthType
+{
+    public static final P4HyperLogLogType P4_HYPER_LOG_LOG = new P4HyperLogLogType();
+
+    @JsonCreator
+    public P4HyperLogLogType()
+    {
+        super(parseTypeSignature(StandardTypes.P4_HYPER_LOG_LOG), Slice.class);
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        HYPER_LOG_LOG.appendTo(block, position, blockBuilder);
+    }
+
+    @Override
+    public Slice getSlice(Block block, int position)
+    {
+        return HYPER_LOG_LOG.getSlice(block, position);
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value)
+    {
+        HYPER_LOG_LOG.writeSlice(blockBuilder, value);
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
+    {
+        HYPER_LOG_LOG.writeSlice(blockBuilder, value, offset, length);
+    }
+
+    @Override
+    public Object getObjectValue(ConnectorSession session, Block block, int position)
+    {
+        return HYPER_LOG_LOG.getObjectValue(session, block, position);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/StandardTypes.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/StandardTypes.java
@@ -20,6 +20,7 @@ public final class StandardTypes
     public static final String DATE = "date";
     public static final String DOUBLE = "double";
     public static final String HYPER_LOG_LOG = "HyperLogLog";
+    public static final String P4_HYPER_LOG_LOG = "P4HyperLogLog";
     public static final String INTERVAL_DAY_TO_SECOND = "interval day to second";
     public static final String INTERVAL_YEAR_TO_MONTH = "interval year to month";
     public static final String TIMESTAMP = "timestamp";

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5192,6 +5192,160 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testP4ApproxSetBigint()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("SELECT cardinality(cast(approx_set(custkey) AS P4HYPERLOGLOG)) FROM orders");
+
+        MaterializedResult expected = resultBuilder(getSession(), BIGINT)
+                .row(1002)
+                .build();
+
+        assertEquals(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testP4ApproxSetVarchar()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("SELECT cardinality(cast(approx_set(CAST(custkey AS VARCHAR)) AS P4HYPERLOGLOG)) FROM orders");
+
+        MaterializedResult expected = resultBuilder(getSession(), BIGINT)
+                .row(1024)
+                .build();
+
+        assertEquals(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testP4ApproxSetDouble()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("SELECT cardinality(cast(approx_set(CAST(custkey AS DOUBLE)) AS P4HYPERLOGLOG)) FROM orders");
+
+        MaterializedResult expected = resultBuilder(getSession(), BIGINT)
+                .row(1014)
+                .build();
+
+        assertEquals(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testP4ApproxSetBigintGroupBy()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT orderstatus, cardinality(cast(approx_set(custkey) AS P4HYPERLOGLOG)) " +
+                "FROM orders " +
+                "GROUP BY orderstatus");
+
+        MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
+                .row("O", 1001)
+                .row("F", 998)
+                .row("P", 308)
+                .build();
+
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testP4ApproxSetVarcharGroupBy()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT orderstatus, cardinality(cast(approx_set(CAST(custkey AS VARCHAR)) AS P4HYPERLOGLOG)) " +
+                "FROM orders " +
+                "GROUP BY orderstatus");
+
+        MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
+                .row("O", 1021)
+                .row("F", 1019)
+                .row("P", 302)
+                .build();
+
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testP4ApproxSetDoubleGroupBy()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT orderstatus, cardinality(cast(approx_set(CAST(custkey AS DOUBLE)) AS P4HYPERLOGLOG)) " +
+                "FROM orders " +
+                "GROUP BY orderstatus");
+
+        MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
+                .row("O", 1011)
+                .row("F", 1011)
+                .row("P", 306)
+                .build();
+
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testP4ApproxSetWithNulls()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("SELECT cardinality(cast(approx_set(IF(orderstatus = 'O', custkey)) AS P4HYPERLOGLOG)) FROM orders");
+
+        MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
+                .row(1001)
+                .build();
+
+        assertEquals(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testP4ApproxSetOnlyNulls()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("SELECT cardinality(cast(approx_set(null) AS P4HYPERLOGLOG)) FROM orders");
+
+        MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
+                .row(new Object[] { null })
+                .build();
+
+        assertEquals(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testP4ApproxSetGroupByWithOnlyNullsInOneGroup()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT orderstatus, cardinality(cast(approx_set(IF(orderstatus != 'O', custkey)) AS P4HYPERLOGLOG)) " +
+                "FROM orders " +
+                "GROUP BY orderstatus");
+
+        MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
+                .row("O", null)
+                .row("F", 998)
+                .row("P", 308)
+                .build();
+
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testP4ApproxSetGroupByWithNulls()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("" +
+                "SELECT orderstatus, cardinality(cast(approx_set(IF(custkey % 2 <> 0, custkey)) AS P4HYPERLOGLOG)) " +
+                "FROM orders " +
+                "GROUP BY orderstatus");
+
+        MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
+                .row("O", 495)
+                .row("F", 491)
+                .row("P", 153)
+                .build();
+
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+    @Test
     public void testValuesWithNonTrivialType()
             throws Exception
     {


### PR DESCRIPTION

P4HyperLogLog implicitly coerces to HyperLogLog, while the latter can be explicitly
cast into P4Hll with "CAST( xxx TO xxx )". Implementation is minimal since we just
need to take care of the type conversion (canCoerce(), and CAST operators), and the
value conversion, which is done by extracting the airlift HLL instance from slice
and then force it into dense form