### PR TITLE
Optimize aggregations for dictionary encoded data

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/GroupByHashPageIndexer.java
+++ b/presto-main/src/main/java/com/facebook/presto/GroupByHashPageIndexer.java
@@ -38,7 +38,8 @@ public class GroupByHashPageIndexer
                 IntStream.range(0, hashTypes.size()).toArray(),
                 Optional.empty(),
                 Optional.empty(),
-                20));
+                20,
+                false));
     }
 
     public GroupByHashPageIndexer(GroupByHash hash)

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -53,6 +53,7 @@ public final class SystemSessionProperties
     public static final String EXECUTION_POLICY = "execution_policy";
     public static final String COLUMNAR_PROCESSING = "columnar_processing";
     public static final String COLUMNAR_PROCESSING_DICTIONARY = "columnar_processing_dictionary";
+    public static final String DICTIONARY_AGGREGATION = "dictionary_aggregation";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -174,6 +175,11 @@ public final class SystemSessionProperties
                         COLUMNAR_PROCESSING_DICTIONARY,
                         "Use columnar processing with optimizations for dictionaries",
                         featuresConfig.isColumnarProcessingDictionary(),
+                        false),
+                booleanSessionProperty(
+                        DICTIONARY_AGGREGATION,
+                        "Enable optimization for aggregations on dictionaries",
+                        featuresConfig.isDictionaryAggregation(),
                         false));
     }
 
