### PR TITLE
Remove null and partition key from SHOW COLUMNS

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.134.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.134.rst
@@ -6,3 +6,10 @@ General Changes
 ---------------
 
 * Add cumulative memory statistics tracking and expose the stat in the web interface.
+* Remove nullability and partition key flags from :doc:`/sql/show-columns`.
+* Remove non-standard ``is_partition_key`` column from ``information_schema.columns``.
+
+Hive Changes
+------------
+
+* The comment for partition keys is now prefixed with *"Partition Key"*.

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
@@ -69,7 +69,6 @@ public class InformationSchemaMetadata
                     .column("column_default", VARCHAR)
                     .column("is_nullable", VARCHAR)
                     .column("data_type", VARCHAR)
-                    .column("is_partition_key", VARCHAR)
                     .column("comment", VARCHAR)
                     .build())
             .table(tableMetadataBuilder(TABLE_TABLES)

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -167,7 +167,6 @@ public class InformationSchemaPageSourceProvider
                         null,
                         "YES",
                         column.getType().getDisplayName(),
-                        column.isPartitionKey() ? "YES" : "NO",
                         column.getComment());
                 ordinalPosition++;
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -136,7 +136,6 @@ import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.sql.QueryUtil.aliased;
 import static com.facebook.presto.sql.QueryUtil.aliasedName;
 import static com.facebook.presto.sql.QueryUtil.aliasedNullToEmpty;
-import static com.facebook.presto.sql.QueryUtil.aliasedYesNoToBoolean;
 import static com.facebook.presto.sql.QueryUtil.ascending;
 import static com.facebook.presto.sql.QueryUtil.caseWhen;
 import static com.facebook.presto.sql.QueryUtil.equal;
