### PR TITLE
Fix PushWriteThroughUnionAll with local union

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginTableWrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginTableWrite.java
@@ -33,6 +33,7 @@ import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.planner.plan.TableCommitNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
+import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -131,7 +132,7 @@ public class BeginTableWrite
             if (node instanceof DeleteNode) {
                 return ((DeleteNode) node).getTarget();
             }
-            if (node instanceof ExchangeNode) {
+            if (node instanceof ExchangeNode || node instanceof UnionNode) {
                 Set<TableWriterNode.WriterTarget> writerTargets = node.getSources().stream()
                         .map(this::getTarget)
                         .collect(toSet());

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -175,11 +175,16 @@ public abstract class AbstractTestDistributedQueries
                 "SELECT orderkey FROM orders ORDER BY orderkey LIMIT 10",
                 "SELECT 10");
 
-        // Tests for CREATE TABLE with UNION ALL: exercises PushTableWriteThroughUnion optimizer
-
-        // WARNING: PushTableWriteThroughUnion optimizer is disabled right now. The tests below don't exercise it.
-        // WARNING: The 2nd query below fails right now if PushTableWriteThroughUnion optimizer is turned on.
         assertCreateTableAsSelect(
+            getSession().withSystemProperty("redistribute_writes", "true").withSystemProperty("push_table_write_through_union", "true"),
+            "test_union_all",
+            "SELECT orderdate, orderkey, totalprice FROM orders WHERE orderkey % 2 = 0 UNION ALL " +
+                    "SELECT orderdate, orderkey, totalprice FROM orders WHERE orderkey % 2 = 1",
+            "SELECT orderdate, orderkey, totalprice FROM orders",
+            "SELECT count(*) FROM orders");
+
+        assertCreateTableAsSelect(
+                getSession().withSystemProperty("redistribute_writes", "false").withSystemProperty("push_table_write_through_union", "true"),
                 "test_union_all",
                 "SELECT orderdate, orderkey, totalprice FROM orders WHERE orderkey % 2 = 0 UNION ALL " +
                         "SELECT orderdate, orderkey, totalprice FROM orders WHERE orderkey % 2 = 1",
@@ -187,7 +192,16 @@ public abstract class AbstractTestDistributedQueries
                 "SELECT count(*) FROM orders");
 
         assertCreateTableAsSelect(
-                getSession().withSystemProperty("redistribute_writes", "false"),
+                getSession().withSystemProperty("redistribute_writes", "true").withSystemProperty("push_table_write_through_union", "true"),
+                "test_union_all",
+                "SELECT orderdate, orderkey, totalprice FROM orders UNION ALL " +
+                        "SELECT DATE '2000-01-01', 1234567890, 1.23",
+                "SELECT orderdate, orderkey, totalprice FROM orders UNION ALL " +
+                        "SELECT DATE '2000-01-01', 1234567890, 1.23",
+                "SELECT count(*) + 1 FROM orders");
+
+        assertCreateTableAsSelect(
+                getSession().withSystemProperty("redistribute_writes", "false").withSystemProperty("push_table_write_through_union", "true"),
                 "test_union_all",
                 "SELECT orderdate, orderkey, totalprice FROM orders UNION ALL " +
                         "SELECT DATE '2000-01-01', 1234567890, 1.23",


### PR DESCRIPTION
The root cause is that local unions are created by AddExchanges to deal with the fact that some union sources are partitioned while others are not. When redistribute_writes is turned off, this used to cause BeginTableWrite to make invalid assumptions about children.