### PR TITLE
Improve error message for LIMIT > max int

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/LimitNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/LimitNode.java
@@ -16,13 +16,15 @@ package com.facebook.presto.sql.planner.plan;
 import com.facebook.presto.sql.planner.Symbol;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
 
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -38,7 +40,8 @@ public class LimitNode
         super(id);
 
         requireNonNull(source, "source is null");
-        Preconditions.checkArgument(count >= 0, "count must be greater than or equal to zero");
+        checkArgument(count >= 0, "count must be greater than or equal to zero");
+        checkCondition(count <= Integer.MAX_VALUE, NOT_SUPPORTED, "LIMIT > %s is not supported", Integer.MAX_VALUE);
 
         this.source = source;
         this.count = count;

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -137,6 +137,13 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testLimitIntMax()
+            throws Exception
+    {
+        assertQuery("SELECT orderkey from orders LIMIT " + Integer.MAX_VALUE);
+    }
+
+    @Test
     public void testNonDeterministicFilter()
     {
         MaterializedResult materializedResult = computeActual("SELECT u FROM ( SELECT if(rand() > 0.5, 0, 1) AS u ) WHERE u <> u");


### PR DESCRIPTION
Currently this fails in TopNOperator constructor, because there's an
integer overflow in the LocalExecutionPlanner when it casts a long to an
int.