### PR TITLE
Allow explict kerberos keytab specification

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig
     private boolean authenticationEnabled;
     private File kerberosConfig;
     private String serviceName;
+    private File keytab;
 
     public File getKerberosConfig()
     {
@@ -56,6 +57,18 @@ public class SecurityConfig
     public SecurityConfig setServiceName(String serviceName)
     {
         this.serviceName = serviceName;
+        return this;
+    }
+
+    public File getKeytab()
+    {
+        return keytab;
+    }
+
+    @Config("http.server.authentication.krb5.keytab")
+    public SecurityConfig setKeytab(File keytab)
+    {
+        this.keytab = keytab;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/SpnegoFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/SpnegoFilter.java
@@ -89,7 +89,9 @@ public class SpnegoFilter
                     if (LOG.isDebugEnabled()) {
                         options.put("debug", "true");
                     }
-
+                    if (config.getKeytab() != null) {
+                        options.put("keyTab", config.getKeytab().getAbsolutePath());
+                    }
                     options.put("isInitiator", "false");
                     options.put("useKeyTab", "true");
                     options.put("principal", servicePrincipal);

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
@@ -28,7 +28,8 @@ public class TestSecurityConfig
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(SecurityConfig.class)
                 .setKerberosConfig(null)
                 .setAuthenticationEnabled(false)
-                .setServiceName(null));
+                .setServiceName(null)
+                .setKeytab(null));
     }
 
     @Test
@@ -38,12 +39,14 @@ public class TestSecurityConfig
                 .put("http.authentication.krb5.config", "/etc/krb5.conf")
                 .put("http.server.authentication.enabled", "true")
                 .put("http.server.authentication.krb5.service-name", "airlift")
+                .put("http.server.authentication.krb5.keytab", "/tmp/presto.keytab")
                 .build();
 
         SecurityConfig expected = new SecurityConfig()
                 .setKerberosConfig(new File("/etc/krb5.conf"))
                 .setAuthenticationEnabled(true)
-                .setServiceName("airlift");
+                .setServiceName("airlift")
+                .setKeytab(new File("/tmp/presto.keytab"));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Add http.server.authentication.krb5.keytab property to
explicitly specify keytab to be used when authenticating presto service
in KDC.