### PR TITLE
Remove CPU time for non-selection query in verifier

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
@@ -390,7 +390,7 @@ public class Validator
                         return new QueryResult(State.SUCCESS, null, nanosSince(start), getCpuTime(limitedStatement.getResultSet()), results);
                     }
                     else {
-                        return new QueryResult(State.SUCCESS, null, nanosSince(start), getCpuTime(limitedStatement.getResultSet()), null);
+                        return new QueryResult(State.SUCCESS, null, nanosSince(start), null, null);
                     }
                 }
                 catch (AssertionError e) {


### PR DESCRIPTION
Currently we cannot get the cpu time for non-selection query, set it to NULL instead of trying to fetch it from resultSet.