### PR TITLE
Update native libraries for hive-hadoop2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
             <dependency>
                 <groupId>com.facebook.presto.hadoop</groupId>
                 <artifactId>hadoop-apache2</artifactId>
-                <version>0.2</version>
+                <version>0.3</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This allows running on older Linux distributions.