### PR TITLE
Fix theoretical memory tracking leak

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -187,6 +187,13 @@ public class SqlTaskExecution
             if (!taskStateMachine.getState().isDone()) {
                 taskHandle = taskExecutor.addTask(taskId);
                 taskStateMachine.addStateChangeListener(new RemoveTaskHandleWhenDone(taskExecutor, taskHandle));
+                taskStateMachine.addStateChangeListener(state -> {
+                    if (state.isDone()) {
+                        for (DriverFactory factory : driverFactories) {
+                            factory.close();
+                        }
+                    }
+                });
             }
             else {
                 taskHandle = null;


### PR DESCRIPTION
DriverFactory is not guaranteed to be closed. It's only closed when all
splits have been received and drivers created for them. However,
several OperatorFactories rely on close() being called.
For example, LookupJoinOperatorFactory will "leak" memory in the memory
tracking system, if close() is not called.