### PR TITLE
Add main method to test query runners

### DIFF
--- a/presto-blackhole/pom.xml
+++ b/presto-blackhole/pom.xml
@@ -67,6 +67,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/BlackHoleQueryRunner.java
+++ b/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/BlackHoleQueryRunner.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.blackhole;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.airlift.log.Logging;
+
+import java.util.Map;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static io.airlift.testing.Closeables.closeAllSuppress;
+
+public final class BlackHoleQueryRunner
+{
+    private BlackHoleQueryRunner() {}
+
+    public static DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createQueryRunner(ImmutableMap.of());
+    }
+
+    public static DistributedQueryRunner createQueryRunner(Map<String, String> extraProperties)
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("blackhole")
+                .setSchema("default")
+                .build();
+
+        DistributedQueryRunner queryRunner = new DistributedQueryRunner(session, 4, extraProperties);
+
+        try {
+            queryRunner.installPlugin(new BlackHolePlugin());
+            queryRunner.createCatalog("blackhole", "blackhole", ImmutableMap.of());
+
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of());
+
+            return queryRunner;
+        }
+        catch (Exception e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        Logging.initialize();
+        DistributedQueryRunner queryRunner = createQueryRunner(ImmutableMap.of("http-server.http.port", "8080"));
+        Thread.sleep(10);
+        Logger log = Logger.get(BlackHoleQueryRunner.class);
+        log.info("======== SERVER STARTED ========");
+        log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
+    }
+}

--- a/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/BlackHoleSmokeTest.java
+++ b/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/BlackHoleSmokeTest.java
@@ -19,9 +19,6 @@ import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.QueryRunner;
-import com.facebook.presto.tests.DistributedQueryRunner;
-import com.facebook.presto.tpch.TpchPlugin;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -34,8 +31,8 @@ import static com.facebook.presto.plugin.blackhole.BlackHoleConnector.FIELD_LENG
 import static com.facebook.presto.plugin.blackhole.BlackHoleConnector.PAGES_PER_SPLIT_PROPERTY;
 import static com.facebook.presto.plugin.blackhole.BlackHoleConnector.ROWS_PER_PAGE_PROPERTY;
 import static com.facebook.presto.plugin.blackhole.BlackHoleConnector.SPLIT_COUNT_PROPERTY;
+import static com.facebook.presto.plugin.blackhole.BlackHoleQueryRunner.createQueryRunner;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
-import static io.airlift.testing.Closeables.closeAllSuppress;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -50,20 +47,7 @@ public class BlackHoleSmokeTest
     public void setUp()
             throws Exception
     {
-        try {
-            queryRunner = new DistributedQueryRunner(createSession(), 3);
-
-            queryRunner.installPlugin(new BlackHolePlugin());
-            queryRunner.createCatalog("blackhole", "blackhole", ImmutableMap.of());
-
-            queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of());
-            assertThatNoBlackHoleTableIsCreated();
-        }
-        catch (Throwable e) {
-            closeAllSuppress(e, queryRunner);
-            throw e;
-        }
+        queryRunner = createQueryRunner();
     }
 
     @AfterTest
@@ -71,14 +55,6 @@ public class BlackHoleSmokeTest
     {
         assertThatNoBlackHoleTableIsCreated();
         queryRunner.close();
-    }
-
-    public static Session createSession()
-    {
-        return testSessionBuilder()
-                .setCatalog("blackhole")
-                .setSchema("default")
-                .build();
     }
 
     @Test
@@ -207,7 +183,7 @@ public class BlackHoleSmokeTest
 
     private List<QualifiedObjectName> listBlackHoleTables()
     {
-        return queryRunner.listTables(createSession(), "blackhole", "default");
+        return queryRunner.listTables(queryRunner.getDefaultSession(), "blackhole", "default");
     }
 
     private void assertThatQueryReturnsValue(String sql, Object expected)
@@ -222,7 +198,7 @@ public class BlackHoleSmokeTest
         int fieldCount = materializedRow.getFieldCount();
         assertTrue(fieldCount == 1, format("Expected only one column, but got '%d'", fieldCount));
         Object value = materializedRow.getField(0);
-        assertTrue(value == expected, format("Expected '%s', but got '%s'", expected, value));
+        assertEquals(value, expected);
         assertTrue(Iterables.getOnlyElement(rows).getFieldCount() == 1);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -82,6 +82,7 @@ import static com.facebook.presto.server.ConditionalModule.installModuleIf;
 import static com.facebook.presto.server.testing.FileUtils.deleteRecursively;
 import static com.google.common.base.Strings.nullToEmpty;
 import static io.airlift.discovery.client.ServiceAnnouncement.serviceAnnouncement;
+import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -152,6 +153,12 @@ public class TestingPrestoServer
         this.coordinator = coordinator;
         baseDataDir = Files.createTempDirectory("PrestoTest");
 
