### PR TITLE
Remove useless stack traces in verifier

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/ErrorCode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ErrorCode.java
@@ -16,6 +16,8 @@ package com.facebook.presto.spi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 import static java.util.Objects.requireNonNull;
 
 public final class ErrorCode
@@ -49,5 +51,25 @@ public final class ErrorCode
     public String toString()
     {
         return name + ":" + code;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        ErrorCode that = (ErrorCode) obj;
+        return Objects.equals(this.code, that.code);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(code);
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Verifier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Verifier.java
@@ -13,8 +13,12 @@
  */
 package com.facebook.presto.verifier;
 
+import com.facebook.presto.spi.ErrorCode;
+import com.facebook.presto.spi.PrestoException;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.event.client.EventClient;
 import io.airlift.log.Logger;
 
@@ -26,6 +30,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 
+import static com.facebook.presto.spi.StandardErrorCode.PAGE_TRANSPORT_TIMEOUT;
+import static com.facebook.presto.spi.StandardErrorCode.TOO_MANY_REQUESTS_FAILED;
+import static com.facebook.presto.spi.StandardErrorCode.WORKER_RESTARTED;
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -35,6 +42,11 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class Verifier
 {
     private static final Logger log = Logger.get(Verifier.class);
+    private static final Set<ErrorCode> EXPECTED_ERRORS = ImmutableSet.<ErrorCode>builder()
+            .add(WORKER_RESTARTED.toErrorCode())
+            .add(TOO_MANY_REQUESTS_FAILED.toErrorCode())
+            .add(PAGE_TRANSPORT_TIMEOUT.toErrorCode())
+            .build();
 
     private final VerifierConfig config;
     private final Set<EventClient> eventClients;
@@ -143,8 +155,9 @@ public class Verifier
 
         if (!validator.valid()) {
             errorMessage = format("Test state %s, Control state %s\n", test.getState(), control.getState());
-            if (test.getException() != null) {
-                errorMessage += getStackTraceAsString(test.getException());
+            Exception e = test.getException();
+            if (e != null && shouldAddStackTrace(e)) {
+                errorMessage += getStackTraceAsString(e);
             }
             else {
                 errorMessage += validator.getResultsComparison(precision).trim();
@@ -197,5 +210,16 @@ public class Verifier
                 validator.valid();
             }
         };
+    }
+
+    private static boolean shouldAddStackTrace(Exception e)
+    {
+        if (e instanceof PrestoException) {
+            ErrorCode errorCode = ((PrestoException) e).getErrorCode();
+            if (EXPECTED_ERRORS.contains(errorCode)) {
+                return false;
+            }
+        }
+        return true;
     }
 }


### PR DESCRIPTION
Exclude stack traces in Verifier for below exceptions:

- `TOO_MANY_REQUESTS_FAILED`
- `PAGE_TRANSPORT_TIMEOUT`
- `WORKER_RESTARTED`

Related issue: #3955