@@ -260,6 +266,11 @@ public final class SystemSessionProperties
     public static boolean isColumnarProcessingDictionaryEnabled(Session session)
     {
         return session.getProperty(COLUMNAR_PROCESSING_DICTIONARY, Boolean.class);
+    }
+
+    public static boolean isDictionaryAggregationEnabled(Session session)
+    {
+        return session.getProperty(DICTIONARY_AGGREGATION, Boolean.class);
     }
 
     public static DataSize getQueryMaxMemory(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/operator/ChannelSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ChannelSet.java
@@ -73,7 +73,7 @@ public class ChannelSet
         public ChannelSetBuilder(Type type, Optional<Integer> hashChannel, int expectedPositions, OperatorContext operatorContext)
         {
             List<Type> types = ImmutableList.of(type);
-            this.hash = createGroupByHash(types, HASH_CHANNELS, Optional.<Integer>empty(), hashChannel, expectedPositions);
+            this.hash = createGroupByHash(operatorContext.getSession(), types, HASH_CHANNELS, Optional.empty(), hashChannel, expectedPositions);
             this.operatorContext = operatorContext;
             this.nullBlockPage = new Page(type.createBlockBuilder(new BlockBuilderStatus(), 1, UNKNOWN.getFixedSize()).appendNull().build());
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/DistinctLimitOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DistinctLimitOperator.java
@@ -102,7 +102,13 @@ public class DistinctLimitOperator
         for (int channel : distinctChannels) {
             distinctTypes.add(types.get(channel));
         }
-        this.groupByHash = createGroupByHash(distinctTypes.build(), Ints.toArray(distinctChannels), Optional.<Integer>empty(), hashChannel, Math.min((int) limit, 10_000));
+        this.groupByHash = createGroupByHash(
+                operatorContext.getSession(),
+                distinctTypes.build(),
+                Ints.toArray(distinctChannels),
+                Optional.empty(),
+                hashChannel,
+                Math.min((int) limit, 10_000));
         this.pageBuilder = new PageBuilder(types);
         remainingLimit = limit;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -286,7 +286,7 @@ public class HashAggregationOperator
                 Optional<Integer> hashChannel,
                 OperatorContext operatorContext)
         {
-            this.groupByHash = createGroupByHash(groupByTypes, Ints.toArray(groupByChannels), maskChannel, hashChannel, expectedGroups);
+            this.groupByHash = createGroupByHash(operatorContext.getSession(), groupByTypes, Ints.toArray(groupByChannels), maskChannel, hashChannel, expectedGroups);
             this.operatorContext = operatorContext;
             this.partial = step.isOutputPartial();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/MarkDistinctHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MarkDistinctHash.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
@@ -30,14 +31,13 @@ public class MarkDistinctHash
     private final GroupByHash groupByHash;
     private long nextDistinctId;
 
-    public MarkDistinctHash(List<Type> types, int[] channels, Optional<Integer> hashChannel)
+    public MarkDistinctHash(Session session, List<Type> types, int[] channels, Optional<Integer> hashChannel)
     {
-        this(types, channels, hashChannel, 10_000);
+        this(session, types, channels, hashChannel, 10_000);
     }
-
-    public MarkDistinctHash(List<Type> types, int[] channels, Optional<Integer> hashChannel, int expectedDistinctValues)
+    public MarkDistinctHash(Session session, List<Type> types, int[] channels, Optional<Integer> hashChannel, int expectedDistinctValues)
     {
-        this.groupByHash = createGroupByHash(types, channels, Optional.<Integer>empty(), hashChannel, expectedDistinctValues);
+        this.groupByHash = createGroupByHash(session, types, channels, Optional.empty(), hashChannel, expectedDistinctValues);
     }
 
     public long getEstimatedSize()

--- a/presto-main/src/main/java/com/facebook/presto/operator/MarkDistinctOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MarkDistinctOperator.java
@@ -98,7 +98,7 @@ public class MarkDistinctOperator
         for (int channel : markDistinctChannels) {
             distinctTypes.add(types.get(channel));
         }
-        this.markDistinctHash = new MarkDistinctHash(distinctTypes.build(), Ints.toArray(markDistinctChannels), hashChannel);
+        this.markDistinctHash = new MarkDistinctHash(operatorContext.getSession(), distinctTypes.build(), Ints.toArray(markDistinctChannels), hashChannel);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/RowNumberOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/RowNumberOperator.java
@@ -141,7 +141,7 @@ public class RowNumberOperator
         }
         else {
             int[] channels = Ints.toArray(partitionChannels);
-            this.groupByHash = Optional.of(createGroupByHash(partitionTypes, channels, Optional.<Integer>empty(), hashChannel, expectedPositions));
+            this.groupByHash = Optional.of(createGroupByHash(operatorContext.getSession(), partitionTypes, channels, Optional.<Integer>empty(), hashChannel, expectedPositions));
         }
         this.types = toTypes(sourceTypes, outputChannels);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/TopNRowNumberOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TopNRowNumberOperator.java
@@ -186,7 +186,7 @@ public class TopNRowNumberOperator
             this.groupByHash = Optional.empty();
         }
         else {
-            this.groupByHash = Optional.of(createGroupByHash(partitionTypes, Ints.toArray(partitionChannels), Optional.<Integer>empty(), hashChannel, expectedPositions));
+            this.groupByHash = Optional.of(createGroupByHash(operatorContext.getSession(), partitionTypes, Ints.toArray(partitionChannels), Optional.<Integer>empty(), hashChannel, expectedPositions));
         }
         this.flushingPartition = Optional.empty();
         this.pageBuilder = new PageBuilder(types);

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
@@ -316,7 +316,7 @@ public class IndexLoader
         public boolean load(List<UpdateRequest> requests)
         {
             // Generate a RecordSet that only presents index keys that have not been cached and are deduped based on lookupSourceInputChannels
-            UnloadedIndexKeyRecordSet recordSetForLookupSource = new UnloadedIndexKeyRecordSet(indexSnapshotReference.get(), lookupSourceInputChannels, indexTypes, requests);
+            UnloadedIndexKeyRecordSet recordSetForLookupSource = new UnloadedIndexKeyRecordSet(pipelineContext.getSession(), indexSnapshotReference.get(), lookupSourceInputChannels, indexTypes, requests);
 
             // Drive index lookup to produce the output (landing in indexSnapshotBuilder)
             try (Driver driver = driverFactory.createDriver(pipelineContext.addDriverContext())) {
@@ -336,7 +336,7 @@ public class IndexLoader
             // Generate a RecordSet that presents unique index keys that have not been cached
             UnloadedIndexKeyRecordSet indexKeysRecordSet = (lookupSourceInputChannels.equals(allInputChannels))
                     ? recordSetForLookupSource
-                    : new UnloadedIndexKeyRecordSet(indexSnapshotReference.get(), allInputChannels, indexTypes, requests);
+                    : new UnloadedIndexKeyRecordSet(pipelineContext.getSession(), indexSnapshotReference.get(), allInputChannels, indexTypes, requests);
 
             // Create lookup source with new data
             IndexSnapshot newValue = indexSnapshotBuilder.createIndexSnapshot(indexKeysRecordSet);

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/UnloadedIndexKeyRecordSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/UnloadedIndexKeyRecordSet.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.index;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.operator.GroupByHash;
 import com.facebook.presto.operator.GroupByIdBlock;
 import com.facebook.presto.spi.Page;
@@ -45,7 +46,7 @@ public class UnloadedIndexKeyRecordSet
     private final List<Type> types;
     private final List<PageAndPositions> pageAndPositions;
 
-    public UnloadedIndexKeyRecordSet(IndexSnapshot existingSnapshot, Set<Integer> channelsForDistinct, List<Type> types, List<UpdateRequest> requests)
+    public UnloadedIndexKeyRecordSet(Session session, IndexSnapshot existingSnapshot, Set<Integer> channelsForDistinct, List<Type> types, List<UpdateRequest> requests)
     {
         requireNonNull(existingSnapshot, "existingSnapshot is null");
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
@@ -60,7 +61,7 @@ public class UnloadedIndexKeyRecordSet
         }
 
         ImmutableList.Builder<PageAndPositions> builder = ImmutableList.builder();
-        GroupByHash groupByHash = createGroupByHash(distinctChannelTypes, normalizedDistinctChannels, Optional.<Integer>empty(), Optional.empty(), 10_000);
+        GroupByHash groupByHash = createGroupByHash(session, distinctChannelTypes, normalizedDistinctChannels, Optional.<Integer>empty(), Optional.empty(), 10_000);
         for (UpdateRequest request : requests) {
             Page page = request.getPage();
             Block[] blocks = page.getBlocks();

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -27,8 +27,10 @@ public class FeaturesConfig
     private boolean optimizeSingleDistinct = true;
     private boolean pushTableWriteThroughUnion = true;
     private boolean intermediateAggregationsEnabled = false;
+
     private boolean columnarProcessing = false;
     private boolean columnarProcessingDictionary = false;
+    private boolean dictionaryAggregation = false;
 
     @LegacyConfig("analyzer.experimental-syntax-enabled")
     @Config("experimental-syntax-enabled")
@@ -160,6 +162,18 @@ public class FeaturesConfig
     public FeaturesConfig setColumnarProcessingDictionary(boolean columnarProcessingDictionary)
     {
         this.columnarProcessingDictionary = columnarProcessingDictionary;
+        return this;
+    }
+
+    public boolean isDictionaryAggregation()
+    {
+        return dictionaryAggregation;
+    }
+
+    @Config("optimizer.dictionary-aggregation")
+    public FeaturesConfig setDictionaryAggregation(boolean dictionaryAggregation)
+    {
+        this.dictionaryAggregation = dictionaryAggregation;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageProcessorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageProcessorCompiler.java
@@ -70,7 +70,6 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.consta
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.equal;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.invokeStatic;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.lessThan;
-import static com.facebook.presto.bytecode.expression.BytecodeExpressions.multiply;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newArray;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newInstance;
 import static com.facebook.presto.bytecode.instruction.JumpInstruction.jump;
@@ -79,7 +78,6 @@ import static com.facebook.presto.sql.gen.BytecodeUtils.loadConstant;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.concat;
-import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 
@@ -418,7 +416,7 @@ public class PageProcessorCompiler
                         .initialize(position.set(constantInt(0)))
                         .condition(lessThan(position, cardinality))
                         .update(position.increment())
-                        .body(outputIds.setElement(position, ids.invoke("getInt", int.class, multiply(selectedPositions.getElement(position), constantInt(SIZE_OF_INT))))));
+                        .body(outputIds.setElement(position, castDictionaryBlock.invoke("getId", int.class, selectedPositions.getElement(position)))));
 
         body.append(outputSourceId.set(dictionarySourceIds.invoke("get", Object.class, inputSourceId.cast(Object.class)).cast(UUID.class)));
         body.append(new IfStatement()

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageProcessorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageProcessorCompiler.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
+import java.util.UUID;
 
 import static com.facebook.presto.bytecode.Access.FINAL;
 import static com.facebook.presto.bytecode.Access.PRIVATE;
@@ -116,7 +117,7 @@ public class PageProcessorCompiler
         generateProcessMethod(classDefinition, filter, projections, projectMethodDefinitions);
         generateGetNonLazyPageMethod(classDefinition, filter, projections);
         generateProcessColumnarMethod(classDefinition, projections, projectColumnarMethodDefinitions);
-        generateProcessColumnarDictionaryMethod(classDefinition, projections, projectColumnarMethodDefinitions, projectDictionaryMethodDefinitions);
+        generateProcessColumnarDictionaryMethod(classDefinition, projections, projectDictionaryMethodDefinitions);
 
         generateFilterPageMethod(classDefinition, filter);
         generateFilterMethod(classDefinition, callSiteBinder, cachedInstanceBinder, filter);
@@ -330,8 +331,18 @@ public class PageProcessorCompiler
         Parameter selectedPositions = arg("selectedPositions", int[].class);
         Parameter pageBuilder = arg("pageBuilder", PageBuilder.class);
         Parameter projectionIndex = arg("projectionIndex", int.class);
+        Parameter dictionarySourceIds = arg("dictionarySourceIds", Map.class);
 
         List<Parameter> params = ImmutableList.<Parameter>builder()
+                .add(session)
+                .add(page)
+                .add(selectedPositions)
+                .add(pageBuilder)
+                .add(projectionIndex)
+                .add(dictionarySourceIds)
+                .build();
+
+        List<Parameter> columnarParams = ImmutableList.<Parameter>builder()
                 .add(session)
                 .add(page)
                 .add(selectedPositions)
@@ -347,14 +358,16 @@ public class PageProcessorCompiler
         List<Integer> inputChannels = getInputChannels(projection);
 
         if (inputChannels.size() != 1) {
-            body.append(thisVariable.invoke(projectColumnar, params).ret());
+            body.append(thisVariable.invoke(projectColumnar, columnarParams)
+                    .ret());
             return method;
         }
 
         Variable inputBlock = scope.declareVariable("inputBlock", body, page.invoke("getBlock", Block.class, constantInt(Iterables.getOnlyElement(inputChannels))));
         IfStatement ifStatement = new IfStatement()
                 .condition(inputBlock.instanceOf(DictionaryBlock.class))
-                .ifFalse(thisVariable.invoke(projectColumnar, params).ret());
+                .ifFalse(thisVariable.invoke(projectColumnar, columnarParams)
+                        .ret());
         body.append(ifStatement);
 
         Variable blockBuilder = scope.declareVariable("blockBuilder", body, pageBuilder.invoke("getBlockBuilder", BlockBuilder.class, projectionIndex));
@@ -363,6 +376,8 @@ public class PageProcessorCompiler
         Variable dictionary = scope.declareVariable(Block.class, "dictionary");
         Variable ids = scope.declareVariable(Slice.class, "ids");
         Variable dictionaryCount = scope.declareVariable(int.class, "dictionaryCount");
+        Variable inputSourceId = scope.declareVariable(UUID.class, "inputSourceId");
+        Variable outputSourceId = scope.declareVariable(UUID.class, "outputSourceId");
 
         Variable outputDictionary = scope.declareVariable(Block.class, "outputDictionary");
         Variable outputIds = scope.declareVariable(int[].class, "outputIds");
@@ -372,10 +387,12 @@ public class PageProcessorCompiler
 
         Variable position = scope.declareVariable("position", body, constantInt(0));
 
-        body.comment("Extract dictionary and ids")
-                .append(dictionary.set(inputBlock.cast(DictionaryBlock.class).invoke("getDictionary", Block.class)))
-                .append(ids.set(inputBlock.cast(DictionaryBlock.class).invoke("getIds", Slice.class)))
-                .append(dictionaryCount.set(dictionary.invoke("getPositionCount", int.class)));
+        BytecodeExpression castDictionaryBlock = inputBlock.cast(DictionaryBlock.class);
+        body.comment("Extract dictionary, ids, positionCount and dictionarySourceId")
+                .append(dictionary.set(castDictionaryBlock.invoke("getDictionary", Block.class)))
+                .append(ids.set(castDictionaryBlock.invoke("getIds", Slice.class)))
+                .append(dictionaryCount.set(dictionary.invoke("getPositionCount", int.class)))
+                .append(inputSourceId.set(castDictionaryBlock.invoke("getDictionarySourceId", UUID.class)));
 
         BytecodeBlock projectDictionary = new BytecodeBlock()
                 .comment("Project dictionary")
@@ -403,14 +420,24 @@ public class PageProcessorCompiler
                         .update(position.increment())
                         .body(outputIds.setElement(position, ids.invoke("getInt", int.class, multiply(selectedPositions.getElement(position), constantInt(SIZE_OF_INT))))));
 
-        body.append(newInstance(DictionaryBlock.class, cardinality, outputDictionary, invokeStatic(Slices.class, "wrappedIntArray", Slice.class, outputIds)).cast(Block.class).ret());
+        body.append(outputSourceId.set(dictionarySourceIds.invoke("get", Object.class, inputSourceId.cast(Object.class)).cast(UUID.class)));
+        body.append(new IfStatement()
+                .condition(equal(outputSourceId, constantNull(UUID.class)))
+                .ifTrue(new BytecodeBlock()
+                        .append(outputSourceId.set(invokeStatic(UUID.class, "randomUUID", UUID.class)))
+                        .append(dictionarySourceIds.invoke("put", Object.class, inputSourceId.cast(Object.class), outputSourceId.cast(Object.class)))
+                        .pop()));
+
+        BytecodeExpression idsSlice = invokeStatic(Slices.class, "wrappedIntArray", Slice.class, outputIds);
+        body.append(newInstance(DictionaryBlock.class, cardinality, outputDictionary, idsSlice, constantFalse(), outputSourceId)
+                .cast(Block.class)
+                .ret());
         return method;
     }
 
     private static void generateProcessColumnarDictionaryMethod(
             ClassDefinition classDefinition,
             List<RowExpression> projections,
-            List<MethodDefinition> projectColumnarMethods,
             List<MethodDefinition> projectDictionaryMethods)
     {
         Parameter session = arg("session", ConnectorSession.class);
@@ -424,13 +451,15 @@ public class PageProcessorCompiler
 
         Variable selectedPositions = scope.declareVariable("selectedPositions", body, thisVariable.invoke("filterPage", int[].class, session, page));
         Variable cardinality = scope.declareVariable("cardinality", body, selectedPositions.length());
+        Variable dictionarySourceIds = scope.declareVariable(type(Map.class, UUID.class, UUID.class), "dictionarySourceIds");
+        body.append(dictionarySourceIds.set(newInstance(type(HashMap.class, UUID.class, UUID.class))));
 
         body.comment("if no rows selected return null")
                 .append(new IfStatement()
                         .condition(equal(cardinality, constantInt(0)))
                         .ifTrue(constantNull(Page.class).ret()));
 
-        if (projectColumnarMethods.isEmpty()) {
+        if (projections.isEmpty()) {
             // if no projections, return new page with selected rows
             body.append(newInstance(Page.class, cardinality, newArray(type(Block[].class), 0)).ret());
             return;
@@ -450,6 +479,7 @@ public class PageProcessorCompiler
                     .add(selectedPositions)
                     .add(pageBuilder)
                     .add(constantInt(projectionIndex))
+                    .add(dictionarySourceIds)
                     .build();
 
             body.append(outputBlocks.setElement(projectionIndex, thisVariable.invoke(projectDictionaryMethods.get(projectionIndex), params)));
@@ -605,7 +635,11 @@ public class PageProcessorCompiler
         BytecodeBlock body = method.getBody();
 
         Variable wasNullVariable = scope.declareVariable("wasNull", body, constantFalse());
-        BytecodeExpressionVisitor visitor = new BytecodeExpressionVisitor(callSiteBinder, cachedInstanceBinder, fieldReferenceCompiler(callSiteBinder, position, wasNullVariable), metadata.getFunctionRegistry());
+        BytecodeExpressionVisitor visitor = new BytecodeExpressionVisitor(
+                callSiteBinder,
+                cachedInstanceBinder,
+                fieldReferenceCompiler(callSiteBinder, position, wasNullVariable),
+                metadata.getFunctionRegistry());
 
         body.getVariable(output)
                 .comment("evaluate projection: " + projection.toString())

--- a/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
@@ -25,6 +25,7 @@ import java.util.List;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.Slices.wrappedIntArray;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestDictionaryBlock
@@ -127,11 +128,15 @@ public class TestDictionaryBlock
 
         assertEquals(dictionaryBlock.isCompact(), false);
         DictionaryBlock compactBlock = dictionaryBlock.compact();
+        assertNotEquals(dictionaryBlock.getDictionarySourceId(), compactBlock.getDictionarySourceId());
 
         assertEquals(compactBlock.getDictionary().getPositionCount(), (expectedValues.length / 2) + 1);
         assertBlock(compactBlock.getDictionary(), new Slice[] { expectedValues[0], expectedValues[1], expectedValues[3] });
         assertEquals(compactBlock.getIds(), wrappedIntArray(0, 1, 1, 2, 2, 0, 1, 1, 2, 2));
         assertEquals(compactBlock.isCompact(), true);
+
+        DictionaryBlock reCompactedBlock = compactBlock.compact();
+        assertEquals(reCompactedBlock.getDictionarySourceId(), compactBlock.getDictionarySourceId());
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
@@ -68,7 +68,7 @@ public class BenchmarkGroupByHash
     @OperationsPerInvocation(POSITIONS)
     public Object groupByHashPreCompute(BenchmarkData data)
     {
-        GroupByHash groupByHash = new MultiChannelGroupByHash(data.getTypes(), data.getChannels(), Optional.empty(), data.getHashChannel(), EXPECTED_SIZE);
+        GroupByHash groupByHash = new MultiChannelGroupByHash(data.getTypes(), data.getChannels(), Optional.empty(), data.getHashChannel(), EXPECTED_SIZE, false);
         data.getPages().forEach(groupByHash::getGroupIds);
 
         ImmutableList.Builder<Page> pages = ImmutableList.builder();
@@ -89,7 +89,7 @@ public class BenchmarkGroupByHash
     @OperationsPerInvocation(POSITIONS)
     public Object addPagePreCompute(BenchmarkData data)
     {
-        GroupByHash groupByHash = new MultiChannelGroupByHash(data.getTypes(), data.getChannels(), Optional.empty(), data.getHashChannel(), EXPECTED_SIZE);
+        GroupByHash groupByHash = new MultiChannelGroupByHash(data.getTypes(), data.getChannels(), Optional.empty(), data.getHashChannel(), EXPECTED_SIZE, false);
         data.getPages().forEach(groupByHash::addPage);
 
         ImmutableList.Builder<Page> pages = ImmutableList.builder();

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -39,7 +39,8 @@ public class TestFeaturesConfig
                 .setPushTableWriteThroughUnion(true)
                 .setIntermediateAggregationsEnabled(false)
                 .setColumnarProcessing(false)
-                .setColumnarProcessingDictionary(false));
+                .setColumnarProcessingDictionary(false)
+                .setDictionaryAggregation(false));
     }
 
     @Test
@@ -57,6 +58,7 @@ public class TestFeaturesConfig
                 .put("optimizer.use-intermediate-aggregations", "true")
                 .put("optimizer.columnar-processing", "true")
                 .put("optimizer.columnar-processing-dictionary", "true")
+                .put("optimizer.dictionary-aggregation", "true")
                 .build();
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("experimental-syntax-enabled", "true")
@@ -70,6 +72,7 @@ public class TestFeaturesConfig
                 .put("optimizer.use-intermediate-aggregations", "true")
                 .put("optimizer.columnar-processing", "true")
                 .put("optimizer.columnar-processing-dictionary", "true")
+                .put("optimizer.dictionary-aggregation", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -83,7 +86,8 @@ public class TestFeaturesConfig
                 .setPushTableWriteThroughUnion(false)
                 .setIntermediateAggregationsEnabled(true)
                 .setColumnarProcessing(true)
-                .setColumnarProcessingDictionary(true);
+                .setColumnarProcessingDictionary(true)
+                .setDictionaryAggregation(true);
 
         assertFullMapping(properties, expected);
         assertDeprecatedEquivalence(FeaturesConfig.class, properties, propertiesLegacy);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/RaptorQueryRunner.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/RaptorQueryRunner.java
@@ -32,8 +32,6 @@ import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 
 public final class RaptorQueryRunner
 {
-    private static final Logger log = Logger.get(RaptorQueryRunner.class);
-
     private RaptorQueryRunner() {}
 
     public static DistributedQueryRunner createRaptorQueryRunner(TpchTable<?>... tables)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/RaptorQueryRunner.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/RaptorQueryRunner.java
@@ -91,7 +91,7 @@ public final class RaptorQueryRunner
         return testSessionBuilder()
                 .setCatalog("raptor")
                 .setSchema(schema)
-                .setSystemProperties(ImmutableMap.of("columnar_processing_dictionary", "true"))
+                .setSystemProperties(ImmutableMap.of("columnar_processing_dictionary", "true", "dictionary_aggregation", "true"))
                 .build();
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -19,6 +19,7 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import static com.facebook.presto.spi.block.BlockValidationUtil.checkValidPositions;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
@@ -38,13 +39,19 @@ public class DictionaryBlock
     private final int retainedSizeInBytes;
     private final int sizeInBytes;
     private final int uniqueIds;
+    private final UUID dictionarySourceId;
 
     public DictionaryBlock(int positionCount, Block dictionary, Slice ids)
     {
-        this(positionCount, dictionary, ids, false);
+        this(positionCount, dictionary, ids, false, UUID.randomUUID());
     }
 
     public DictionaryBlock(int positionCount, Block dictionary, Slice ids, boolean dictionaryIsCompacted)
+    {
+        this(positionCount, dictionary, ids, dictionaryIsCompacted, UUID.randomUUID());
+    }
+
+    public DictionaryBlock(int positionCount, Block dictionary, Slice ids, boolean dictionaryIsCompacted, UUID dictionarySourceId)
     {
         requireNonNull(dictionary, "dictionary is null");
         requireNonNull(ids, "ids is null");
@@ -60,6 +67,7 @@ public class DictionaryBlock
         this.positionCount = positionCount;
         this.dictionary = dictionary;
         this.ids = ids;
+        this.dictionarySourceId = requireNonNull(dictionarySourceId, "dictionarySourceId is null");
 
         this.retainedSizeInBytes = INSTANCE_SIZE + dictionary.getRetainedSizeInBytes() + ids.getRetainedSize();
 
@@ -269,6 +277,11 @@ public class DictionaryBlock
     public Slice getIds()
     {
         return ids;
+    }
+
+    public UUID getDictionarySourceId()
+    {
+        return dictionarySourceId;
     }
 
     public boolean isCompact()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -279,6 +279,11 @@ public class DictionaryBlock
         return ids;
     }
 
+    public int getId(int position)
+    {
+        return ids.getInt(position * SIZE_OF_INT);
+    }
+
     public UUID getDictionarySourceId()
     {
         return dictionarySourceId;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlockEncoding.java
@@ -18,6 +18,8 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
+import java.util.UUID;
+
 import static java.util.Objects.requireNonNull;
 
 public class DictionaryBlockEncoding
@@ -59,6 +61,10 @@ public class DictionaryBlockEncoding
         sliceOutput
                 .appendInt(ids.length())
                 .writeBytes(ids);
+
+        // instance id
+        sliceOutput.appendLong(dictionaryBlock.getDictionarySourceId().getMostSignificantBits());
+        sliceOutput.appendLong(dictionaryBlock.getDictionarySourceId().getLeastSignificantBits());
     }
 
     @Override
@@ -74,8 +80,12 @@ public class DictionaryBlockEncoding
         int lengthIdsSlice = sliceInput.readInt();
         Slice ids = sliceInput.readSlice(lengthIdsSlice);
 
+        // instance id
+        long mostSignificantBits = sliceInput.readLong();
+        long leastSignificantBits = sliceInput.readLong();
+
         // we always compact the dictionary before we send it
-        return new DictionaryBlock(positionCount, dictionaryBlock, ids, true);
+        return new DictionaryBlock(positionCount, dictionaryBlock, ids, true, new UUID(mostSignificantBits, leastSignificantBits));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
@@ -145,27 +145,6 @@ public class SliceArrayBlock
         return new SliceArrayBlock(length, deepCopyAndCompact(values, positionOffset, length));
     }
 
-    static Slice[] deepCopyAndCompactDictionary(Slice[] values, int[] ids, int positionOffset, int length)
-    {
-        Slice[] newValues = new Slice[length];
-        // Compact the slices. Use an IdentityHashMap because this could be very expensive otherwise.
-        Map<Slice, Slice> distinctValues = new IdentityHashMap<>();
-        for (int i = positionOffset; i < positionOffset + length; i++) {
-            Slice slice = values[ids[i]];
-            if (slice == null) {
-                continue;
-            }
-
-            Slice distinct = distinctValues.get(slice);
-            if (distinct == null) {
-                distinct = Slices.copyOf(slice);
-                distinctValues.put(slice, distinct);
-            }
-            newValues[i] = distinct;
-        }
-        return newValues;
-    }
-
     static Slice[] deepCopyAndCompact(Slice[] values, int positionOffset, int length)
     {
         Slice[] newValues = Arrays.copyOfRange(values, positionOffset, positionOffset + length);

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 
 import java.util.Locale;
 import java.util.Optional;
+import java.util.UUID;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
@@ -95,7 +96,7 @@ public class TestDictionaryBlockEncoding
         Slice idsSlice = Slices.wrappedIntArray(ids);
 
         BlockEncoding blockEncoding = new DictionaryBlockEncoding(new VariableWidthBlockEncoding());
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(positionCount, dictionary, idsSlice);
+        DictionaryBlock dictionaryBlock = new DictionaryBlock(positionCount, dictionary, idsSlice, false, UUID.randomUUID());
 
         DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1024);
         blockEncoding.writeBlock(sliceOutput, dictionaryBlock);
@@ -105,6 +106,7 @@ public class TestDictionaryBlockEncoding
         DictionaryBlock actualDictionaryBlock = (DictionaryBlock) actualBlock;
         assertBlockEquals(VARCHAR, actualDictionaryBlock.getDictionary(), dictionary);
         assertEquals(actualDictionaryBlock.getIds(), idsSlice);
+        assertEquals(actualDictionaryBlock.getDictionarySourceId(), dictionaryBlock.getDictionarySourceId());
     }
 
     private static void assertBlockEquals(Type type, Block actual, Block expected)


### PR DESCRIPTION
    Optimize aggregations for dictionary encoded data

    This optimization is limited to aggregations on a single column that is
    dictionary encoded. The optimization does the following:

    1. If aggregation is on a dictionary encoded column, extract the
       dictionary
    2. Every position of the dictionary that is referenced is added to the
       GroupByHash
    3. Hold on to the last seen dictionary to keep track of positions that
       we have been processed.