### PR TITLE
Increase default http timeout threads

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -48,7 +48,7 @@ public class TaskManagerConfig
     private int writerCount = 1;
     private int taskDefaultConcurrency = 1;
     private int httpResponseThreads = 100;
-    private int httpTimeoutThreads = 1;
+    private int httpTimeoutThreads = 3;
 
     @MinDuration("1ms")
     @MaxDuration("10s")

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -47,7 +47,7 @@ public class TestTaskManagerConfig
                 .setWriterCount(1)
                 .setTaskDefaultConcurrency(1)
                 .setHttpResponseThreads(100)
-                .setHttpTimeoutThreads(1));
+                .setHttpTimeoutThreads(3));
     }
 
     @Test


### PR DESCRIPTION
With a default of one thread, it's impossible to tell if there's a
backlog of http requests that need to be timed out.