### PR TITLE
Remove extra parenthesis in query.html

### DIFF
--- a/presto-main/src/main/resources/webapp/query.html
+++ b/presto-main/src/main/resources/webapp/query.html
@@ -290,7 +290,7 @@ d3.json('/v1/query/' + window.location.search.substring(1), function (query) {
 });
 
 function formatCumulativeMemory(cumulativeMemory) {
-    return (cumulativeMemory / Math.pow(1000.0, 4)).toLocaleString()) + 'GB seconds'
+    return (cumulativeMemory / Math.pow(1000.0, 4)).toLocaleString() + 'GB seconds'
 }
 
 function formatStackTrace(info) {


### PR DESCRIPTION
`query.html` page has an extra parenthesis preventing the page from being loaded. This PR fixes that.
![image](https://cloud.githubusercontent.com/assets/1223839/12432701/9bf5eb80-beb1-11e5-8a32-76fc5f137724.png)