### PR TITLE
Fix invalid plan with precomputed hash optimization in scalar subquery

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4613,6 +4613,10 @@ public abstract class AbstractTestQueries
                 multipleRowsErrorMsg);
         assertQueryFails("SELECT (VALUES (1), (2)) IN (1,2)",
                 multipleRowsErrorMsg);
+
+        // exposes a bug in optimize hash generation because EnforceSingleNode does not
+        // support more than one column from the underlying query
+        assertQuery("SELECT custkey, (SELECT DISTINCT custkey FROM orders ORDER BY custkey LIMIT 1) FROM orders");
     }
 
     @Test


### PR DESCRIPTION
A query that includes an aggregation, join or other operation at the top-level
of a scalar subquery breaks when the pre-computed hash optimization kicks in
due to the additional column containing the hash.

When processing EnforceSingleRow, add a projection to restore schema
expected by that node.