### PR TITLE
Add support for removing nulls with array_remove

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayRemoveFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayRemoveFunction.java
@@ -46,9 +46,9 @@ public final class ArrayRemoveFunction
     public static final ArrayRemoveFunction ARRAY_REMOVE_FUNCTION = new ArrayRemoveFunction();
     private static final String FUNCTION_NAME = "array_remove";
 
-    private static final MethodHandle METHOD_HANDLE_BOOLEAN = methodHandle(ArrayRemoveFunction.class, "remove", MethodHandle.class, Type.class, Block.class, boolean.class);
-    private static final MethodHandle METHOD_HANDLE_LONG = methodHandle(ArrayRemoveFunction.class, "remove", MethodHandle.class, Type.class, Block.class, long.class);
-    private static final MethodHandle METHOD_HANDLE_DOUBLE = methodHandle(ArrayRemoveFunction.class, "remove", MethodHandle.class, Type.class, Block.class, double.class);
+    private static final MethodHandle METHOD_HANDLE_BOOLEAN = methodHandle(ArrayRemoveFunction.class, "remove", MethodHandle.class, Type.class, Block.class, Boolean.class);
+    private static final MethodHandle METHOD_HANDLE_LONG = methodHandle(ArrayRemoveFunction.class, "remove", MethodHandle.class, Type.class, Block.class, Long.class);
+    private static final MethodHandle METHOD_HANDLE_DOUBLE = methodHandle(ArrayRemoveFunction.class, "remove", MethodHandle.class, Type.class, Block.class, Double.class);
     private static final MethodHandle METHOD_HANDLE_SLICE = methodHandle(ArrayRemoveFunction.class, "remove", MethodHandle.class, Type.class, Block.class, Slice.class);
     private static final MethodHandle METHOD_HANDLE_OBJECT = methodHandle(ArrayRemoveFunction.class, "remove", MethodHandle.class, Type.class, Block.class, Object.class);
 
@@ -100,7 +100,7 @@ public final class ArrayRemoveFunction
         }
 
         MethodHandle methodHandle = baseMethodHandle.bindTo(equalsFunction).bindTo(type);
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false, false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(false, ImmutableList.of(false, true), methodHandle, isDeterministic());
     }
 
     public static Block remove(MethodHandle equalsFunction, Type type, Block array, Slice value)
@@ -108,17 +108,17 @@ public final class ArrayRemoveFunction
         return remove(equalsFunction, type, array, (Object) value);
     }
 
-    public static Block remove(MethodHandle equalsFunction, Type type, Block array, long value)
+    public static Block remove(MethodHandle equalsFunction, Type type, Block array, Long value)
     {
         return remove(equalsFunction, type, array, (Object) value);
     }
 
-    public static Block remove(MethodHandle equalsFunction, Type type, Block array, double value)
+    public static Block remove(MethodHandle equalsFunction, Type type, Block array, Double value)
     {
         return remove(equalsFunction, type, array, (Object) value);
     }
 
-    public static Block remove(MethodHandle equalsFunction, Type type, Block array, boolean value)
+    public static Block remove(MethodHandle equalsFunction, Type type, Block array, Boolean value)
     {
         return remove(equalsFunction, type, array, (Object) value);
     }
@@ -132,7 +132,9 @@ public final class ArrayRemoveFunction
             Object element = readNativeValue(type, array, i);
 
             try {
-                if (element == null || !(boolean) equalsFunction.invoke(element, value)) {
+                if ((element == null && value != null)
+                        || (element != null && value == null)
+                        || (element != null && value != null && !(boolean) equalsFunction.invoke(element, value))) {
                     positions.add(i);
                     sizeAfterRemove += array.getLength(i);
                 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -690,6 +690,11 @@ public class TestArrayOperators
         assertFunction("ARRAY_REMOVE(ARRAY [TRUE, FALSE, TRUE], FALSE)", new ArrayType(BOOLEAN), ImmutableList.of(true, true));
         assertFunction("ARRAY_REMOVE(ARRAY [NULL, FALSE, TRUE], TRUE)", new ArrayType(BOOLEAN), asList(null, false));
         assertFunction("ARRAY_REMOVE(ARRAY [ARRAY ['foo'], ARRAY ['bar'], ARRAY ['baz']], ARRAY ['bar'])", new ArrayType(new ArrayType(VARCHAR)), ImmutableList.of(ImmutableList.of("foo"), ImmutableList.of("baz")));
+        assertFunction("ARRAY_REMOVE(ARRAY [1, 2, NULL, 3, NULL, 4, 5], NULL)", new ArrayType(BIGINT), asList(1L, 2L, 3L, 4L, 5L));
+        assertFunction("ARRAY_REMOVE(ARRAY ['foo', NULL, 'bar', NULL], NULL)", new ArrayType(VARCHAR), asList("foo", "bar"));
+        assertFunction("ARRAY_REMOVE(ARRAY [1.0, NULL, nan(), -1.23, NULL], NULL)", new ArrayType(DOUBLE), asList(1.0, NaN, -1.23));
+        assertFunction("ARRAY_REMOVE(ARRAY [TRUE, NULL, FALSE, TRUE, NULL], NULL)", new ArrayType(BOOLEAN), asList(true, false, true));
+//        assertFunction("ARRAY_REMOVE(ARRAY [NULL, NULL, NULL], NULL)", new ArrayType(UNKNOWN), asList());
     }
 
     public void assertInvalidFunction(String projection, SemanticErrorCode errorCode)


### PR DESCRIPTION
Postgres already supports removing `null`s from arrays that contain `null` values, this PR adds the same functionality to the `array_remove` function.