### PR TITLE
Fix java version setting by rpm

### DIFF
--- a/presto-server-rpm/src/main/resources/dist/etc/init.d/presto
+++ b/presto-server-rpm/src/main/resources/dist/etc/init.d/presto
@@ -34,7 +34,7 @@ start () {
     if [ -z "$JAVA8_HOME" ]
     then
         echo "Warning: No value found for JAVA8_HOME. Default Java will be used."
-        sudo -u $SERVICE_USER /usr/lib/presto/bin/launcher start ${CONFIGURATION}
+        sudo -u $SERVICE_USER /usr/lib/presto/bin/launcher start ${CONFIGURATION[@]}
     else
         sudo -u $SERVICE_USER PATH=${JAVA8_HOME}/bin:$PATH /usr/lib/presto/bin/launcher start "${CONFIGURATION[@]}"
     fi

--- a/presto-server-rpm/src/main/rpm/preinstall
+++ b/presto-server-rpm/src/main/rpm/preinstall
@@ -5,17 +5,27 @@
 java_version() {
 # The one argument is the location of java (either $JAVA_HOME or a potential
 # candidate for JAVA_HOME.
-  "$1"/bin/java -version 2>&1 | grep "java version" | awk '{ print substr($3, 2, length($3)-2); }'
+  JAVA="$1"/bin/java
+  "$JAVA" -version 2>&1 | grep "java version" | awk '{ print substr($3, 2, length($3)-2); }'
 }
 
 java_vendor() {
 # The one argument is the location of java (either $JAVA_HOME or a potential
 # candidate for JAVA_HOME).
 # Returns the java vendor name. eg: Oracle Corporation
-  "$1"/bin/java -XshowSettings:properties -version 2>&1 | grep "java.vendor =" | awk '{ print $3 " " $4; }'
+  JAVA="$1"/bin/java
+  "$JAVA" -XshowSettings:properties -version 2>&1 | grep "java.vendor =" | awk '{ print $3 " " $4; }'
 }
 
 check_if_correct_java_version() {
+
+# If the string is empty return non-zero code.  We don't want false positives if /bin/java is
+# a valid java version because that will leave java8_home unset and the init.d scripts will
+# use the default java version, which may not be java 8.
+  if [ -z $1 ] ; then
+    return 1
+  fi
+
 # The one argument is the location of java (either $JAVA_HOME or a potential
 # candidate for JAVA_HOME).
   JAVA_VERSION=$(java_version "$1")
@@ -40,7 +50,9 @@ if ! check_if_correct_java_version "$JAVA8_HOME" && ! check_if_correct_java_vers
       /usr/java/jre1.8* \
       /usr/jdk64/jdk1.8* \
       /usr/lib/jvm/default-java \
-      /usr/java/default ; do
+      /usr/java/default \
+      / \
+      /usr ; do
       if [ -e "$candidate"/bin/java ]; then
         if check_if_correct_java_version "$candidate" ; then
           java_found=true


### PR DESCRIPTION
Makes the following fixes to the way java version is set by the rpm
1. fix using default java if JAVA8_HOME isn't set in init script
2. set JAVA8_HOME appropriately when it is empty and /bin/java is a
valid java8 version in preinstall script
3. don't ignore whitespace when checking java version in preinstall script

Testing: manually verified correct handling of empty java8_home, using
default java, and JAVA_HOME/JAVA8_HOME with whitespace