@@ -323,8 +322,6 @@ class StatementAnalyzer
                 selectList(
                         aliasedName("column_name", "Column"),
                         aliasedName("data_type", "Type"),
-                        aliasedYesNoToBoolean("is_nullable", "Null"),
-                        aliasedYesNoToBoolean("is_partition_key", "Partition Key"),
                         aliasedNullToEmpty("comment", "Comment")),
                 from(tableName.getCatalogName(), TABLE_COLUMNS),
                 logicalAnd(

--- a/presto-main/src/test/java/com/facebook/presto/TestHiddenColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/TestHiddenColumns.java
@@ -21,7 +21,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
-import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static org.testng.Assert.assertEquals;
 
@@ -47,10 +46,10 @@ public class TestHiddenColumns
     public void testDescribeTable()
             throws Exception
     {
-        MaterializedResult expected = MaterializedResult.resultBuilder(TEST_SESSION, VARCHAR, VARCHAR, BOOLEAN, BOOLEAN, VARCHAR)
-                .row("regionkey", "bigint", true, false, "")
-                .row("name", "varchar", true, false, "")
-                .row("comment", "varchar", true, false, "")
+        MaterializedResult expected = MaterializedResult.resultBuilder(TEST_SESSION, VARCHAR, VARCHAR, VARCHAR)
+                .row("regionkey", "bigint", "")
+                .row("name", "varchar", "")
+                .row("comment", "varchar", "")
                 .build();
         assertEquals(runner.execute("DESC REGION"), expected);
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
@@ -14,13 +14,11 @@
 package com.facebook.presto.sql;
 
 import com.facebook.presto.sql.tree.AliasedRelation;
-import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupingElement;
-import com.facebook.presto.sql.tree.IfExpression;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
@@ -139,15 +137,6 @@ public final class QueryUtil
     public static SelectItem aliasedNullToEmpty(String column, String alias)
     {
         return new SingleColumn(new CoalesceExpression(nameReference(column), new StringLiteral("")), alias);
-    }
-
-    public static SelectItem aliasedYesNoToBoolean(String column, String alias)
-    {
-        Expression expression = new IfExpression(
-                equal(nameReference(column), new StringLiteral("YES")),
-                BooleanLiteral.TRUE_LITERAL,
-                BooleanLiteral.FALSE_LITERAL);
-        return new SingleColumn(expression, alias);
     }
 
     public static List<SortItem> ordering(SortItem... items)

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/catalog/describe.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/catalog/describe.result
@@ -1,5 +1,5 @@
--- delimiter: |; trimValues:true; types: LONGNVARCHAR|LONGNVARCHAR|BOOLEAN|BOOLEAN|LONGNVARCHAR
-n_nationkey | bigint  | true | false         | |
-n_name      | varchar | true | false         | |
-n_regionkey | bigint  | true | false         | |
-n_comment   | varchar | true | false         | |
+-- delimiter: |; trimValues:true; types: LONGNVARCHAR|LONGNVARCHAR|LONGNVARCHAR
+n_nationkey | bigint  | |
+n_name      | varchar | |
+n_regionkey | bigint  | |
+n_comment   | varchar | |

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/catalog/showColumns.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/catalog/showColumns.result
@@ -1,5 +1,5 @@
--- delimiter: |; ignoreOrder: true; ignoreExcessRows:true; trimValues:true; types: LONGNVARCHAR|LONGNVARCHAR|BOOLEAN|BOOLEAN|LONGNVARCHAR
- node_id      | varchar | true | false         |         |
- http_uri     | varchar | true | false         |         |
- node_version | varchar | true | false         |         |
- active       | boolean | true | false         |         |
+-- delimiter: |; ignoreOrder: true; ignoreExcessRows:true; trimValues:true; types: LONGNVARCHAR|LONGNVARCHAR|LONGNVARCHAR
+ node_id      | varchar |         |
+ http_uri     | varchar |         |
+ node_version | varchar |         |
+ active       | boolean |         |

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
@@ -65,8 +65,7 @@ system| information_schema| columns| ordinal_position| 5| null| YES| bigint| NO|
 system| information_schema| columns| column_default| 6| null| YES| varchar| NO| null|
 system| information_schema| columns| is_nullable| 7| null| YES| varchar| NO| null|
 system| information_schema| columns| data_type| 8| null| YES| varchar| NO| null|
-system| information_schema| columns| is_partition_key| 9| null| YES| varchar| NO| null|
-system| information_schema| columns| comment| 10| null| YES| varchar| NO| null|
+system| information_schema| columns| comment| 9| null| YES| varchar| NO| null|
 system| information_schema| views| table_catalog| 1| null| YES| varchar| NO| null|
 system| information_schema| views| table_schema| 2| null| YES| varchar| NO| null|
 system| information_schema| views| table_name| 3| null| YES| varchar| NO| null|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.sql
@@ -8,6 +8,5 @@ select
   column_default,
   is_nullable,
   data_type,
-  is_partition_key,
   comment
 from SYSTEM.information_schema.columns

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -28,7 +28,6 @@ import org.testng.annotations.Test;
 import java.util.List;
 
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.INFORMATION_SCHEMA;
-import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.SqlFormatter.formatSql;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
@@ -505,9 +504,9 @@ public abstract class AbstractTestDistributedQueries
         // test SHOW COLUMNS
         actual = computeActual("SHOW COLUMNS FROM meta_test_view");
 
-        expected = resultBuilder(getSession(), VARCHAR, VARCHAR, BOOLEAN, BOOLEAN, VARCHAR)
-                .row("x", "bigint", true, false, "")
-                .row("y", "varchar", true, false, "")
+        expected = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR)
+                .row("x", "bigint", "")
+                .row("y", "varchar", "")
                 .build();
 
         assertEquals(actual, expected);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -25,7 +25,6 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_MEMORY;
-import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.ADD_COLUMN;
 import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.CREATE_TABLE;
@@ -306,16 +305,16 @@ public abstract class AbstractTestIntegrationSmokeTest
         else {
             orderDateType = "varchar";
         }
-        return MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR, VARCHAR, BOOLEAN, BOOLEAN, VARCHAR)
-                    .row("orderkey", "bigint", true, false, "")
-                    .row("custkey", "bigint", true, false, "")
-                    .row("orderstatus", "varchar", true, false, "")
-                    .row("totalprice", "double", true, false, "")
-                    .row("orderdate", orderDateType, true, false, "")
-                    .row("orderpriority", "varchar", true, false, "")
-                    .row("clerk", "varchar", true, false, "")
-                    .row("shippriority", "bigint", true, false, "")
-                    .row("comment", "varchar", true, false, "")
+        return MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR, VARCHAR, VARCHAR)
+                    .row("orderkey", "bigint", "")
+                    .row("custkey", "bigint", "")
+                    .row("orderstatus", "varchar", "")
+                    .row("totalprice", "double", "")
+                    .row("orderdate", orderDateType, "")
+                    .row("orderpriority", "varchar", "")
+                    .row("clerk", "varchar", "")
+                    .row("shippriority", "bigint", "")
+                    .row("comment", "varchar", "")
                     .build();
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -49,7 +49,6 @@ import java.util.Set;
 
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.INFORMATION_SCHEMA;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.TimeType.TIME;
@@ -3850,16 +3849,16 @@ public abstract class AbstractTestQueries
     {
         MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
 
-        MaterializedResult expected = resultBuilder(getSession(), VARCHAR, VARCHAR, BOOLEAN, BOOLEAN, VARCHAR)
-                .row("orderkey", "bigint", true, false, "")
-                .row("custkey", "bigint", true, false, "")
-                .row("orderstatus", "varchar", true, false, "")
-                .row("totalprice", "double", true, false, "")
-                .row("orderdate", "date", true, false, "")
-                .row("orderpriority", "varchar", true, false, "")
-                .row("clerk", "varchar", true, false, "")
-                .row("shippriority", "bigint", true, false, "")
-                .row("comment", "varchar", true, false, "")
+        MaterializedResult expected = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR)
+                .row("orderkey", "bigint", "")
+                .row("custkey", "bigint", "")
+                .row("orderstatus", "varchar", "")
+                .row("totalprice", "double", "")
+                .row("orderdate", "date", "")
+                .row("orderpriority", "varchar", "")
+                .row("clerk", "varchar", "")
+                .row("shippriority", "bigint", "")
+                .row("comment", "varchar", "")
                 .build();
 
         assertEquals(actual, expected);


### PR DESCRIPTION
Knowledge of nullability is not implemented at all.

Partition keys are only used by the Hive connector, so we can handle that
by adding the information to the comment column.