### PR TITLE
Add one constructor to AllColumns for hqltranslator usage

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AllColumns.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AllColumns.java
@@ -34,6 +34,11 @@ public class AllColumns
         prefix = Optional.empty();
     }
 
+    public AllColumns(QualifiedName prefix)
+    {
+        this(Optional.empty(), prefix);
+    }
+
     public AllColumns(NodeLocation location, QualifiedName prefix)
     {
         this(Optional.of(location), prefix);


### PR DESCRIPTION
Add a constructor to AllColumns which only takes prefix as input. This was original supported in previous presto version. 