### PR TITLE
Clarify that varchar(n) is not a supported type, while varchar is.

### DIFF
--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -5,6 +5,9 @@ Data Types
 Presto currently supports a limited set of data types.
 These types can be used with the standard ``CAST`` operator.
 
+Note that types parameterized by integers, such as VARCHAR(n) are NOT yet
+supported.
+
 BOOLEAN
 -------
 
@@ -25,12 +28,12 @@ DOUBLE
 VARCHAR
 -------
 
-    Variable length character data.
+    Variable length character data. (Note however that VARCHAR(n) is not supported.)
 
 VARBINARY
 ---------
 
-    Variable length binary data.
+    Variable length binary data. (Note however that VARBINARY(n) is not supported.)
 
 JSON
 ----
@@ -117,4 +120,3 @@ ROW
     accessed with field reference operator ``.``
 
     Example: ``my_column.my_field``
-


### PR DESCRIPTION
We had the same question as #3257 too. This makes it a little clearer that that varchar(n) isn't supported, while varchar is.