### PR TITLE
Add optimization for RunLengthEncoded blocks in PageProcessor

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPageProcessorCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPageProcessorCompiler.java
@@ -17,7 +17,8 @@ import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.operator.PageProcessor;
-import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.relational.CallExpression;
 import com.facebook.presto.sql.relational.ConstantExpression;
@@ -25,18 +26,27 @@ import com.facebook.presto.sql.relational.InputReferenceExpression;
 import com.facebook.presto.sql.relational.RowExpression;
 import com.facebook.presto.type.ArrayType;
 import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static java.lang.Boolean.TRUE;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestPageProcessorCompiler
 {
+    private static final MetadataManager METADATA_MANAGER = createTestMetadataManager();
+
     @Test
     public void testNoCaching()
             throws Throwable
     {
-        MetadataManager metadata = MetadataManager.createTestMetadataManager();
+        MetadataManager metadata = METADATA_MANAGER;
         ExpressionCompiler compiler = new ExpressionCompiler(metadata);
         ImmutableList.Builder<RowExpression> projectionsBuilder = ImmutableList.builder();
         ArrayType arrayType = new ArrayType(VARCHAR);
@@ -44,8 +54,30 @@ public class TestPageProcessorCompiler
         projectionsBuilder.add(new CallExpression(signature, arrayType, ImmutableList.of(new InputReferenceExpression(0, arrayType), new InputReferenceExpression(1, arrayType))));
 
         ImmutableList<RowExpression> projections = projectionsBuilder.build();
-        PageProcessor pageProcessor = compiler.compilePageProcessor(new ConstantExpression(true, BooleanType.BOOLEAN), projections);
-        PageProcessor pageProcessor2 = compiler.compilePageProcessor(new ConstantExpression(true, BooleanType.BOOLEAN), projections);
+        PageProcessor pageProcessor = compiler.compilePageProcessor(new ConstantExpression(true, BOOLEAN), projections);
+        PageProcessor pageProcessor2 = compiler.compilePageProcessor(new ConstantExpression(true, BOOLEAN), projections);
         assertTrue(pageProcessor != pageProcessor2);
+    }
+
+    @Test
+    public void testSanityRLE()
+            throws Exception
+    {
+        PageProcessor processor = new ExpressionCompiler(createTestMetadataManager())
+                .compilePageProcessor(new ConstantExpression(TRUE, BOOLEAN), ImmutableList.of(new InputReferenceExpression(0, BIGINT), new InputReferenceExpression(1, VARCHAR)));
+
+        Slice varcharValue = Slices.utf8Slice("hello");
+        Page page = new Page(RunLengthEncodedBlock.create(BIGINT, 123L, 100), RunLengthEncodedBlock.create(VARCHAR, varcharValue, 100));
+        Page outputPage = processor.processColumnarDictionary(null, page, ImmutableList.of(BIGINT, VARCHAR));
+
+        assertEquals(outputPage.getPositionCount(), 100);
+        assertTrue(outputPage.getBlock(0) instanceof RunLengthEncodedBlock);
+        assertTrue(outputPage.getBlock(1) instanceof RunLengthEncodedBlock);
+
+        RunLengthEncodedBlock rleBlock = (RunLengthEncodedBlock) outputPage.getBlock(0);
+        assertEquals(BIGINT.getLong(rleBlock.getValue(), 0), 123L);
+
+        RunLengthEncodedBlock rleBlock1 = (RunLengthEncodedBlock) outputPage.getBlock(1);
+        assertEquals(VARCHAR.getSlice(rleBlock1.getValue(), 0), varcharValue);
     }
 }


### PR DESCRIPTION
For columnar processing RunLengthEncoded blocks can be highly optimized
by only processing the value block and outputting an RLE block.

Fixes #4211 