### PR TITLE
Some fixes related to unknown type

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/byteCode/instruction/TypeInstruction.java
+++ b/presto-main/src/main/java/com/facebook/presto/byteCode/instruction/TypeInstruction.java
@@ -118,4 +118,10 @@ public class TypeInstruction
     {
         return visitor.visitInstruction(parent, this);
     }
+
+    @Override
+    public String toString()
+    {
+        return opCode + " " + type;
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -42,6 +42,7 @@ import com.facebook.presto.operator.scalar.ArrayFunctions;
 import com.facebook.presto.operator.scalar.ColorFunctions;
 import com.facebook.presto.operator.scalar.CombineHashFunction;
 import com.facebook.presto.operator.scalar.DateTimeFunctions;
+import com.facebook.presto.operator.scalar.FailureFunction;
 import com.facebook.presto.operator.scalar.HyperLogLogFunctions;
 import com.facebook.presto.operator.scalar.JsonFunctions;
 import com.facebook.presto.operator.scalar.JsonOperators;
@@ -337,6 +338,7 @@ public class FunctionRegistry
                 .scalar(ArrayFunctions.class)
                 .scalar(CombineHashFunction.class)
                 .scalar(JsonOperators.class)
+                .scalar(FailureFunction.class)
                 .functions(IDENTITY_CAST, CAST_FROM_UNKNOWN)
                 .functions(ARRAY_CONTAINS, ARRAY_JOIN, ARRAY_JOIN_WITH_NULL_REPLACEMENT)
                 .functions(ARRAY_MIN, ARRAY_MAX)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -165,6 +165,7 @@ import static com.facebook.presto.operator.scalar.ArraySubscriptOperator.ARRAY_S
 import static com.facebook.presto.operator.scalar.ArrayToArrayCast.ARRAY_TO_ARRAY_CAST;
 import static com.facebook.presto.operator.scalar.ArrayToElementConcatFunction.ARRAY_TO_ELEMENT_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayToJsonCast.ARRAY_TO_JSON;
+import static com.facebook.presto.operator.scalar.CastFromUnknownOperator.CAST_FROM_UNKNOWN;
 import static com.facebook.presto.operator.scalar.ConcatFunction.CONCAT;
 import static com.facebook.presto.operator.scalar.ElementToArrayConcatFunction.ELEMENT_TO_ARRAY_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.Greatest.GREATEST;
@@ -336,7 +337,7 @@ public class FunctionRegistry
                 .scalar(ArrayFunctions.class)
                 .scalar(CombineHashFunction.class)
                 .scalar(JsonOperators.class)
-                .function(IDENTITY_CAST)
+                .functions(IDENTITY_CAST, CAST_FROM_UNKNOWN)
                 .functions(ARRAY_CONTAINS, ARRAY_JOIN, ARRAY_JOIN_WITH_NULL_REPLACEMENT)
                 .functions(ARRAY_MIN, ARRAY_MAX)
                 .functions(ARRAY_TO_ARRAY_CAST, ARRAY_HASH_CODE, ARRAY_EQUAL, ARRAY_NOT_EQUAL, ARRAY_LESS_THAN, ARRAY_LESS_THAN_OR_EQUAL, ARRAY_GREATER_THAN, ARRAY_GREATER_THAN_OR_EQUAL)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/CastFromUnknownOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/CastFromUnknownOperator.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.SqlOperator;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.OperatorType.CAST;
+import static com.facebook.presto.metadata.Signature.typeParameter;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public final class CastFromUnknownOperator
+        extends SqlOperator
+{
+    public static final CastFromUnknownOperator CAST_FROM_UNKNOWN = new CastFromUnknownOperator();
+    private static final MethodHandle METHOD_HANDLE_LONG = methodHandle(CastFromUnknownOperator.class, "toLong", Void.class);
+    private static final MethodHandle METHOD_HANDLE_DOUBLE = methodHandle(CastFromUnknownOperator.class, "toDouble", Void.class);
+    private static final MethodHandle METHOD_HANDLE_BOOLEAN = methodHandle(CastFromUnknownOperator.class, "toBoolean", Void.class);
+    private static final MethodHandle METHOD_HANDLE_SLICE = methodHandle(CastFromUnknownOperator.class, "toSlice", Void.class);
+    private static final MethodHandle METHOD_HANDLE_OBJECT = methodHandle(CastFromUnknownOperator.class, "toObject", Void.class);
+
+    public CastFromUnknownOperator()
+    {
+        super(CAST, ImmutableList.of(typeParameter("E")), "E", ImmutableList.of("unknown"));
+    }
+
+    @Override
+    public ScalarFunctionImplementation specialize(Map<String, Type> types, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        Type toType = types.get("E");
+        MethodHandle methodHandle;
+        if (toType.getJavaType() == long.class) {
+            methodHandle = METHOD_HANDLE_LONG;
+        }
+        else if (toType.getJavaType() == double.class) {
+            methodHandle = METHOD_HANDLE_DOUBLE;
+        }
+        else if (toType.getJavaType() == boolean.class) {
+            methodHandle = METHOD_HANDLE_BOOLEAN;
+        }
+        else if (toType.getJavaType() == Slice.class) {
+            methodHandle = METHOD_HANDLE_SLICE;
+        }
+        else {
+            methodHandle = METHOD_HANDLE_OBJECT.asType(METHOD_HANDLE_OBJECT.type().changeReturnType(toType.getJavaType()));
+        }
+        return new ScalarFunctionImplementation(true, ImmutableList.of(true), methodHandle, isDeterministic());
+    }
+
+    public static Long toLong(Void arg)
+    {
+        return null;
+    }
+
+    public static Double toDouble(Void arg)
+    {
+        return null;
+    }
+
+    public static Boolean toBoolean(Void arg)
+    {
+        return null;
+    }
+
+    public static Slice toSlice(Void arg)
+    {
+        return null;
+    }
+
+    public static Object toObject(Void arg)
+    {
+        return null;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/FailureFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/FailureFunction.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.client.FailureInfo;
+import com.facebook.presto.operator.Description;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.type.SqlType;
+import io.airlift.json.JsonCodec;
+import io.airlift.slice.Slice;
+
+public final class FailureFunction
+{
+    private static final JsonCodec<FailureInfo> JSON_CODEC = JsonCodec.jsonCodec(FailureInfo.class);
+
+    private FailureFunction() {}
+
+    // We shouldn't be using UNKNOWN as an explicit type. This will be fixed when we fix type inference
+    @Description("Decodes json to an exception and throws it")
+    @ScalarFunction
+    @SqlType("unknown")
+    public static void fail(@SqlType(StandardTypes.JSON) Slice failureInfo)
+    {
+        throw JSON_CODEC.fromJson(failureInfo.getBytes()).toException();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/FailureFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/FailureFunction.java
@@ -15,6 +15,8 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.operator.Description;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.type.SqlType;
 import io.airlift.json.JsonCodec;
@@ -30,8 +32,10 @@ public final class FailureFunction
     @Description("Decodes json to an exception and throws it")
     @ScalarFunction
     @SqlType("unknown")
-    public static void fail(@SqlType(StandardTypes.JSON) Slice failureInfo)
+    public static void fail(@SqlType(StandardTypes.JSON) Slice failureInfoSlice)
     {
-        throw JSON_CODEC.fromJson(failureInfo.getBytes()).toException();
+        FailureInfo failureInfo = JSON_CODEC.fromJson(failureInfoSlice.getBytes());
+        // wrap the failure in a new exception to append the current stack trace
+        throw new PrestoException(StandardErrorCode.USER_ERROR, failureInfo.toException());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/AddFakeLineNumberClassVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/AddFakeLineNumberClassVisitor.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.gen;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+
+import static org.objectweb.asm.Opcodes.ASM5;
+
+class AddFakeLineNumberClassVisitor
+        extends ClassVisitor
+{
+    int methodCount;
+
+    public AddFakeLineNumberClassVisitor(ClassVisitor cv)
+    {
+        super(ASM5, cv);
+        super.visitSource("FakeSource.java", null);
+    }
+
+    @Override
+    public void visitSource(String source, String debug)
+    {
+        super.visitSource(source, debug);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions)
+    {
+        MethodVisitor methodVisitor = cv.visitMethod(access, name, desc, signature, exceptions);
+        methodCount++;
+        return new AddFakeLineNumberMethodVisitor(methodVisitor, 1000 * methodCount);
+    }
+
+    private static class AddFakeLineNumberMethodVisitor
+            extends MethodVisitor
+    {
+        private int count;
+
+        public AddFakeLineNumberMethodVisitor(MethodVisitor mv, int startLineNumber)
+        {
+            super(ASM5, mv);
+            this.count = startLineNumber;
+        }
+
+        private void addFakeLineNumber()
+        {
+            Label label = new Label();
+            mv.visitLabel(label);
+            mv.visitLineNumber(++count, label);
+        }
+
+        @Override
+        public void visitInsn(int opcode)
+        {
+            addFakeLineNumber();
+            super.visitInsn(opcode);
+        }
+
+        @Override
+        public void visitIntInsn(int opcode, int operand)
+        {
+            addFakeLineNumber();
+            super.visitIntInsn(opcode, operand);
+        }
+
+        @Override
+        public void visitVarInsn(int opcode, int var)
+        {
+            addFakeLineNumber();
+            super.visitVarInsn(opcode, var);
+        }
+
+        @Override
+        public void visitTypeInsn(int opcode, String type)
+        {
+            addFakeLineNumber();
+            super.visitTypeInsn(opcode, type);
+        }
+
+        @Override
+        public void visitFieldInsn(int opcode, String owner, String name, String desc)
+        {
+            addFakeLineNumber();
+            super.visitFieldInsn(opcode, owner, name, desc);
+        }
+
+        @Override
+        public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf)
+        {
+            addFakeLineNumber();
+            super.visitMethodInsn(opcode, owner, name, desc, itf);
+        }
+
+        @Override
+        public void visitInvokeDynamicInsn(String name, String desc, Handle bsm, Object... bsmArgs)
+        {
+            addFakeLineNumber();
+            super.visitInvokeDynamicInsn(name, desc, bsm, bsmArgs);
+        }
+
+        @Override
+        public void visitJumpInsn(int opcode, Label label)
+        {
+            addFakeLineNumber();
+            super.visitJumpInsn(opcode, label);
+        }
+
+        @Override
+        public void visitLdcInsn(Object cst)
+        {
+            addFakeLineNumber();
+            super.visitLdcInsn(cst);
+        }
+
+        @Override
+        public void visitIincInsn(int var, int increment)
+        {
+            addFakeLineNumber();
+            super.visitIincInsn(var, increment);
+        }
+
+        @Override
+        public void visitTableSwitchInsn(int min, int max, Label dflt, Label... labels)
+        {
+            addFakeLineNumber();
+            super.visitTableSwitchInsn(min, max, dflt, labels);
+        }
+
+        @Override
+        public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels)
+        {
+            addFakeLineNumber();
+            super.visitLookupSwitchInsn(dflt, keys, labels);
+        }
+
+        @Override
+        public void visitMultiANewArrayInsn(String desc, int dims)
+        {
+            addFakeLineNumber();
+            super.visitMultiANewArrayInsn(desc, dims);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CastCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CastCodeGenerator.java
@@ -13,17 +13,13 @@
  */
 package com.facebook.presto.sql.gen;
 
-import com.facebook.presto.byteCode.ByteCodeBlock;
 import com.facebook.presto.byteCode.ByteCodeNode;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.relational.RowExpression;
-import com.facebook.presto.type.UnknownType;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-
-import static com.facebook.presto.byteCode.expression.ByteCodeExpressions.constantTrue;
 
 public class CastCodeGenerator
         implements ByteCodeGenerator
@@ -32,12 +28,6 @@ public class CastCodeGenerator
     public ByteCodeNode generateExpression(Signature signature, ByteCodeGeneratorContext generatorContext, Type returnType, List<RowExpression> arguments)
     {
         RowExpression argument = arguments.get(0);
-
-        if (argument.getType().equals(UnknownType.UNKNOWN)) {
-            return new ByteCodeBlock()
-                    .append(generatorContext.wasNull().set(constantTrue()))
-                    .pushJavaDefault(returnType.getJavaType());
-        }
 
         Signature function = generatorContext
                 .getRegistry()

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CompilerUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CompilerUtils.java
@@ -136,7 +136,7 @@ public final class CompilerUtils
         if (DUMP_BYTE_CODE_RAW) {
             for (byte[] byteCode : byteCodes.values()) {
                 ClassReader classReader = new ClassReader(byteCode);
-                classReader.accept(new TraceClassVisitor(new PrintWriter(System.err)), ClassReader.SKIP_FRAMES);
+                classReader.accept(new TraceClassVisitor(new PrintWriter(System.err)), ClassReader.EXPAND_FRAMES);
             }
         }
         Map<String, Class<?>> classes = classLoader.defineClasses(byteCodes);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CompilerUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CompilerUtils.java
@@ -48,6 +48,7 @@ public final class CompilerUtils
 {
     private static final Logger log = Logger.get(CompilerUtils.class);
 
+    private static final boolean ADD_FAKE_LINE_NUMBER = false;
     private static final boolean DUMP_BYTE_CODE_TREE = false;
     private static final boolean DUMP_BYTE_CODE_RAW = false;
     private static final boolean RUN_ASM_VERIFIER = false; // verifier doesn't work right now
@@ -101,7 +102,7 @@ public final class CompilerUtils
         for (ClassDefinition classDefinition : classDefinitions) {
             ClassWriter cw = new SmartClassWriter(classInfoLoader);
             try {
-                classDefinition.visit(cw);
+                classDefinition.visit(ADD_FAKE_LINE_NUMBER ? new AddFakeLineNumberClassVisitor(cw) : cw);
             }
             catch (IndexOutOfBoundsException e) {
                 Printer printer = new Textifier();

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
@@ -24,7 +24,6 @@ import com.facebook.presto.sql.relational.ConstantExpression;
 import com.facebook.presto.sql.relational.InputReferenceExpression;
 import com.facebook.presto.sql.relational.RowExpression;
 import com.facebook.presto.sql.relational.RowExpressionVisitor;
-import com.facebook.presto.type.UnknownType;
 import com.google.common.collect.Iterables;
 
 import java.lang.invoke.MethodHandle;
@@ -87,9 +86,6 @@ public class ExpressionOptimizer
             Signature signature = call.getSignature();
 
             if (signature.getName().equals(CAST)) {
-                if (call.getArguments().get(0).getType().equals(UnknownType.UNKNOWN)) {
-                    return constantNull(call.getType());
-                }
                 Signature functionSignature = registry.getCoercion(call.getArguments().get(0).getType(), call.getType());
                 function = registry.getScalarFunctionImplementation(functionSignature);
             }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestFailureFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestFailureFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.client.FailureInfo;
+import com.facebook.presto.util.Failures;
+import io.airlift.json.JsonCodec;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
+
+public class TestFailureFunction
+        extends AbstractTestFunctions
+{
+    private static final String FAILURE_INFO = JsonCodec.jsonCodec(FailureInfo.class).toJson(Failures.toFailure(new RuntimeException("fail me")).toFailureInfo());
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "fail me")
+    public void testFailure()
+    {
+        assertFunction("fail(json_parse('" + FAILURE_INFO + "'))", UNKNOWN, null);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestFailureFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestFailureFunction.java
@@ -14,10 +14,12 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.client.FailureInfo;
+import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.util.Failures;
 import io.airlift.json.JsonCodec;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 
 public class TestFailureFunction
@@ -29,5 +31,13 @@ public class TestFailureFunction
     public void testFailure()
     {
         assertFunction("fail(json_parse('" + FAILURE_INFO + "'))", UNKNOWN, null);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "/ by zero")
+    public void testQuery()
+    {
+        // The other test does not exercise this function during execution (i.e. inside a page processor).
+        // It only verifies constant folding works.
+        new LocalQueryRunner(TEST_SESSION).execute("select if(x, 78, 0/0) from (values rand() >= 0, rand() < 0) t(x)");
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -25,9 +25,14 @@ import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolResolver;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionRewriter;
+import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.LikePredicate;
+import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
 import com.facebook.presto.sql.tree.StringLiteral;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -574,10 +579,10 @@ public class TestExpressionInterpreter
                         "else 1 " +
                         "end");
 
-        assertOptimizedEquals("case when 0 / 0 = 0 then 1 end",
-                "case when 0 / 0 = 0 then 1 end");
+        assertOptimizedMatches("case when 0 / 0 = 0 then 1 end",
+                "case when cast(fail() as boolean) then 1 end");
 
-        assertOptimizedEquals("if(false, 1, 0 / 0)", "if (false, 1, 0 / 0)");
+        assertOptimizedMatches("if(false, 1, 0 / 0)", "cast(fail() as bigint)");
     }
 
     @Test
@@ -736,15 +741,27 @@ public class TestExpressionInterpreter
                         "when unbound_long then 4 " +
                         "end");
 
-        assertOptimizedEquals("case 1 " +
+        assertOptimizedMatches("case 1 " +
+                "when unbound_long then 1 " +
+                "when 0 / 0 then 2 " +
+                "else 1 " +
+                "end",
+                "" +
+                        "case 1 " +
+                        "when unbound_long then 1 " +
+                        "when cast(fail() AS bigint) then 2 " +
+                        "else 1 " +
+                        "end");
+
+        assertOptimizedMatches("case 1 " +
                 "when 0 / 0 then 1 " +
                 "when 0 / 0 then 2 " +
                 "else 1 " +
                 "end",
                 "" +
                         "case 1 " +
-                        "when 0 / 0 then 1 " +
-                        "when 0 / 0 then 2 " +
+                        "when cast(fail() as bigint) then 1 " +
+                        "when cast(fail() as bigint) then 2 " +
                         "else 1 " +
                         "end");
     }
@@ -756,8 +773,8 @@ public class TestExpressionInterpreter
         assertOptimizedEquals("coalesce(2 * 3 * unbound_long, 1 - 1, null)", "coalesce(6 * unbound_long, 0)");
         assertOptimizedEquals("coalesce(2 * 3 * unbound_long, 1.0/2.0, null)", "coalesce(6 * unbound_long, 0.5)");
         assertOptimizedEquals("coalesce(unbound_long, 2, 1.0/2.0, 12.34, null)", "coalesce(unbound_long, 2.0, 0.5, 12.34)");
-        assertOptimizedEquals("coalesce(0 / 0 > 1, unbound_boolean, 0 / 0 = 0)",
-                "coalesce(0 / 0 > 1, unbound_boolean, 0 / 0 = 0)");
+        assertOptimizedMatches("coalesce(0 / 0 > 1, unbound_boolean, 0 / 0 = 0)",
+                "coalesce(cast(fail() as boolean), unbound_boolean, cast(fail() as boolean))");
     }
 
     @Test
@@ -874,6 +891,32 @@ public class TestExpressionInterpreter
         assertOptimizedEquals("unbound_string like unbound_pattern escape unbound_string", "unbound_string like unbound_pattern escape unbound_string");
     }
 
+    @Test
+    public void testFailedExpressionOptimization()
+            throws Exception
+    {
+        assertOptimizedEquals("if(unbound_boolean, 1, 0 / 0)", "CASE WHEN unbound_boolean THEN 1 ELSE 0 / 0 END");
+        assertOptimizedEquals("if(unbound_boolean, 0 / 0, 1)", "CASE WHEN unbound_boolean THEN 0 / 0 ELSE 1 END");
+
+        assertOptimizedMatches("CASE unbound_long WHEN 1 THEN 1 WHEN 0 / 0 THEN 2 END",
+                "CASE unbound_long WHEN 1 THEN 1 WHEN cast(fail() as bigint) THEN 2 END");
+
+        assertOptimizedMatches("CASE unbound_boolean WHEN true THEN 1 ELSE 0 / 0 END",
+                "CASE unbound_boolean WHEN true THEN 1 ELSE cast(fail() as bigint) END");
+
+        assertOptimizedMatches("CASE bound_long WHEN unbound_long THEN 1 WHEN 0 / 0 THEN 2 ELSE 1 END",
+                "CASE 1234 WHEN unbound_long THEN 1 WHEN cast(fail() as bigint) THEN 2 ELSE 1 END");
+
+        assertOptimizedMatches("case when unbound_boolean then 1 when 0 / 0 = 0 then 2 end",
+                "case when unbound_boolean then 1 when cast(fail() as boolean) then 2 end");
+
+        assertOptimizedMatches("case when unbound_boolean then 1 else 0 / 0  end",
+                "case when unbound_boolean then 1 else cast(fail() as bigint) end");
+
+        assertOptimizedMatches("case when unbound_boolean then 0 / 0 else 1 end",
+                "case when unbound_boolean then cast(fail() as bigint) else 1 end");
+    }
+
     @Test(expectedExceptions = PrestoException.class)
     public void testOptimizeDivideByZero()
             throws Exception
@@ -952,6 +995,16 @@ public class TestExpressionInterpreter
         assertEquals(optimize(expression), SQL_PARSER.createExpression(expression));
     }
 
+    private static void assertOptimizedMatches(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        // replaces FunctionCalls to FailureFunction by fail()
+        Object actualOptimized = optimize(actual);
+        if (actualOptimized instanceof Expression) {
+            actualOptimized = ExpressionTreeRewriter.rewriteWith(new FailedFunctionRewriter(), (Expression) actualOptimized);
+        }
+        assertEquals(actualOptimized, SQL_PARSER.createExpression(expected));
+    }
+
     private static Object optimize(@Language("SQL") String expression)
     {
         assertRoundTrip(expression);
@@ -1010,5 +1063,18 @@ public class TestExpressionInterpreter
         ExpressionInterpreter interpreter = expressionInterpreter(expression, METADATA, TEST_SESSION, expressionTypes);
 
         return interpreter.evaluate((RecordCursor) null);
+    }
+
+    private static class FailedFunctionRewriter
+            extends ExpressionRewriter<Object>
+    {
+        @Override
+        public Expression rewriteFunctionCall(FunctionCall node, Object context, ExpressionTreeRewriter<Object> treeRewriter)
+        {
+            if (node.getName().equals(QualifiedName.of("fail"))) {
+                return new FunctionCall(QualifiedName.of("fail"), ImmutableList.of());
+            }
+            return node;
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -185,8 +185,11 @@ public class TestArrayOperators
 
         assertInvalidFunction("ARRAY [ARRAY[1]] || ARRAY[ARRAY[true], ARRAY[false]]", FUNCTION_NOT_FOUND);
 
+        // This query is ambiguous. The result can be [[1], NULL] or [[1], [NULL]] depending on interpretation
+        assertFunction("ARRAY [ARRAY [1]] || ARRAY [NULL]", new ArrayType(new ArrayType(BIGINT)), asList(ImmutableList.of(1L), null));
+
         try {
-            assertFunction("ARRAY [ARRAY[1]] || ARRAY[NULL]", new ArrayType(new ArrayType(BIGINT)), null);
+            assertFunction("ARRAY [ARRAY [1]] || ARRAY [ARRAY ['x']]", new ArrayType(new ArrayType(BIGINT)), null);
             fail("arrays must be of the same type");
         }
         catch (RuntimeException e) {
@@ -214,6 +217,14 @@ public class TestArrayOperators
                 sqlTimestamp(100_000), sqlTimestamp(1000)));
         assertFunction("ARRAY [2, 8] || ARRAY[ARRAY[3, 6], ARRAY[4]]", new ArrayType(new ArrayType(BIGINT)), ImmutableList.of(ImmutableList.of(2L, 8L), ImmutableList.of(3L, 6L), ImmutableList.of(4L)));
         assertFunction("ARRAY [ARRAY [1], ARRAY [2, 8]] || ARRAY [3, 6]", new ArrayType(new ArrayType(BIGINT)), ImmutableList.of(ImmutableList.of(1L), ImmutableList.of(2L, 8L), ImmutableList.of(3L, 6L)));
+
+        try {
+            assertFunction("ARRAY [ARRAY[1]] || ARRAY ['x']", new ArrayType(new ArrayType(BIGINT)), null);
+            fail("arrays must be of the same type");
+        }
+        catch (RuntimeException e) {
+            // Expected
+        }
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -85,6 +85,7 @@ public class TestArrayOperators
     public void testArrayElements()
             throws Exception
     {
+        assertFunction("CAST(ARRAY [null] AS ARRAY<BIGINT>)", new ArrayType(BIGINT), asList((Long) null));
         assertFunction("CAST(ARRAY [1, 2, 3] AS ARRAY<BIGINT>)", new ArrayType(BIGINT), ImmutableList.of(1L, 2L, 3L));
         assertFunction("CAST(ARRAY [1, null, 3] AS ARRAY<BIGINT>)", new ArrayType(BIGINT), asList(1L, null, 3L));
 

--- a/presto-main/src/test/java/com/facebook/presto/type/TestUnknownOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestUnknownOperators.java
@@ -14,7 +14,10 @@
 package com.facebook.presto.type;
 
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.operator.scalar.ScalarFunction;
 import org.testng.annotations.Test;
+
+import javax.annotation.Nullable;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -25,6 +28,19 @@ import static com.facebook.presto.type.UnknownType.UNKNOWN;
 public class TestUnknownOperators
         extends AbstractTestFunctions
 {
+    private TestUnknownOperators()
+    {
+        registerScalar(getClass());
+    }
+
+    @ScalarFunction(value = "null_function", deterministic = false)
+    @Nullable
+    @SqlType("unknown")
+    public static Void nullFunction()
+    {
+        return null;
+    }
+
     @Test
     public void testLiteral()
             throws Exception
@@ -86,6 +102,7 @@ public class TestUnknownOperators
             throws Exception
     {
         assertFunction("cast(NULL as bigint)", BIGINT, null);
+        assertFunction("cast(null_function() as bigint)", BIGINT, null);
     }
 
     @Test
@@ -93,6 +110,7 @@ public class TestUnknownOperators
             throws Exception
     {
         assertFunction("cast(NULL as varchar)", VARCHAR, null);
+        assertFunction("cast(null_function() as varchar)", VARCHAR, null);
     }
 
     @Test
@@ -100,6 +118,7 @@ public class TestUnknownOperators
             throws Exception
     {
         assertFunction("cast(NULL as double)", DOUBLE, null);
+        assertFunction("cast(null_function() as double)", DOUBLE, null);
     }
 
     @Test
@@ -107,5 +126,6 @@ public class TestUnknownOperators
             throws Exception
     {
         assertFunction("cast(NULL as boolean)", BOOLEAN, null);
+        assertFunction("cast(null_function() as boolean)", BOOLEAN, null);
     }
 }


### PR DESCRIPTION
1. Add debug flag for fake source file and line number in byte code
 * This is extremely useful in helping me debug issues in 2
 * When ADD_FAKE_LINE_NUMBER flag is turned on, every instruction in generated byte code will have a fake line number associated with them. This way, stack trace will have line numbers for generated byte code. When combined with DUMP_BYTE_CODE_RAW, they become a powerful tool to debug byte code.
2. Reimplement cast from unknown to any type
 * Cast from unknown used to be implemented as a set of special handlings here and there. This pull request reimplements them as an ordinary parametric scalar function (operator).
 * Also fix a Void handling bug in ByteCodeUtils.unboxPrimitiveIfNecessary.
 * Prerequisite for 3 and 4
3. Fix cast from array<unknown> to array<T>
 * Fixes #2852 
4. Revert "Do not constant fold failures in conditional expressions"
 * That original commit removes fail function because it was believed at the time that fixing a correctness bug in fail function was not possible without major changes. It turns out that the belief was wrong.
5. Add current stacktrace to stored failure in fail function
 * Also add test that verifies the code works during query execution time.   The old test only verifies constant folding works for this function.