+        properties = new HashMap<>(properties);
+        String coordinatorPort = properties.remove("http-server.http.port");
+        if (coordinatorPort == null) {
+            coordinatorPort = "0";
+        }
+
         ImmutableMap.Builder<String, String> serverProperties = ImmutableMap.<String, String>builder()
                 .putAll(properties)
                 .put("coordinator", String.valueOf(coordinator))
@@ -172,7 +179,7 @@ public class TestingPrestoServer
 
         ImmutableList.Builder<Module> modules = ImmutableList.<Module>builder()
                 .add(new TestingNodeModule(Optional.ofNullable(environment)))
-                .add(new TestingHttpServerModule())
+                .add(new TestingHttpServerModule(parseInt(coordinator ? coordinatorPort : "0")))
                 .add(new JsonModule())
                 .add(new JaxrsModule(true))
                 .add(new MBeanModule())

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/RaptorQueryRunner.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/RaptorQueryRunner.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
-import static io.airlift.tpch.TpchTable.getTables;
 
 public final class RaptorQueryRunner
 {
@@ -46,7 +45,13 @@ public final class RaptorQueryRunner
     public static DistributedQueryRunner createRaptorQueryRunner(Iterable<TpchTable<?>> tables)
             throws Exception
     {
-        DistributedQueryRunner queryRunner = new DistributedQueryRunner(createSession("tpch"), 2);
+        return createRaptorQueryRunner(ImmutableMap.of(), ImmutableList.copyOf(tables));
+    }
+
+    public static DistributedQueryRunner createRaptorQueryRunner(Map<String, String> extraProperties, Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = new DistributedQueryRunner(createSession("tpch"), 2, extraProperties);
 
         queryRunner.installPlugin(new TpchPlugin());
         queryRunner.createCatalog("tpch", "tpch");
@@ -96,7 +101,7 @@ public final class RaptorQueryRunner
             throws Exception
     {
         Logging.initialize();
-        DistributedQueryRunner queryRunner = createRaptorQueryRunner(getTables());
+        DistributedQueryRunner queryRunner = createRaptorQueryRunner(ImmutableMap.of("http-server.http.port", "8080"), ImmutableList.of());
         Thread.sleep(10);
         Logger log = Logger.get(RaptorQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -172,5 +172,11 @@
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedQueries.java
@@ -13,11 +13,7 @@
  */
 package com.facebook.presto.tests;
 
-import com.facebook.presto.Session;
-import com.facebook.presto.tpch.TpchPlugin;
-import com.facebook.presto.tpch.testing.SampledTpchPlugin;
-
-import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
 
 public class TestTpchDistributedQueries
         extends AbstractTestQueries
@@ -26,31 +22,5 @@ public class TestTpchDistributedQueries
             throws Exception
     {
         super(createQueryRunner());
-    }
-
-    private static DistributedQueryRunner createQueryRunner()
-            throws Exception
-    {
-        Session session = testSessionBuilder()
-                .setSource("test")
-                .setCatalog("tpch")
-                .setSchema("tiny")
-                .build();
-
-        DistributedQueryRunner queryRunner = new DistributedQueryRunner(session, 4);
-
-        try {
-            queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
-
-            queryRunner.installPlugin(new SampledTpchPlugin());
-            queryRunner.createCatalog("tpch_sampled", "tpch_sampled");
-
-            return queryRunner;
-        }
-        catch (Exception e) {
-            queryRunner.close();
-            throw e;
-        }
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.tpch;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.facebook.presto.tpch.testing.SampledTpchPlugin;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.airlift.log.Logging;
+
+import java.util.Map;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public final class TpchQueryRunner
+{
+    private TpchQueryRunner() {}
+
+    public static DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createQueryRunner(ImmutableMap.of());
+    }
+
+    public static DistributedQueryRunner createQueryRunner(Map<String, String> extraProperties)
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setSource("test")
+                .setCatalog("tpch")
+                .setSchema("tiny")
+                .build();
+
+        DistributedQueryRunner queryRunner = new DistributedQueryRunner(session, 4, extraProperties);
+
+        try {
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
+
+            queryRunner.installPlugin(new SampledTpchPlugin());
+            queryRunner.createCatalog("tpch_sampled", "tpch_sampled");
+
+            return queryRunner;
+        }
+        catch (Exception e) {
+            queryRunner.close();
+            throw e;
+        }
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        Logging.initialize();
+        DistributedQueryRunner queryRunner = createQueryRunner(ImmutableMap.of("http-server.http.port", "8080"));
+        Thread.sleep(10);
+        Logger log = Logger.get(TpchQueryRunner.class);
+        log.info("======== SERVER STARTED ========");
+        log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
+    }
+}


### PR DESCRIPTION
The *QueryRunner classes know how to create a small Presto cluster for unit
tests, and since they are used for testing, they always work.  Thes mini
clusters are useful for debugging issues with connector since they start
quickly and don't suffer from class loader and build issuses when starting a
full Presto server.