### PR TITLE
Add resource_over_commit session property

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.132.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.132.rst
@@ -9,6 +9,9 @@ General Changes
 * Add support for creating constant arrays with more than 255 elements.
 * Fix analyzer for queries with ``GROUP BY ()`` such that errors are raised
   during analysis rather than execution.
+* Add ``resource_over_commit`` session property. This disables all memory
+  limits for the query. Instead it may be killed at any time, if the coordinator
+  needs to reclaim memory.
 
 CLI Changes
 -----------

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -47,6 +47,7 @@ public final class SystemSessionProperties
     public static final String TASK_SHARE_INDEX_LOADING = "task_share_index_loading";
     public static final String QUERY_MAX_MEMORY = "query_max_memory";
     public static final String QUERY_MAX_RUN_TIME = "query_max_run_time";
+    public static final String RESOURCE_OVER_COMMIT = "resource_over_commit";
     public static final String REDISTRIBUTE_WRITES = "redistribute_writes";
     public static final String PUSH_TABLE_WRITE_THROUGH_UNION = "push_table_write_through_union";
     public static final String EXECUTION_POLICY = "execution_policy";
@@ -160,6 +161,11 @@ public final class SystemSessionProperties
                         true,
                         value -> DataSize.valueOf((String) value)),
                 booleanSessionProperty(
+                        RESOURCE_OVER_COMMIT,
+                        "Use resources which are not guaranteed to be available to the query",
+                        false,
+                        false),
+                booleanSessionProperty(
                         COLUMNAR_PROCESSING,
                         "Use columnar processing",
                         featuresConfig.isColumnarProcessing(),
@@ -264,6 +270,11 @@ public final class SystemSessionProperties
     public static Duration getQueryMaxRunTime(Session session)
     {
         return session.getProperty(QUERY_MAX_RUN_TIME, Duration.class);
+    }
+
+    public static boolean resourceOverCommit(Session session)
+    {
+        return session.getProperty(RESOURCE_OVER_COMMIT, Boolean.class);
     }
 
     private static <T> T getPropertyOr(Session session, String propertyName, String defaultPropertyName, Class<T> type)

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -53,6 +53,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import static com.facebook.presto.SystemSessionProperties.resourceOverCommit;
 import static com.google.common.base.Predicates.notNull;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.transform;
@@ -257,6 +258,11 @@ public class SqlTaskManager
         requireNonNull(fragment, "fragment is null");
         requireNonNull(sources, "sources is null");
         requireNonNull(outputBuffers, "outputBuffers is null");
+
+        if (resourceOverCommit(session)) {
+            // TODO: This should have been done when the QueryContext was created. However, the session isn't available at that point.
+            queryContexts.getUnchecked(taskId.getQueryId()).setResourceOverCommit();
+        }
 
         SqlTask sqlTask = tasks.getUnchecked(taskId);
         sqlTask.recordHeartbeat();

--- a/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
@@ -37,10 +37,13 @@ import static java.util.Objects.requireNonNull;
 public class QueryContext
 {
     private final QueryId queryId;
-    private final long maxMemory;
     private final Executor executor;
     private final List<TaskContext> taskContexts = new CopyOnWriteArrayList<>();
     private final MemoryPool systemMemoryPool;
+
+    // TODO: This field should be final. However, due to the way QueryContext is constructed the memory limit is not known in advance
+    @GuardedBy("this")
+    private long maxMemory;
 
     @GuardedBy("this")
     private long reserved;
@@ -58,6 +61,13 @@ public class QueryContext
         this.memoryPool = requireNonNull(memoryPool, "memoryPool is null");
         this.systemMemoryPool = requireNonNull(systemMemoryPool, "systemMemoryPool is null");
         this.executor = requireNonNull(executor, "executor is null");
+    }
+
+    // TODO: This method should be removed, and the correct limit set in the constructor. However, due to the way QueryContext is constructed the memory limit is not known in advance
+    public synchronized void setResourceOverCommit()
+    {
+        // Don't enforce any limit. The coordinator will kill the query if the cluster runs out of memory.
+        maxMemory = Long.MAX_VALUE;
     }
 
     public synchronized ListenableFuture<?> reserveMemory(long bytes)

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import static com.facebook.presto.SystemSessionProperties.RESOURCE_OVER_COMMIT;
 import static com.facebook.presto.execution.QueryState.FINISHED;
 import static com.facebook.presto.execution.StageInfo.getAllStages;
 import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
@@ -49,6 +50,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 @Test(singleThreaded = true)
 public class TestMemoryManager
@@ -65,6 +67,29 @@ public class TestMemoryManager
             .build();
 
     private final ExecutorService executor = newCachedThreadPool();
+
+    @Test(timeOut = 240_000)
+    public void testResourceOverCommit()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("task.operator-pre-allocated-memory", "0B")
+                .put("query.max-memory-per-node", "1kB")
+                .put("query.max-memory", "1kB")
+                .build();
+
+        try (DistributedQueryRunner queryRunner = createQueryRunner(TINY_SESSION, properties)) {
+            try {
+                queryRunner.execute("SELECT COUNT(*), clerk FROM orders GROUP BY clerk");
+                fail();
+            }
+            catch (RuntimeException e) {
+                // expected
+            }
+            Session session = TINY_SESSION.withSystemProperty(RESOURCE_OVER_COMMIT, "true");
+            queryRunner.execute(session, "SELECT COUNT(*), clerk FROM orders GROUP BY clerk");
+        }
+    }
 
     @Test(timeOut = 240_000, expectedExceptions = ExecutionException.class, expectedExceptionsMessageRegExp = ".*The cluster is out of memory, and your query was killed. Please try again in a few minutes.")
     public void testOutOfMemoryKiller()


### PR DESCRIPTION
This session property indicates that the query would like to opt-out of
the normal memory management system. This disables all memory limits for
the query, but means that it may be killed at any time, even if its
memory usage is zero, if the coordinator needs to reclaim memory.