### PR TITLE
Fix deadlock between HttpPageBufferClient and ExchangeClient

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.133.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.133.rst
@@ -9,6 +9,7 @@ General Changes
 * Add :doc:`/connector/system` procedure for killing running queries.
 * Properly expire idle transactions that consist of just the start transaction statement
   and nothing else.
+* Fix possible deadlock in worker communication when task restart is detected.
 * Performance improvements for aggregations on dictionary encoded data.
   This optimization is turned off by default. It can be configured via the
   ``optimizer.dictionary-aggregation`` config property or the


### PR DESCRIPTION
* By design, HttpPageBufferClient must not delegate to clientCallback when  it's holding a lock to `this`. And `checkNotHoldsLock` is used to enforce this  requirement and help reason about this invariant locally.
* `checkNotHoldsLock` is missing in `handleFailure`. And `PagesResponse` `onSuccess`  callback delegates to `handleFailure` while holding the lock to this.
* As a result, `handleFailure` delegates to `ExchangeClient.clientFailed`, which  tries to acquires a lock on the parent `ExchangeClient` while still holding a  lock to `HttpPageBufferClient`.
* This creates a deadlock because both `ExchangeClient.getStatus` and  `HttpPageBufferClient.getStatus` acquires a lock on their respective this.  And the former delegates to the latter.