### PR TITLE
Fix table layout for Blackhole connector

### DIFF
--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
@@ -217,6 +217,12 @@ public class BlackHoleMetadata
     @Override
     public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
     {
-        return new ConnectorTableLayout(handle);
+        return new ConnectorTableLayout(
+                handle,
+                Optional.empty(),
+                TupleDomain.none(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of());
     }
 }


### PR DESCRIPTION
It uses TupleDomain.none(), not all()