### PR TITLE
Properly expire started transactions that go idle

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.133.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.133.rst
@@ -7,3 +7,5 @@ General Changes
 
 * Add support for calling connector-defined procedures using :doc:`/sql/call`.
 * Add :doc:`/connector/system` procedure for killing running queries.
+* Properly expire idle transactions that consist of just the start transaction statement
+  and nothing else.

--- a/presto-main/src/main/java/com/facebook/presto/execution/StartTransactionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StartTransactionTask.java
@@ -61,6 +61,11 @@ public class StartTransactionTask
                 false);
 
         stateMachine.setStartedTransactionId(transactionId);
+
+        // Since the current session does not contain this new transaction ID, we need to manually mark it as inactive
+        // when this statement completes.
+        transactionManager.trySetInactive(transactionId);
+
         return completedFuture(null);
     }
 


### PR DESCRIPTION
This fixes a bug whereby transactions that consist of just the START TRANSACTION
statement will not be expired.