### PR TITLE
Only disallow ORDER BY LIMIT > int max

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/LimitNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/LimitNode.java
@@ -22,8 +22,6 @@ import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
 
-import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
-import static com.facebook.presto.util.Failures.checkCondition;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
@@ -41,7 +39,6 @@ public class LimitNode
 
         requireNonNull(source, "source is null");
         checkArgument(count >= 0, "count must be greater than or equal to zero");
-        checkCondition(count <= Integer.MAX_VALUE, NOT_SUPPORTED, "LIMIT > %s is not supported", Integer.MAX_VALUE);
 
         this.source = source;
         this.count = count;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TopNNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TopNNode.java
@@ -26,6 +26,8 @@ import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Map;
 
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.util.Failures.checkCondition;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -50,6 +52,7 @@ public class TopNNode
 
         requireNonNull(source, "source is null");
         Preconditions.checkArgument(count >= 0, "count must be positive");
+        checkCondition(count <= Integer.MAX_VALUE, NOT_SUPPORTED, "ORDER BY LIMIT > %s is not supported", Integer.MAX_VALUE);
         requireNonNull(orderBy, "orderBy is null");
         Preconditions.checkArgument(!orderBy.isEmpty(), "orderBy is empty");
         Preconditions.checkArgument(orderings.size() == orderBy.size(), "orderBy and orderings sizes don't match");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -141,6 +141,7 @@ public abstract class AbstractTestQueries
             throws Exception
     {
         assertQuery("SELECT orderkey from orders LIMIT " + Integer.MAX_VALUE);
+        assertQuery("SELECT orderkey from orders ORDER BY orderkey LIMIT " + Integer.MAX_VALUE);
     }
 
     @Test


### PR DESCRIPTION
LIMIT > int max works fine, if there's no ORDER BY, so only disallow it
for queries with ORDER BY.
This fixes an overly aggressive assertion added by
f6733cb1197f05d1791f95aeca49eae9c810057b