### PR TITLE
Separate multiple-tasks-per-node tests

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -138,7 +138,6 @@ public class DistributedQueryRunner
         if (coordinator) {
             propertiesBuilder.put("node-scheduler.include-coordinator", "true");
             propertiesBuilder.put("distributed-joins-enabled", "true");
-            propertiesBuilder.put("node-scheduler.multiple-tasks-per-node-enabled", "true");
         }
         HashMap<String, String> properties = new HashMap<>(propertiesBuilder.build());
         properties.putAll(extraProperties);

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMultipleTasksPerNode.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMultipleTasksPerNode.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+
+public class TestMultipleTasksPerNode
+        extends AbstractTestQueryFramework
+{
+    public TestMultipleTasksPerNode()
+            throws Exception
+    {
+        super(createQueryRunner(ImmutableMap.of("node-scheduler.multiple-tasks-per-node-enabled", "true")));
+    }
+
+    @Test
+    public void test15WayGroupBy()
+            throws Exception
+    {
+        // Among other things, this test verifies we are not getting for overflow in the distributed HashPagePartitionFunction
+        assertQuery("" +
+                "SELECT " +
+                "    orderkey + 1, orderkey + 2, orderkey + 3, orderkey + 4, orderkey + 5, " +
+                "    orderkey + 6, orderkey + 7, orderkey + 8, orderkey + 9, orderkey + 10, " +
+                "    count(*) " +
+                "FROM orders " +
+                "GROUP BY " +
+                "    orderkey + 1, orderkey + 2, orderkey + 3, orderkey + 4, orderkey + 5, " +
+                "    orderkey + 6, orderkey + 7, orderkey + 8, orderkey + 9, orderkey + 10");
+    }
+
+    @Test
+    public void testJoinAggregations()
+            throws Exception
+    {
+        assertQuery(
+                "SELECT x + y FROM (" +
+                        "   SELECT orderdate, COUNT(*) x FROM orders GROUP BY orderdate) a JOIN (" +
+                        "   SELECT orderdate, COUNT(*) y FROM orders GROUP BY orderdate) b ON a.orderdate = b.orderdate");
+    }
+}


### PR DESCRIPTION
This reduces run time of tests in presto-tests by ~5%, and should reduce
http stress, which will hopefully help Travis