### PR TITLE
Avoid pruning projections in outer tables

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1858,6 +1858,22 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testOuterJoinProjectionPruning()
+            throws Exception
+    {
+        MaterializedResult actual = computeActual("SELECT count(1), count(one) " +
+                "FROM (values (1, 'a'), (2, 'a')) as l(k, a) " +
+                "LEFT JOIN (select k, 1 one from (values 1) as r(k)) r " +
+                "ON l.k = r.k GROUP BY a");
+
+        MaterializedResult expected = resultBuilder(getSession(), BIGINT, BIGINT)
+                .row(2, 1) // (total rows, # of non null values)
+                .build();
+
+        assertEquals(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
     public void testSimpleLeftJoin()
             throws Exception
     {


### PR DESCRIPTION
We found a corner case bug that `PruneRedundantProjection` optimization can produce an wrong query plan when outer joins are involved.

Here is a query that produces two rows with the left (outer) join:
```
presto> SELECT a, l.c, incr FROM (values ('a', 1), ('a', 2)) as l(a, c) LEFT JOIN (select c, 1 incr from (values 1) as r(c)) r on l.c = r.c ;
 a | c | incr
---+--+------
 a | 1 |    1
 a | 2 | NULL
```

But the following count(1) query only reports 1 row:
```
presto> SELECT count(1), count(incr) FROM (values ('a', 1), ('a', 2)) as l(a, c) LEFT JOIN (select c, 1 incr from (values 1) as r(c)) r on l.c = r.c group by a;
 _col0 | _col1
-------+-------
     1 |     1
(1 row)
```

If we replace count(1) with count(*), the query works as expected:
```
presto> SELECT count(*), count(incr) FROM (values ('a', 1), ('a', 2)) as l(a, c) LEFT JOIN (select c, 1 incr from (values 1) as r(c)) r on l.c = r.c group by a;
 _col0 | _col1
-------+-------
     2 |     1
(1 row)
```

The cause of this problem is PruneRedundantProjection optimizer wrongly replaces `1` in count(1) with expression `1 incr` that exists in the right table of the outer join. 

This PR excludes expressions that exist in the outer tables from the pruning candidates. With this fix, the query works correctly:
```
presto> SELECT count(1), count(incr) FROM (values ('a', 1), ('a', 2)) as l(a, c) LEFT OUTER JOIN (select c, 1 incr from (values 1) as r(c)) r on l.c = r.c group by a;
 _col0 | _col1
-------+-------
     2 |     1
```
