### PR TITLE
Add identifier to dictionary blocks

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
@@ -25,6 +25,7 @@ import java.util.List;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.Slices.wrappedIntArray;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestDictionaryBlock
@@ -127,11 +128,15 @@ public class TestDictionaryBlock
 
         assertEquals(dictionaryBlock.isCompact(), false);
         DictionaryBlock compactBlock = dictionaryBlock.compact();
+        assertNotEquals(dictionaryBlock.getIdentifier(), compactBlock.getIdentifier());
 
         assertEquals(compactBlock.getDictionary().getPositionCount(), (expectedValues.length / 2) + 1);
         assertBlock(compactBlock.getDictionary(), new Slice[] { expectedValues[0], expectedValues[1], expectedValues[3] });
         assertEquals(compactBlock.getIds(), wrappedIntArray(0, 1, 1, 2, 2, 0, 1, 1, 2, 2));
         assertEquals(compactBlock.isCompact(), true);
+
+        DictionaryBlock reCompactedBlock = compactBlock.compact();
+        assertEquals(reCompactedBlock.getIdentifier(), compactBlock.getIdentifier());
     }
 
     @Test

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/RaptorQueryRunner.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/RaptorQueryRunner.java
@@ -32,8 +32,6 @@ import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 
 public final class RaptorQueryRunner
 {
-    private static final Logger log = Logger.get(RaptorQueryRunner.class);
-
     private RaptorQueryRunner() {}
 
     public static DistributedQueryRunner createRaptorQueryRunner(TpchTable<?>... tables)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -19,6 +19,7 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import static com.facebook.presto.spi.block.BlockValidationUtil.checkValidPositions;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
@@ -38,13 +39,19 @@ public class DictionaryBlock
     private final int retainedSizeInBytes;
     private final int sizeInBytes;
     private final int uniqueIds;
+    private final UUID identifier;
+
+    public DictionaryBlock(int positionCount, Block dictionary, Slice ids, boolean dictionaryIsCompacted)
+    {
+        this(positionCount, dictionary, ids, dictionaryIsCompacted, UUID.randomUUID());
+    }
 
     public DictionaryBlock(int positionCount, Block dictionary, Slice ids)
     {
-        this(positionCount, dictionary, ids, false);
+        this(positionCount, dictionary, ids, false, UUID.randomUUID());
     }
 
-    public DictionaryBlock(int positionCount, Block dictionary, Slice ids, boolean dictionaryIsCompacted)
+    public DictionaryBlock(int positionCount, Block dictionary, Slice ids, boolean dictionaryIsCompacted, UUID identifier)
     {
         requireNonNull(dictionary, "dictionary is null");
         requireNonNull(ids, "ids is null");
@@ -60,6 +67,7 @@ public class DictionaryBlock
         this.positionCount = positionCount;
         this.dictionary = dictionary;
         this.ids = ids;
+        this.identifier = requireNonNull(identifier, "identifier is null");
 
         this.retainedSizeInBytes = INSTANCE_SIZE + dictionary.getRetainedSizeInBytes() + ids.getRetainedSize();
 
@@ -269,6 +277,11 @@ public class DictionaryBlock
     public Slice getIds()
     {
         return ids;
+    }
+
+    public UUID getIdentifier()
+    {
+        return identifier;
     }
 
     public boolean isCompact()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlockEncoding.java
@@ -18,6 +18,8 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
+import java.util.UUID;
+
 import static java.util.Objects.requireNonNull;
 
 public class DictionaryBlockEncoding
@@ -59,6 +61,10 @@ public class DictionaryBlockEncoding
         sliceOutput
                 .appendInt(ids.length())
                 .writeBytes(ids);
+
+        // instance id
+        sliceOutput.appendLong(dictionaryBlock.getIdentifier().getMostSignificantBits());
+        sliceOutput.appendLong(dictionaryBlock.getIdentifier().getLeastSignificantBits());
     }
 
     @Override
@@ -74,8 +80,12 @@ public class DictionaryBlockEncoding
         int lengthIdsSlice = sliceInput.readInt();
         Slice ids = sliceInput.readSlice(lengthIdsSlice);
 
+        // instance id
+        long msb = sliceInput.readLong();
+        long lsb = sliceInput.readLong();
+
         // we always compact the dictionary before we send it
-        return new DictionaryBlock(positionCount, dictionaryBlock, ids, true);
+        return new DictionaryBlock(positionCount, dictionaryBlock, ids, true, new UUID(msb, lsb));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
@@ -145,27 +145,6 @@ public class SliceArrayBlock
         return new SliceArrayBlock(length, deepCopyAndCompact(values, positionOffset, length));
     }
 
-    static Slice[] deepCopyAndCompactDictionary(Slice[] values, int[] ids, int positionOffset, int length)
-    {
-        Slice[] newValues = new Slice[length];
-        // Compact the slices. Use an IdentityHashMap because this could be very expensive otherwise.
-        Map<Slice, Slice> distinctValues = new IdentityHashMap<>();
-        for (int i = positionOffset; i < positionOffset + length; i++) {
-            Slice slice = values[ids[i]];
-            if (slice == null) {
-                continue;
-            }
-
-            Slice distinct = distinctValues.get(slice);
-            if (distinct == null) {
-                distinct = Slices.copyOf(slice);
-                distinctValues.put(slice, distinct);
-            }
-            newValues[i] = distinct;
-        }
-        return newValues;
-    }
-
     static Slice[] deepCopyAndCompact(Slice[] values, int positionOffset, int length)
     {
         Slice[] newValues = Arrays.copyOfRange(values, positionOffset, positionOffset + length);

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 
 import java.util.Locale;
 import java.util.Optional;
+import java.util.UUID;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
@@ -95,7 +96,7 @@ public class TestDictionaryBlockEncoding
         Slice idsSlice = Slices.wrappedIntArray(ids);
 
         BlockEncoding blockEncoding = new DictionaryBlockEncoding(new VariableWidthBlockEncoding());
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(positionCount, dictionary, idsSlice);
+        DictionaryBlock dictionaryBlock = new DictionaryBlock(positionCount, dictionary, idsSlice, false, UUID.randomUUID());
 
         DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1024);
         blockEncoding.writeBlock(sliceOutput, dictionaryBlock);
@@ -105,6 +106,7 @@ public class TestDictionaryBlockEncoding
         DictionaryBlock actualDictionaryBlock = (DictionaryBlock) actualBlock;
         assertBlockEquals(VARCHAR, actualDictionaryBlock.getDictionary(), dictionary);
         assertEquals(actualDictionaryBlock.getIds(), idsSlice);
+        assertEquals(actualDictionaryBlock.getIdentifier(), dictionaryBlock.getIdentifier());
     }
 
     private static void assertBlockEquals(Type type, Block actual, Block expected)


### PR DESCRIPTION
The identifier in a dictionary block represents the source block it was
projected from. If a dictionary block is projected into several blocks,
all the projected blocks will have the same identifier.

This is needed for deterministically corelating dictionary blocks in a
page for optimizations in operators and for compacting pages.