### PR TITLE
[StatusPrinter] Print stacktrace if debug flag is set in cli

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
@@ -122,6 +122,9 @@ Parallelism: 2.5
                 }
                 catch (RuntimeException e) {
                     log.debug(e, "error printing status");
+                    if (debug) {
+                        e.printStackTrace(out);
+                    }
                 }
             }
         }


### PR DESCRIPTION
In `StatusPrinter` an exception may go unnoticed even if `debug` is set. We noticed this problem when a parquet file is corrupt and server throws the exception below and the client just ignores it and says the query is gone. This PR prints the stack trace of the ignored exception in `debug` mode.


```Java
2016-01-19T09:38:13.915-0800	WARN	http-worker-436	com.facebook.presto.server.ThrowableMapper	Request failed for /v1/statement/20160119_173807_00012_z8wst/8
com.fasterxml.jackson.databind.JsonMappingException: position is not valid (through reference chain: com.facebook.presto.client.QueryResults["data"])
	at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:210)
	at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:177)
	at com.fasterxml.jackson.databind.ser.std.StdSerializer.wrapAndThrow(StdSerializer.java:187)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:647)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:152)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:128)
	at com.fasterxml.jackson.databind.ObjectWriter.writeValue(ObjectWriter.java:602)
	at io.airlift.jaxrs.JsonMapper.writeTo(JsonMapper.java:245)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor$TerminalWriterInterceptor.invokeWriteTo(WriterInterceptorExecutor.java:265)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor$TerminalWriterInterceptor.aroundWriteTo(WriterInterceptorExecutor.java:250)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:162)
	at org.glassfish.jersey.server.internal.JsonWithPaddingInterceptor.aroundWriteTo(JsonWithPaddingInterceptor.java:106)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:162)
	at org.glassfish.jersey.server.internal.MappableExceptionWrapperInterceptor.aroundWriteTo(MappableExceptionWrapperInterceptor.java:85)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:162)
	at org.glassfish.jersey.message.internal.MessageBodyFactory.writeTo(MessageBodyFactory.java:1154)
	at org.glassfish.jersey.server.ServerRuntime$Responder.writeResponse(ServerRuntime.java:621)
	at org.glassfish.jersey.server.ServerRuntime$Responder.processResponse(ServerRuntime.java:377)
	at org.glassfish.jersey.server.ServerRuntime$Responder.process(ServerRuntime.java:367)
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:274)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:271)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:267)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:315)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:297)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:267)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:297)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:254)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:1030)
	at org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:373)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:381)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:344)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:221)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:835)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1685)
	at org.eclipse.jetty.servlets.GzipFilter.doFilter(GzipFilter.java:51)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1668)
	at io.airlift.http.server.TraceTokenFilter.doFilter(TraceTokenFilter.java:63)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1668)
	at io.airlift.http.server.TimingFilter.doFilter(TimingFilter.java:52)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1668)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:581)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1158)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:511)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1090)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:109)
	at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:169)
	at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:52)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:119)
	at org.eclipse.jetty.server.Server.handle(Server.java:517)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:308)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:242)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:273)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:95)
	at org.eclipse.jetty.io.SelectChannelEndPoint$2.run(SelectChannelEndPoint.java:75)
	at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.produceAndRun(ExecuteProduceConsume.java:213)
	at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.run(ExecuteProduceConsume.java:147)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:654)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:572)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalArgumentException: position is not valid
	at com.facebook.presto.spi.block.AbstractVariableWidthBlock.checkReadablePosition(AbstractVariableWidthBlock.java:169)
	at com.facebook.presto.spi.block.AbstractVariableWidthBlock.isNull(AbstractVariableWidthBlock.java:157)
	at com.facebook.presto.spi.block.AbstractInterleavedBlock.isNull(AbstractInterleavedBlock.java:288)
	at com.facebook.presto.spi.type.VarcharType.getObjectValue(VarcharType.java:49)
	at com.facebook.presto.type.MapType.getObjectValue(MapType.java:179)
	at com.facebook.presto.server.StatementResource$Query$RowIterator.computeNext(StatementResource.java:745)
	at com.facebook.presto.server.StatementResource$Query$RowIterator.computeNext(StatementResource.java:718)
	at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:143)
	at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:138)
	at com.google.common.collect.Iterators$5.hasNext(Iterators.java:547)
	at com.google.common.collect.Iterators$3.hasNext(Iterators.java:164)
	at com.fasterxml.jackson.databind.ser.std.IterableSerializer.serializeContents(IterableSerializer.java:69)
	at com.fasterxml.jackson.databind.ser.std.IterableSerializer.serializeContents(IterableSerializer.java:16)
	at com.fasterxml.jackson.databind.ser.std.AsArraySerializerBase.serialize(AsArraySerializerBase.java:183)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:505)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:639)
	... 56 more
```