### PR TITLE
Fix blocking at parial memory full by TopNOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/TopNOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TopNOperator.java
@@ -176,7 +176,7 @@ public class TopNOperator
     @Override
     public boolean needsInput()
     {
-        return !finishing && outputIterator == null && (topNBuilder == null || !topNBuilder.isFull());
+        return !finishing && (outputIterator == null || !outputIterator.hasNext()) && (topNBuilder == null || !topNBuilder.isFull());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
@@ -43,10 +43,15 @@ public final class TestingTaskContext
 
     public static TaskContext createTaskContext(Executor executor, Session session, DataSize maxMemory)
     {
+        return createTaskContext(executor, session, maxMemory, new DataSize(1, MEGABYTE));
+    }
+
+    public static TaskContext createTaskContext(Executor executor, Session session, DataSize maxMemory, DataSize preallocated)
+    {
         MemoryPool memoryPool = new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE));
         MemoryPool systemMemoryPool = new MemoryPool(new MemoryPoolId("testSystem"), new DataSize(1, GIGABYTE));
         QueryContext queryContext = new QueryContext(new QueryId("test_query"), maxMemory, memoryPool, systemMemoryPool, executor);
-        return createTaskContext(queryContext, executor, session, new DataSize(1, MEGABYTE));
+        return createTaskContext(queryContext, executor, session, preallocated);
     }
 
     public static TaskContext createTaskContext(QueryContext queryContext, Executor executor, Session session, DataSize preallocated)


### PR DESCRIPTION
I found a case the `TopNOperator` doesn't process any records after partial flush, so it was permanently blocked.

It seems that `needsInput` always returns `false` after the partial flush. 