### PR TITLE
Replace DynamicSliceOutput with Slices.allocate in copyPositions

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -13,8 +13,8 @@
  */
 package com.facebook.presto.spi.block;
 
-import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 
 import java.util.ArrayList;
@@ -45,8 +45,9 @@ public abstract class AbstractArrayBlock
     @Override
     public Block copyPositions(List<Integer> positions)
     {
-        DynamicSliceOutput newOffsets = new DynamicSliceOutput(positions.size() * Integer.BYTES);
-        DynamicSliceOutput newValueIsNull = new DynamicSliceOutput(positions.size());
+        SliceOutput newOffsets = Slices.allocate(positions.size() * Integer.BYTES).getOutput();
+        SliceOutput newValueIsNull = Slices.allocate(positions.size()).getOutput();
+
         List<Integer> valuesPositions = new ArrayList<>();
         int countNewOffset = 0;
         for (int position : positions) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spi.block;
 
-import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
@@ -90,12 +89,12 @@ public class FixedWidthBlock
     {
         checkValidPositions(positions, positionCount);
 
-        SliceOutput newSlice = new DynamicSliceOutput(positions.size() * fixedSize);
-        SliceOutput newValueIsNull = new DynamicSliceOutput(positions.size());
+        SliceOutput newSlice = Slices.allocate(positions.size() * fixedSize).getOutput();
+        SliceOutput newValueIsNull = Slices.allocate(positions.size()).getOutput();
 
         for (int position : positions) {
-            newValueIsNull.appendByte(valueIsNull.getByte(position));
-            newSlice.appendBytes(getRawSlice().getBytes(position * fixedSize, fixedSize));
+            newSlice.writeBytes(slice, position * fixedSize, fixedSize);
+            newValueIsNull.writeByte(valueIsNull.getByte(position));
         }
         return new FixedWidthBlock(fixedSize, positions.size(), newSlice.slice(), newValueIsNull.slice());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
@@ -97,8 +97,8 @@ public class FixedWidthBlockBuilder
     {
         checkValidPositions(positions, positionCount);
 
-        SliceOutput newSlice = new DynamicSliceOutput(positions.size() * fixedSize);
-        SliceOutput newValueIsNull = new DynamicSliceOutput(positions.size());
+        SliceOutput newSlice = Slices.allocate(positions.size() * fixedSize).getOutput();
+        SliceOutput newValueIsNull = Slices.allocate(positions.size()).getOutput();
 
         for (int position : positions) {
             newValueIsNull.appendByte(valueIsNull.getUnderlyingSlice().getByte(position));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyFixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyFixedWidthBlock.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spi.block;
 
-import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.SizeOf;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -98,8 +97,8 @@ public class LazyFixedWidthBlock
         checkValidPositions(positions, positionCount);
 
         assureLoaded();
-        SliceOutput newSlice = new DynamicSliceOutput(positions.size() * fixedSize);
-        SliceOutput newValueIsNull = new DynamicSliceOutput(positions.size());
+        SliceOutput newSlice = Slices.allocate(positions.size() * fixedSize).getOutput();
+        SliceOutput newValueIsNull = Slices.allocate(positions.size()).getOutput();
 
         for (int position : positions) {
             newValueIsNull.appendByte(valueIsNull[position] ? 1 : 0);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spi.block;
 
-import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
@@ -97,9 +96,9 @@ public class VariableWidthBlock
         checkValidPositions(positions, positionCount);
 
         int finalLength = positions.stream().mapToInt(this::getLength).sum();
-        SliceOutput newSlice = new DynamicSliceOutput(finalLength);
-        SliceOutput newOffsets = new DynamicSliceOutput(positions.size() * SIZE_OF_INT);
-        SliceOutput newValueIsNull = new DynamicSliceOutput(positions.size());
+        SliceOutput newSlice = Slices.allocate(finalLength).getOutput();
+        SliceOutput newOffsets = Slices.allocate((positions.size() * SIZE_OF_INT) + SIZE_OF_INT).getOutput();
+        SliceOutput newValueIsNull = Slices.allocate(positions.size()).getOutput();
 
         newOffsets.appendInt(0);
         for (int position : positions) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -107,9 +107,9 @@ public class VariableWidthBlockBuilder
         checkValidPositions(positions, this.positions);
 
         int finalLength = positions.stream().mapToInt(this::getLength).sum();
-        SliceOutput newSlice = new DynamicSliceOutput(finalLength);
-        SliceOutput newOffsets = new DynamicSliceOutput(positions.size() * SIZE_OF_INT);
-        SliceOutput newValueIsNull = new DynamicSliceOutput(positions.size());
+        SliceOutput newSlice = Slices.allocate(finalLength).getOutput();
+        SliceOutput newOffsets = Slices.allocate((positions.size() * SIZE_OF_INT) + SIZE_OF_INT).getOutput();
+        SliceOutput newValueIsNull = Slices.allocate(positions.size()).getOutput();
 
         newOffsets.appendInt(0);
         for (int position : positions) {


### PR DESCRIPTION
Several implementations of copy copyPositions use DynamicSliceOutput
even though we know the exact size of the slice that we need. Replace
these usages with Slices.allocate.