### PR TITLE
Avoid relying on iteration order of Map.keySet and Map.values

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanSanityChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanSanityChecker.java
@@ -212,7 +212,7 @@ public final class PlanSanityChecker
             verifyUniqueId(node);
 
             Set<Symbol> inputs = ImmutableSet.copyOf(source.getOutputSymbols());
-            for (Expression expression : node.getExpressions()) {
+            for (Expression expression : node.getAssignments().values()) {
                 Set<Symbol> dependencies = DependencyExtractor.extractUnique(expression);
                 checkDependencies(inputs, dependencies, "Invalid node. Expression dependencies (%s) not in source plan output (%s)", dependencies, inputs);
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -189,7 +189,7 @@ public class MetadataQueryOptimizer
                 else if (source instanceof ProjectNode) {
                     // verify projections are deterministic
                     ProjectNode project = (ProjectNode) source;
-                    if (!Iterables.all(project.getExpressions(), DeterminismEvaluator::isDeterministic)) {
+                    if (!Iterables.all(project.getAssignments().values(), DeterminismEvaluator::isDeterministic)) {
                         return Optional.empty();
                     }
                     source = project.getSource();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -425,7 +425,7 @@ public class PruneUnreferencedOutputs
             ImmutableMap.Builder<Symbol, Expression> builder = ImmutableMap.builder();
             for (int i = 0; i < node.getOutputSymbols().size(); i++) {
                 Symbol output = node.getOutputSymbols().get(i);
-                Expression expression = node.getExpressions().get(i);
+                Expression expression = node.getAssignments().get(output);
 
                 if (context.get().contains(output)) {
                     expectedInputs.addAll(DependencyExtractor.extractUnique(expression));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ProjectNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ProjectNode.java
@@ -46,11 +46,6 @@ public class ProjectNode
         this.outputs = ImmutableList.copyOf(assignments.keySet());
     }
 
-    public List<Expression> getExpressions()
-    {
-        return ImmutableList.copyOf(assignments.values());
-    }
-
     @Override
     public List<Symbol> getOutputSymbols()
     {


### PR DESCRIPTION
Many parts of planning rely on ProjectNode.getExpressions() and
ProjectNode.getOutputSymbols() being in corresponding order. However,
this is only true if the iteration order of Map.keySet and Map.values
for the Map passed to the constructor of ProjectNode are corresponding.