### PR TITLE
Fixing squid S2095: Resources should be closed

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/KeyReader.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/KeyReader.java
@@ -32,8 +32,7 @@ public final class KeyReader
             return -1;
         }
 
-        try {
-            InputStream in = new FileInputStream(FileDescriptor.in);
+        try (InputStream in = new FileInputStream(FileDescriptor.in)) {
             if (in.available() > 0) {
                 return in.read();
             }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -667,6 +667,9 @@ public class HiveMetadata
             rollbackPartitionUpdates(partitionUpdates, "table creation");
             throw throwable;
         }
+        finally {
+            partitionCommitter.close();
+        }
     }
 
     @Override
@@ -845,6 +848,9 @@ public class HiveMetadata
             partitionCommitter.abort();
             rollbackPartitionUpdates(partitionUpdates, "insert");
             throw t;
+        }
+        finally {
+            partitionCommitter.close();
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2095 - “Resources should be closed”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S2095
Please let me know if you have any questions.
Luiz Santana