### PR TITLE
Change javascript in query.html to support Safari

### DIFF
--- a/presto-main/src/main/resources/webapp/query.html
+++ b/presto-main/src/main/resources/webapp/query.html
@@ -361,7 +361,7 @@ function removeQueryId(id)
 
 function taskIdToTinySortCompatibleString(id) {
     var taskIdArr = removeQueryId(id).split(".");
-    return taskIdArr.map(numStr => new Array(5 - numStr.length).join("0") + numStr).join("|");
+    return taskIdArr.map( function(numStr) { return new Array(5 - numStr.length).join("0") + numStr }).join("|");
 }
 
 function getTasks(stage) {


### PR DESCRIPTION
Safari's lack of support for arrow function breaks the tasks table in the
query page on the Web UI. Changed the arrow function to an anonymous function.

#4414