### PR TITLE
Throw exception when using SET/RESET SESSION from JDBC

### DIFF
--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcResultSet.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcResultSet.java
@@ -26,6 +26,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.sql.Types;
 
@@ -130,6 +131,20 @@ public class TestJdbcResultSet
             assertFalse(rs.next());
             assertNotNull(rs.getStats());
         }
+    }
+
+    @Test(expectedExceptions = SQLFeatureNotSupportedException.class, expectedExceptionsMessageRegExp = "SET/RESET SESSION")
+    public void testSetSession()
+        throws Exception
+    {
+        statement.execute("SET SESSION hash_partition_count=16");
+    }
+
+    @Test(expectedExceptions = SQLFeatureNotSupportedException.class, expectedExceptionsMessageRegExp = "SET/RESET SESSION")
+    public void testResetSession()
+        throws Exception
+    {
+        statement.execute("RESET SESSION hash_partition_count");
     }
 
     private Connection createConnection()


### PR DESCRIPTION
Throw exception when SET SESSION or RESET SESSION commands used from JDBC because they do not affect anything yet.
Related issue: #4054 