### PR TITLE
Disable dictionary processing for non-deterministic expressions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -657,6 +657,11 @@ public class FunctionRegistry
     public boolean canResolveOperator(OperatorType operatorType, Type returnType, List<? extends  Type> argumentTypes)
     {
         Signature signature = internalOperator(operatorType, returnType, argumentTypes);
+        return isRegistered(signature);
+    }
+
+    public boolean isRegistered(Signature signature)
+    {
         try {
             // TODO: this is hacky, but until the magic literal and row field reference hacks are cleaned up it's difficult to implement this.
             getScalarFunctionImplementation(signature);

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/DeterminismEvaluator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/DeterminismEvaluator.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+
+import static java.util.Objects.requireNonNull;
+
+public class DeterminismEvaluator
+{
+    final FunctionRegistry registry;
+
+    public DeterminismEvaluator(FunctionRegistry registry)
+    {
+        this.registry = requireNonNull(registry, "registry is null");
+    }
+
+    public boolean isDeterministic(RowExpression expression)
+    {
+        return expression.accept(new Visitor(registry), null);
+    }
+
+    private static class Visitor
+            implements RowExpressionVisitor<Void, Boolean>
+    {
+        private final FunctionRegistry registry;
+
+        public Visitor(FunctionRegistry registry)
+        {
+            this.registry = registry;
+        }
+
+        @Override
+        public Boolean visitInputReference(InputReferenceExpression reference, Void context)
+        {
+            return true;
+        }
+
+        @Override
+        public Boolean visitConstant(ConstantExpression literal, Void context)
+        {
+            return true;
+        }
+
+        @Override
+        public Boolean visitCall(CallExpression call, Void context)
+        {
+            Signature signature = call.getSignature();
+            if (registry.isRegistered(signature) && !registry.getScalarFunctionImplementation(signature).isDeterministic()) {
+                return false;
+            }
+
+            return call.getArguments().stream()
+                    .allMatch(expression -> expression.accept(this, context));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_W
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.wrappedIntArray;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
@@ -137,9 +138,11 @@ public final class BlockAssertions
 
     public static Block createStringDictionaryBlock(int start, int length)
     {
+        checkArgument(length > 5, "block must have more than 5 entries");
+
         int dictionarySize = length / 5;
         BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), dictionarySize);
-        for (int i = start; i < dictionarySize; i++) {
+        for (int i = start; i < start + dictionarySize; i++) {
             VARCHAR.writeString(builder, String.valueOf(i));
         }
         int[] ids = new int[length];
@@ -247,9 +250,11 @@ public final class BlockAssertions
 
     public static Block createLongDictionaryBlock(int start, int length)
     {
+        checkArgument(length > 5, "block must have more than 5 entries");
+
         int dictionarySize = length / 5;
         BlockBuilder builder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), dictionarySize);
-        for (int i = start; i < dictionarySize; i++) {
+        for (int i = start; i < start + dictionarySize; i++) {
             BIGINT.writeLong(builder, i);
         }
         int[] ids = new int[length];

--- a/presto-main/src/test/java/com/facebook/presto/sql/relational/TestDeterminismEvaluator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/relational/TestDeterminismEvaluator.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.metadata.Signature;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.metadata.FunctionKind.SCALAR;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.metadata.OperatorType.LESS_THAN;
+import static com.facebook.presto.metadata.Signature.internalOperator;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static java.util.Collections.singletonList;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestDeterminismEvaluator
+{
+    @Test
+    public void testDeterminismEvaluator()
+            throws Exception
+    {
+        DeterminismEvaluator determinismEvaluator = new DeterminismEvaluator(createTestMetadataManager().getFunctionRegistry());
+
+        CallExpression random = new CallExpression(new Signature("random", SCALAR, "bigint", "bigint"), BIGINT, singletonList(new ConstantExpression(10L, BIGINT)));
+        assertFalse(determinismEvaluator.isDeterministic(random));
+
+        InputReferenceExpression col0 = new InputReferenceExpression(0, BIGINT);
+        Signature lessThan = internalOperator(LESS_THAN, BOOLEAN, ImmutableList.of(BIGINT, BIGINT));
+
+        CallExpression lessThanExpression = new CallExpression(lessThan, BOOLEAN, ImmutableList.of(col0, new ConstantExpression(10L, BIGINT)));
+        assertTrue(determinismEvaluator.isDeterministic(lessThanExpression));
+
+        CallExpression lessThanRandomExpression = new CallExpression(lessThan, BOOLEAN, ImmutableList.of(col0, random));
+        assertFalse(determinismEvaluator.isDeterministic(lessThanRandomExpression));
+    }
+}


### PR DESCRIPTION
If a projection is non-deterministic fall back to simple columnar
processing instead of dictionary processing.