### PR TITLE
Fix problem with current_date in non-UTC client

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -23,6 +23,7 @@ import com.google.common.primitives.Ints;
 import io.airlift.slice.Slice;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeField;
+import org.joda.time.Days;
 import org.joda.time.chrono.ISOChronology;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -83,8 +84,11 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.DATE)
     public static long currentDate(ConnectorSession session)
     {
-        long millis = getChronology(session.getTimeZoneKey()).dayOfMonth().roundFloor(session.getStartTime());
-        return MILLISECONDS.toDays(millis);
+        ISOChronology chronology = getChronology(session.getTimeZoneKey());
+
+        DateTime currentDateTime = new DateTime(System.currentTimeMillis(), chronology).withTimeAtStartOfDay();
+        DateTime baseDateTime = new DateTime(1970, 1, 1, 0, 0, chronology).withTimeAtStartOfDay();
+        return Days.daysBetween(baseDateTime, currentDateTime).getDays();
     }
 
     @Description("current time with time zone")


### PR DESCRIPTION
Hi,

There is a problem with current_date if client located in not-UTC environment.
But current_timestamp - works correctly.
It because previous code rounded current timestamp to local start of a day, took milliseconds and calculated number of days basing on this local start date.
As result - 2016-02-10 00:00:00 Europe/Kiev = 2016-02-09 22:00:00 UTC
And rolling back number of days to SqlDate in DateType - we get wrong date.

Example of problem:
presto:default> select current_date;
   _col0
------------
 2016-02-09
(1 row)

Query 20160210_130359_00014_bui5w, FINISHED, 1 node
Splits: 1 total, 1 done (100,00%)
0:00 [0 rows, 0B] [0 rows/s, 0B/s]

presto:default> select current_timestamp;
                _col0
-------------------------------------
 2016-02-10 15:04:04.226 Europe/Kiev
(1 row)

Query 20160210_130404_00015_bui5w, FINISHED, 1 node
Splits: 1 total, 1 done (100,00%)
0:00 [0 rows, 0B] [0 rows/s, 0B/s]