### PR TITLE
Document connector setup for namenode HA

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -49,17 +49,16 @@ will create a catalog named ``sales`` using the configured connector.
 HDFS Configuration
 ^^^^^^^^^^^^^^^^^^
 
-Presto configures the HDFS client automatically for most setups and
-does not require any configuration files. In some rare cases, such
-as when using federated HDFS, it may be necessary to specify additional
-HDFS client options in order to access your HDFS cluster. To do so, add
-the ``hive.config.resources`` property to reference your HDFS config files:
+For basic setups, Presto configures the HDFS client automatically and
+does not require any configuration files. In some cases, such as when using
+federated HDFS or NameNode high availability, it is necessary to specify
+additional HDFS client options in order to access your HDFS cluster. To do so,
+add the ``hive.config.resources`` property to reference your HDFS config files:
 
 .. code-block:: none
 
     hive.config.resources=/etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml
 
-Only specify additional configuration files if absolutely necessary.
 We also recommend reducing the configuration files to have the minimum
 set of required properties, as additional properties may cause problems.
 


### PR DESCRIPTION
Explicitly document configuration for namenode HA.  We've encountered a
lot of people having issues configuring Presto for HA clusters.