### PR TITLE
Fix handling of parquet maps with null values

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -1137,6 +1137,11 @@ public class ParquetHiveRecordCursor
         {
             keyConverter.afterValue();
             valueConverter.afterValue();
+            //handle the case where we have a key, but the value is null
+            //null keys are not supported anyway, so we can ignore that case here
+            if (builder.getPositionCount() < 2) {
+                builder.appendNull();
+            }
         }
 
         @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -56,7 +56,6 @@ import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.util.Progressable;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
@@ -270,15 +269,11 @@ public abstract class AbstractTestHiveFileFormats
                             null, "some string", rowBlockOf(ImmutableList.of(BIGINT, VARCHAR), null, "nested_string2")
                     )
             ))
+            .add(new TestColumn("t_map_null_value",
+                    getStandardMapObjectInspector(javaStringObjectInspector, javaStringObjectInspector),
+                    asMap("k1", null, "k2", "v2"),
+                    mapBlockOf(VARCHAR, VARCHAR, new String[] {"k1", "k2"}, new String[] {null, "v2"})))
             .build();
-
-    private static Map<Integer, Integer> mapWithNullKey()
-    {
-        Map<Integer, Integer> map = new HashMap<>();
-        map.put(null, 0);
-        map.put(2, 3);
-        return map;
-    }
 
     private static <K, V> Map<K, V> asMap(K k1, V v1, K k2, V v2)
     {
@@ -335,13 +330,7 @@ public abstract class AbstractTestHiveFileFormats
                 Text.class,
                 compressionCodec != null,
                 tableProperties,
-                new Progressable()
-                {
-                    @Override
-                    public void progress()
-                    {
-                    }
-                }
+                () -> { }
         );
 
         try {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StructuralTestUtil.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StructuralTestUtil.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 import static com.facebook.presto.type.TypeJsonUtils.appendToBlockBuilder;
+import static com.google.common.base.Preconditions.checkArgument;
 
 public final class StructuralTestUtil
 {
@@ -77,6 +78,19 @@ public final class StructuralTestUtil
         BlockBuilder blockBuilder = new InterleavedBlockBuilder(ImmutableList.of(keyType, valueType), new BlockBuilderStatus(), 1024);
         appendToBlockBuilder(keyType, key, blockBuilder);
         appendToBlockBuilder(valueType, value, blockBuilder);
+        return blockBuilder.build();
+    }
+
+    public static Block mapBlockOf(Type keyType, Type valueType, Object[] keys, Object[] values)
+    {
+        checkArgument(keys.length == values.length, "keys/values must have the same length");
+        BlockBuilder blockBuilder = new InterleavedBlockBuilder(ImmutableList.of(keyType, valueType), new BlockBuilderStatus(), 1024);
+        for (int i = 0; i < keys.length; i++) {
+            Object key = keys[i];
+            Object value = values[i];
+            appendToBlockBuilder(keyType, key, blockBuilder);
+            appendToBlockBuilder(valueType, value, blockBuilder);
+        }
         return blockBuilder.build();
     }
 


### PR DESCRIPTION
A parquet map with a `null` value currently messes up the state kept in the parquet hive record cursor and fails on read:

```Java
Caused by: org.apache.parquet.io.ParquetDecodingException: Can not read value at 1 in block 0 in file s3n://netflix-dataoven-prod-users/hive/warehouse/dse.db/pmt_events_f/dateint=20160115/pmt_event_class=threatmetrix_transaction/batchid=1453325789/rw-00278-0000.parquet
	at org.apache.parquet.hadoop.InternalParquetRecordReader.nextKeyValue(InternalParquetRecordReader.java:244)
	at org.apache.parquet.hadoop.ParquetRecordReader.nextKeyValue(ParquetRecordReader.java:211)
	at com.facebook.presto.hive.parquet.ParquetHiveRecordCursor.advanceNextPosition(ParquetHiveRecordCursor.java:252)
	... 10 more
Caused by: java.lang.IllegalStateException: Expected entry size to be exactly 8 but was 19
	at com.facebook.presto.spi.block.FixedWidthBlockBuilder.closeEntry(FixedWidthBlockBuilder.java:175)
	at com.facebook.presto.spi.block.InterleavedBlockBuilder.closeEntry(InterleavedBlockBuilder.java:210)
	at com.facebook.presto.spi.block.ArrayElementBlockWriter.closeEntry(ArrayElementBlockWriter.java:118)
	at com.facebook.presto.spi.type.VarbinaryType.writeSlice(VarbinaryType.java:109)
	at com.facebook.presto.spi.type.VarbinaryType.writeSlice(VarbinaryType.java:103)
	at com.facebook.presto.hive.parquet.ParquetHiveRecordCursor$ParquetPrimitiveConverter.addBinary(ParquetHiveRecordCursor.java:1242)
	at org.apache.parquet.column.impl.ColumnReaderImpl$2$6.writeValue(ColumnReaderImpl.java:318)
	at org.apache.parquet.column.impl.ColumnReaderImpl.writeCurrentValueToConverter(ColumnReaderImpl.java:365)
	at org.apache.parquet.io.RecordReaderImplementation.read(RecordReaderImplementation.java:415)
	at org.apache.parquet.hadoop.InternalParquetRecordReader.nextKeyValue(InternalParquetRecordReader.java:219)
	... 12 more
```

This PR fixes the issue by appending a null value if necessary when a map entry is read completely.

@zhenxiao @dain Can you please review?