### PR TITLE
Allow type-compatible changes to view definitions

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -454,6 +454,25 @@ public abstract class AbstractTestDistributedQueries
     }
 
     @Test
+    public void testCompatibleTypeChangeForView()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE test_table AS SELECT 'abcdefg' a", 1);
+        assertUpdate("CREATE VIEW test_view AS SELECT a FROM test_table");
+
+        assertQuery("SELECT * FROM test_view", "VALUES 'abcdefg'");
+
+        // replace table with a version that's implicitly coercible to the previous one
+        assertUpdate("DROP TABLE test_table");
+        assertUpdate("CREATE TABLE test_table AS SELECT 'abc' a", 1);
+
+        assertQuery("SELECT * FROM test_view", "VALUES 'abc'");
+
+        assertUpdate("DROP VIEW test_view");
+        assertUpdate("DROP TABLE test_table");
+    }
+
+    @Test
     public void testViewMetadata()
             throws Exception
     {


### PR DESCRIPTION
If the output of a view changes in a type-compatible way (e.g.,
due to changes to underlying tables or inferred expression types), don't
consider it stale.

A type-compatible change is any change where the actual type of running
the view query is implicitly coercible to the declared type of the view.

The planner now adds coercions if necessary to produce the expected output.

Fixes https://github.com/facebook/presto/issues/4501