### PR TITLE
Fix type signature serialization for varchar

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
@@ -272,8 +272,15 @@ public class TypeSignature
     @JsonValue
     public String toString()
     {
+        // TODO: remove these hacks
         if (base.equalsIgnoreCase(StandardTypes.ROW)) {
             return rowToString();
+        }
+        else if (base.equalsIgnoreCase(StandardTypes.VARCHAR) &&
+                (parameters.size() == 1) &&
+                parameters.get(0).isLongLiteral() &&
+                parameters.get(0).getLongLiteral() == VarcharType.MAX_LENGTH) {
+            return base;
         }
         else {
             StringBuilder typeName = new StringBuilder(base);

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
@@ -142,6 +144,14 @@ public class TestTypeSignature
     {
         assertSignature("foo(42)", "foo", ImmutableList.<String>of("42"));
         assertSignature("varchar(10)", "varchar", ImmutableList.<String>of("10"));
+    }
+
+    @Test
+    public void testVarchar()
+            throws Exception
+    {
+        assertEquals(VARCHAR.getTypeSignature().toString(), "varchar");
+        assertEquals(createVarcharType(42).getTypeSignature().toString(), "varchar(42)");
     }
 
     private static void assertRowSignature(


### PR DESCRIPTION
Varchar without length should serialize without a length
rather than using the internal MAX_INT representation.

Fixes #4532 