### PR TITLE
Minor Parquet reader cleanup

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCodecFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetCodecFactory.java
@@ -98,7 +98,7 @@ public class ParquetCodecFactory
         decompressors.clear();
     }
 
-    public class BytesDecompressor
+    public static class BytesDecompressor
     {
         private final CompressionCodec codec;
         private final Decompressor decompressor;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -413,7 +413,7 @@ public class ParquetHiveRecordCursor
         }
     }
 
-    public class PrestoParquetRecordReader
+    public static class PrestoParquetRecordReader
             extends ParquetRecordReader<FakeParquetRecord>
     {
         public PrestoParquetRecordReader(PrestoReadSupport readSupport)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetFileReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetFileReader.java
@@ -36,7 +36,6 @@ public class ParquetFileReader
 {
     private final List<BlockMetaData> blocks;
     private final FSDataInputStream inputStream;
-    private final Path file;
     private final Map<ColumnDescriptor, ColumnChunkMetaData> columnMetadata = new HashMap<>();
     private final ParquetCodecFactory codecFactory;
 
@@ -50,7 +49,6 @@ public class ParquetFileReader
             List<ColumnDescriptor> columns)
             throws IOException
     {
-        this.file = file;
         this.inputStream = file.getFileSystem(configuration).open(file);
         this.blocks = blocks;
         if (!blocks.isEmpty()) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
@@ -19,7 +19,6 @@ import com.google.common.primitives.Ints;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import parquet.column.ColumnDescriptor;
-import parquet.column.page.PageReadStore;
 import parquet.hadoop.metadata.BlockMetaData;
 import parquet.schema.MessageType;
 
@@ -40,7 +39,6 @@ public class ParquetReader
     private final List<BlockMetaData> blocks;
     private final Configuration configuration;
 
-    private PageReadStore readerStore;
     private long fileRowCount;
     private long currentPosition;
     private long currentGroupRowCount;
@@ -70,9 +68,7 @@ public class ParquetReader
     public void close()
             throws IOException
     {
-        if (fileReader != null) {
-            fileReader.close();
-        }
+        fileReader.close();
     }
 
     public float getProgress()


### PR DESCRIPTION
This PR removes some unused fields, and removes a redundant null check (fileReader is guaranteed to be non-null as it is initialized in the constructor)