### PR TITLE
Use a custom identifier for dictionary blocks

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
@@ -15,13 +15,13 @@ package com.facebook.presto.spi;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.DictionaryId;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.Objects.requireNonNull;
@@ -123,7 +123,7 @@ public class Page
             }
         }
 
-        Map<UUID, DictionaryBlockIndexes> dictionaryBlocks = getRelatedDictionaryBlocks();
+        Map<DictionaryId, DictionaryBlockIndexes> dictionaryBlocks = getRelatedDictionaryBlocks();
         for (DictionaryBlockIndexes blockIndexes : dictionaryBlocks.values()) {
             List<Block> compactBlocks = DictionaryBlock.compactBlocks(blockIndexes.getBlocks());
             List<Integer> indexes = blockIndexes.getIndexes();
@@ -139,14 +139,14 @@ public class Page
         retainedSizeInBytes.set(retainedSize);
     }
 
-    private Map<UUID, DictionaryBlockIndexes> getRelatedDictionaryBlocks()
+    private Map<DictionaryId, DictionaryBlockIndexes> getRelatedDictionaryBlocks()
     {
-        Map<UUID, DictionaryBlockIndexes> relatedDictionaryBlocks = new HashMap<>();
+        Map<DictionaryId, DictionaryBlockIndexes> relatedDictionaryBlocks = new HashMap<>();
 
         for (int i = 0; i < blocks.length; i++) {
             Block block = blocks[i];
             if (block instanceof DictionaryBlock) {
-                UUID sourceId = ((DictionaryBlock) block).getDictionarySourceId();
+                DictionaryId sourceId = ((DictionaryBlock) block).getDictionarySourceId();
                 relatedDictionaryBlocks.computeIfAbsent(sourceId, id -> new DictionaryBlockIndexes())
                         .addBlock(block, i);
             }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlockEncoding.java
@@ -18,8 +18,6 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
-import java.util.UUID;
-
 import static java.util.Objects.requireNonNull;
 
 public class DictionaryBlockEncoding
@@ -65,6 +63,7 @@ public class DictionaryBlockEncoding
         // instance id
         sliceOutput.appendLong(dictionaryBlock.getDictionarySourceId().getMostSignificantBits());
         sliceOutput.appendLong(dictionaryBlock.getDictionarySourceId().getLeastSignificantBits());
+        sliceOutput.appendLong(dictionaryBlock.getDictionarySourceId().getSequenceId());
     }
 
     @Override
@@ -83,9 +82,10 @@ public class DictionaryBlockEncoding
         // instance id
         long mostSignificantBits = sliceInput.readLong();
         long leastSignificantBits = sliceInput.readLong();
+        long sequenceId = sliceInput.readLong();
 
         // we always compact the dictionary before we send it
-        return new DictionaryBlock(positionCount, dictionaryBlock, ids, true, new UUID(mostSignificantBits, leastSignificantBits));
+        return new DictionaryBlock(positionCount, dictionaryBlock, ids, true, new DictionaryId(mostSignificantBits, leastSignificantBits, sequenceId));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryId.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryId.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class DictionaryId
+{
+    private static final UUID nodeId = UUID.randomUUID();
+    private static final AtomicLong sequenceGenerator = new AtomicLong();
+
+    private final long mostSignificantBits;
+    private final long leastSignificantBits;
+    private final long sequenceId;
+
+    public static DictionaryId randomDictionaryId()
+    {
+        return new DictionaryId(nodeId.getMostSignificantBits(), nodeId.getLeastSignificantBits(), sequenceGenerator.getAndIncrement());
+    }
+
+    public DictionaryId(long mostSignificantBits, long leastSignificantBits, long sequenceId)
+    {
+        this.mostSignificantBits = mostSignificantBits;
+        this.leastSignificantBits = leastSignificantBits;
+        this.sequenceId = sequenceId;
+    }
+
+    public long getMostSignificantBits()
+    {
+        return mostSignificantBits;
+    }
+
+    public long getLeastSignificantBits()
+    {
+        return leastSignificantBits;
+    }
+
+    public long getSequenceId()
+    {
+        return sequenceId;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DictionaryId that = (DictionaryId) o;
+        return mostSignificantBits == that.mostSignificantBits &&
+                leastSignificantBits == that.leastSignificantBits &&
+                sequenceId == that.sequenceId;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(mostSignificantBits, leastSignificantBits, sequenceId);
+    }
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestPage.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestPage.java
@@ -17,13 +17,13 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.DictionaryId;
 import com.facebook.presto.spi.block.SliceArrayBlock;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
-import java.util.UUID;
-
+import static com.facebook.presto.spi.block.DictionaryId.randomDictionaryId;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static io.airlift.slice.Slices.wrappedIntArray;
 import static org.testng.Assert.assertEquals;
@@ -72,12 +72,12 @@ public class TestPage
         Block lengthsDictionary = blockBuilder.build();
 
         // Create 2 dictionary blocks with the same source id
-        UUID commonSourceId = UUID.randomUUID();
+        DictionaryId commonSourceId = randomDictionaryId();
         DictionaryBlock commonSourceIdBlock1 = createDictionaryBlock(expectedValues, 100, commonSourceId);
         DictionaryBlock commonSourceIdBlock2 = new DictionaryBlock(commonSourceIdBlock1.getPositionCount(), lengthsDictionary, commonSourceIdBlock1.getIds(), commonSourceId);
 
         // Create block with a different source id
-        DictionaryBlock randomSourceIdBlock = createDictionaryBlock(expectedValues, 100, UUID.randomUUID());
+        DictionaryBlock randomSourceIdBlock = createDictionaryBlock(expectedValues, 100, randomDictionaryId());
 
         Page page = new Page(commonSourceIdBlock1, randomSourceIdBlock, commonSourceIdBlock2);
         page.compact();
@@ -105,7 +105,7 @@ public class TestPage
         return dynamicSliceOutput.slice();
     }
 
-    private static DictionaryBlock createDictionaryBlock(Slice[] expectedValues, int positionCount, UUID uuid)
+    private static DictionaryBlock createDictionaryBlock(Slice[] expectedValues, int positionCount, DictionaryId dictionaryId)
     {
         int dictionarySize = expectedValues.length;
         int[] ids = new int[positionCount];
@@ -113,6 +113,6 @@ public class TestPage
         for (int i = 0; i < positionCount; i++) {
             ids[i] = i % dictionarySize;
         }
-        return new DictionaryBlock(positionCount, new SliceArrayBlock(dictionarySize, expectedValues), wrappedIntArray(ids), uuid);
+        return new DictionaryBlock(positionCount, new SliceArrayBlock(dictionarySize, expectedValues), wrappedIntArray(ids), dictionaryId);
     }
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
@@ -25,7 +25,6 @@ import org.testng.annotations.Test;
 
 import java.util.Locale;
 import java.util.Optional;
-import java.util.UUID;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
@@ -96,7 +95,7 @@ public class TestDictionaryBlockEncoding
         Slice idsSlice = Slices.wrappedIntArray(ids);
 
         BlockEncoding blockEncoding = new DictionaryBlockEncoding(new VariableWidthBlockEncoding());
-        DictionaryBlock dictionaryBlock = new DictionaryBlock(positionCount, dictionary, idsSlice, false, UUID.randomUUID());
+        DictionaryBlock dictionaryBlock = new DictionaryBlock(positionCount, dictionary, idsSlice);
 
         DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1024);
         blockEncoding.writeBlock(sliceOutput, dictionaryBlock);


### PR DESCRIPTION
We used UUID.randomUUID() to get a dictionary identifier, which can have a
lot of contention and slow down queries. Change it to use a custom dictionary identifier.