### PR TITLE
Fix minor bugs in Web UI

### DIFF
--- a/presto-main/src/main/resources/webapp/query.html
+++ b/presto-main/src/main/resources/webapp/query.html
@@ -359,10 +359,9 @@ function removeQueryId(id)
     return id
 }
 
-function taskIdToSortableString(id) {
+function taskIdToTinySortCompatibleString(id) {
     var taskIdArr = removeQueryId(id).split(".");
-    var maxLength = Number.MAX_VALUE.toString().length + 1;
-    return taskIdArr.map(numStr => new Array(maxLength - numStr.length).join("0") + numStr).join(".");
+    return taskIdArr.map(numStr => new Array(5 - numStr.length).join("0") + numStr).join("|");
 }
 
 function getTasks(stage) {
@@ -385,7 +384,7 @@ function taskData(d) {
     });
 
     return [
-        {"display": "<a href=" + d.self + "?pretty>" + htmlEscape(d.taskId) + "</a>", "sortableString": taskIdToSortableString(d.taskId)},
+        {"display": "<a href=" + d.self + "?pretty>" + htmlEscape(d.taskId) + "</a>", "sortableString": taskIdToTinySortCompatibleString(d.taskId)},
         {"display": htmlEscape(urlHostname(d.self))},
         {"display": htmlEscape(formatState(d.state, d.stats.fullyBlocked))},
         {"display": htmlEscape(formatCount(rows)), "sortableString": rows},

--- a/presto-main/src/main/resources/webapp/query.html
+++ b/presto-main/src/main/resources/webapp/query.html
@@ -290,7 +290,7 @@ d3.json('/v1/query/' + window.location.search.substring(1), function (query) {
 });
 
 function formatCumulativeMemory(cumulativeMemory) {
-    return (cumulativeMemory / Math.pow(1000.0, 4)).toLocaleString()) + 'GB seconds'
+    return (cumulativeMemory / Math.pow(1000.0, 4)).toLocaleString() + 'GB seconds';
 }
 
 function formatStackTrace(info) {


### PR DESCRIPTION
The functionality to convert task IDs to sortable strings generated
numbers that were too large for TinySort to deal with. Changed
zero-padding to 5 digits and also fixed a missing parenthesis error.