### PR TITLE
Change default builder to multithreaded

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
--b singlethreaded
+-b multithreaded
+


### PR DESCRIPTION
This is the default in Maven, and reduces build time for "mvn clean
install -DskipTests -T4" from 6min 31sec to 4min 15secs on my laptop