### PR TITLE
Clarify that hive.config.resources is local path

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -63,6 +63,10 @@ Only specify additional configuration files if absolutely necessary.
 We also recommend reducing the configuration files to have the minimum
 set of required properties, as additional properties may cause problems.
 
+The files referenced in hive.config.resources must exist on all Presto
+nodes for each Presto Server instance to use -- even if the nodes are not
+themselves Hadoop nodes.
+
 Configuration Properties
 ------------------------
 


### PR DESCRIPTION
Clarify in the docs that the paths referred to in hive.config.resources
are local to each Presto node, meaning that the files must exist on all
presto nodes, even if they are not hadoop nodes that would already have
those config files.