### PR TITLE
Avoid calling seekToRow on the ORC reader

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
@@ -17,6 +17,7 @@ import com.facebook.presto.raptor.util.Closer;
 import com.facebook.presto.raptor.util.SyncingFileSystem;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.google.common.primitives.Ints;
+import io.airlift.log.Logger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -42,6 +43,7 @@ import static com.facebook.presto.raptor.util.Closer.closer;
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.units.Duration.nanosSince;
 import static org.apache.hadoop.hive.ql.io.orc.OrcFile.createReader;
 import static org.apache.hadoop.hive.ql.io.orc.OrcFile.createWriter;
 import static org.apache.hadoop.hive.ql.io.orc.OrcFile.writerOptions;
@@ -49,6 +51,7 @@ import static org.apache.hadoop.hive.ql.io.orc.OrcUtil.getFieldValue;
 
 public final class OrcFileRewriter
 {
+    private static final Logger log = Logger.get(OrcFileRewriter.class);
     private static final Configuration CONFIGURATION = new Configuration();
 
     private OrcFileRewriter() {}
@@ -63,7 +66,8 @@ public final class OrcFileRewriter
             if (reader.getNumberOfRows() < rowsToDelete.length()) {
                 throw new IOException("File has fewer rows than deletion vector");
             }
-            if (reader.getNumberOfRows() == rowsToDelete.cardinality()) {
+            int deleteRowCount = rowsToDelete.cardinality();
+            if (reader.getNumberOfRows() == deleteRowCount) {
                 return new OrcFileInfo(0, 0);
             }
             if (reader.getNumberOfRows() >= Integer.MAX_VALUE) {
@@ -76,9 +80,12 @@ public final class OrcFileRewriter
                     .compress(reader.getCompression())
                     .inspector(reader.getObjectInspector());
 
+            long start = System.nanoTime();
             try (Closer<RecordReader, IOException> recordReader = closer(reader.rows(), RecordReader::close);
                     Closer<Writer, IOException> writer = closer(createWriter(path(output), writerOptions), Writer::close)) {
-                return rewrite(recordReader.get(), writer.get(), rowsToDelete, inputRowCount);
+                OrcFileInfo fileInfo = rewrite(recordReader.get(), writer.get(), rowsToDelete, inputRowCount);
+                log.debug("Rewrote file %s in %s (input rows: %s, output rows: %s)", input.getName(), nanosSince(start), inputRowCount, inputRowCount - deleteRowCount);
+                return fileInfo;
             }
         }
     }


### PR DESCRIPTION
Calling seekToRow on the ORC reader tries to recompute the offsets each
time which in this implementation can be an expensive operation. Avoid
calling seekToRow instead iterate through the file sequentially.