### PR TITLE
Move the SQL query below the Summary block

### DIFF
--- a/presto-main/src/main/resources/webapp/query.html
+++ b/presto-main/src/main/resources/webapp/query.html
@@ -64,8 +64,6 @@
 
     <h2>Summary</h2>
 
-    <div class="sql"><pre><code id="query"></code></pre></div>
-
     <dl class="dl-horizontal">
         <dt>Query State</dt>
         <dd id="queryState"></dd>
@@ -133,6 +131,10 @@
         <dt>Session Properties</dt>
         <dd id="sessionProperties"></dd>
     </dl>
+
+    <h2>Query</h2>
+    
+    <div class="sql"><pre><code id="query"></code></pre></div>
 
     <h2>Stages</h2>
 


### PR DESCRIPTION
Generally when I'm going into the Presto interface it's to see how a query is performing, to see it's memory/cpu time etc. However since queries can become very long vertically, I'm finding myself just scrolling endlessly to get to the stats, whereas it seems better to just have them at the top.