### PR TITLE
Remove redundant check for aggregation functions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1631,10 +1631,8 @@ class StatementAnalyzer
                 .distinct()
                 .collect(toImmutableList());
 
-        // check if:
-        // - aggregation is present: SELECT SUM(x) FROM table; or
-        // - group by is present: SELECT ... FROM table GROUP BY category
-        if (!aggregates.isEmpty() || !groupingSets.isEmpty()) {
+        // is this an aggregation query?
+        if (!groupingSets.isEmpty()) {
             // ensure SELECT, ORDER BY and HAVING are constant with respect to group
             // e.g, these are all valid expressions:
             //     SELECT f(a) GROUP BY a

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -683,6 +683,13 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testGroupByEmpty()
+            throws Exception
+    {
+        assertFails(MUST_BE_AGGREGATE_OR_GROUP_BY, "SELECT a FROM t1 GROUP BY ()");
+    }
+
+    @Test
     public void testSingleGroupingSet()
             throws Exception
     {


### PR DESCRIPTION
- We already create a grand total grouping set when implicit
  aggregations are present, and therefore can simply check if
  groupingSets is non-empty
- Add test to verify error for select items not in GROUP BY ()