### PR TITLE
Send plan in update request only if required

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -47,6 +47,7 @@ import javax.inject.Inject;
 
 import java.io.Closeable;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -251,7 +252,7 @@ public class SqlTaskManager
     }
 
     @Override
-    public TaskInfo updateTask(Session session, TaskId taskId, PlanFragment fragment, List<TaskSource> sources, OutputBuffers outputBuffers)
+    public TaskInfo updateTask(Session session, TaskId taskId, Optional<PlanFragment> fragment, List<TaskSource> sources, OutputBuffers outputBuffers)
     {
         requireNonNull(session, "session is null");
         requireNonNull(taskId, "taskId is null");

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskInfo.java
@@ -59,6 +59,7 @@ public class TaskInfo
     private final Set<PlanNodeId> noMoreSplits;
     private final TaskStats stats;
     private final List<ExecutionFailureInfo> failures;
+    private final boolean needsPlan;
 
     @JsonCreator
     public TaskInfo(@JsonProperty("taskId") TaskId taskId,
@@ -70,7 +71,8 @@ public class TaskInfo
             @JsonProperty("outputBuffers") SharedBufferInfo outputBuffers,
             @JsonProperty("noMoreSplits") Set<PlanNodeId> noMoreSplits,
             @JsonProperty("stats") TaskStats stats,
-            @JsonProperty("failures") List<ExecutionFailureInfo> failures)
+            @JsonProperty("failures") List<ExecutionFailureInfo> failures,
+            @JsonProperty("needsPlan") boolean needsPlan)
     {
         this.taskId = requireNonNull(taskId, "taskId is null");
         this.taskInstanceId = requireNonNull(taskInstanceId, "taskInstanceId is null");
@@ -89,6 +91,7 @@ public class TaskInfo
         else {
             this.failures = ImmutableList.of();
         }
+        this.needsPlan = needsPlan;
     }
 
     @JsonProperty
@@ -151,9 +154,15 @@ public class TaskInfo
         return failures;
     }
 
+    @JsonProperty
+    public boolean isNeedsPlan()
+    {
+        return needsPlan;
+    }
+
     public TaskInfo summarize()
     {
-        return new TaskInfo(taskId, taskInstanceId, version, state, self, lastHeartbeat, outputBuffers, noMoreSplits, stats.summarize(), failures);
+        return new TaskInfo(taskId, taskInstanceId, version, state, self, lastHeartbeat, outputBuffers, noMoreSplits, stats.summarize(), failures, needsPlan);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.planner.PlanFragment;
 import io.airlift.units.DataSize;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public interface TaskManager
@@ -58,7 +59,7 @@ public interface TaskManager
      * Updates the task plan, sources and output buffers.  If the task does not
      * already exist, is is created and then updated.
      */
-    TaskInfo updateTask(Session session, TaskId taskId, PlanFragment fragment, List<TaskSource> sources, OutputBuffers outputBuffers);
+    TaskInfo updateTask(Session session, TaskId taskId, Optional<PlanFragment> fragment, List<TaskSource> sources, OutputBuffers outputBuffers);
 
     /**
      * Cancels a task.  If the task does not already exist, is is created and then

--- a/presto-main/src/main/java/com/facebook/presto/server/TaskUpdateRequest.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskUpdateRequest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -29,14 +30,14 @@ import static java.util.Objects.requireNonNull;
 public class TaskUpdateRequest
 {
     private final SessionRepresentation session;
-    private final PlanFragment fragment;
+    private final Optional<PlanFragment> fragment;
     private final List<TaskSource> sources;
     private final OutputBuffers outputIds;
 
     @JsonCreator
     public TaskUpdateRequest(
             @JsonProperty("session") SessionRepresentation session,
-            @JsonProperty("fragment") PlanFragment fragment,
+            @JsonProperty("fragment") Optional<PlanFragment> fragment,
             @JsonProperty("sources") List<TaskSource> sources,
             @JsonProperty("outputIds") OutputBuffers outputIds)
     {
@@ -58,7 +59,7 @@ public class TaskUpdateRequest
     }
 
     @JsonProperty
-    public PlanFragment getFragment()
+    public Optional<PlanFragment> getFragment()
     {
         return fragment;
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -211,7 +211,8 @@ public class MockRemoteTaskFactory
                     sharedBuffer.getInfo(),
                     ImmutableSet.<PlanNodeId>of(),
                     taskContext.getTaskStats(),
-                    failures);
+                    failures,
+                    true);
         }
 
         public synchronized void finishSplits(int splits)

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -123,6 +123,6 @@ public final class TaskTestUtils
 
     public static TaskInfo updateTask(SqlTask sqlTask, List<TaskSource> taskSources, OutputBuffers outputBuffers)
     {
-        return sqlTask.updateTask(TEST_SESSION, PLAN_FRAGMENT, taskSources, outputBuffers);
+        return sqlTask.updateTask(TEST_SESSION, Optional.of(PLAN_FRAGMENT), taskSources, outputBuffers);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -34,6 +34,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
@@ -101,7 +102,7 @@ public class TestSqlTask
         SqlTask sqlTask = createInitialTask();
 
         TaskInfo taskInfo = sqlTask.updateTask(TEST_SESSION,
-                PLAN_FRAGMENT,
+                Optional.of(PLAN_FRAGMENT),
                 ImmutableList.<TaskSource>of(),
                 INITIAL_EMPTY_OUTPUT_BUFFERS);
         assertEquals(taskInfo.getState(), TaskState.RUNNING);
@@ -110,7 +111,7 @@ public class TestSqlTask
         assertEquals(taskInfo.getState(), TaskState.RUNNING);
 
         taskInfo = sqlTask.updateTask(TEST_SESSION,
-                PLAN_FRAGMENT,
+                Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.<ScheduledSplit>of(), true)),
                 INITIAL_EMPTY_OUTPUT_BUFFERS.withNoMoreBufferIds());
         assertEquals(taskInfo.getState(), TaskState.FINISHED);
@@ -126,7 +127,7 @@ public class TestSqlTask
         SqlTask sqlTask = createInitialTask();
 
         TaskInfo taskInfo = sqlTask.updateTask(TEST_SESSION,
-                PLAN_FRAGMENT,
+                Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.of(SPLIT), true)),
                 INITIAL_EMPTY_OUTPUT_BUFFERS.withBuffer(OUT, 0).withNoMoreBufferIds());
         assertEquals(taskInfo.getState(), TaskState.RUNNING);
@@ -161,7 +162,7 @@ public class TestSqlTask
         SqlTask sqlTask = createInitialTask();
 
         TaskInfo taskInfo = sqlTask.updateTask(TEST_SESSION,
-                PLAN_FRAGMENT,
+                Optional.of(PLAN_FRAGMENT),
                 ImmutableList.<TaskSource>of(),
                 INITIAL_EMPTY_OUTPUT_BUFFERS);
         assertEquals(taskInfo.getState(), TaskState.RUNNING);
@@ -187,7 +188,7 @@ public class TestSqlTask
         SqlTask sqlTask = createInitialTask();
 
         TaskInfo taskInfo = sqlTask.updateTask(TEST_SESSION,
-                PLAN_FRAGMENT,
+                Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.of(SPLIT), true)),
                 INITIAL_EMPTY_OUTPUT_BUFFERS.withBuffer(OUT, 0).withNoMoreBufferIds());
         assertEquals(taskInfo.getState(), TaskState.RUNNING);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -35,6 +35,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.OutputBuffers.INITIAL_EMPTY_OUTPUT_BUFFERS;
@@ -79,7 +80,7 @@ public class TestSqlTaskManager
             TaskId taskId = TASK_ID;
             TaskInfo taskInfo = sqlTaskManager.updateTask(TEST_SESSION,
                     taskId,
-                    PLAN_FRAGMENT,
+                    Optional.of(PLAN_FRAGMENT),
                     ImmutableList.<TaskSource>of(),
                     INITIAL_EMPTY_OUTPUT_BUFFERS);
             assertEquals(taskInfo.getState(), TaskState.RUNNING);
@@ -89,7 +90,7 @@ public class TestSqlTaskManager
 
             taskInfo = sqlTaskManager.updateTask(TEST_SESSION,
                     taskId,
-                    PLAN_FRAGMENT,
+                    Optional.of(PLAN_FRAGMENT),
                     ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.<ScheduledSplit>of(), true)),
                     INITIAL_EMPTY_OUTPUT_BUFFERS.withNoMoreBufferIds());
             assertEquals(taskInfo.getState(), TaskState.FINISHED);
@@ -107,7 +108,7 @@ public class TestSqlTaskManager
             TaskId taskId = TASK_ID;
             TaskInfo taskInfo = sqlTaskManager.updateTask(TEST_SESSION,
                     taskId,
-                    PLAN_FRAGMENT,
+                    Optional.of(PLAN_FRAGMENT),
                     ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.of(SPLIT), true)),
                     INITIAL_EMPTY_OUTPUT_BUFFERS.withBuffer(OUT, 0).withNoMoreBufferIds());
             assertEquals(taskInfo.getState(), TaskState.RUNNING);
@@ -143,7 +144,7 @@ public class TestSqlTaskManager
             TaskId taskId = TASK_ID;
             TaskInfo taskInfo = sqlTaskManager.updateTask(TEST_SESSION,
                     taskId,
-                    PLAN_FRAGMENT,
+                    Optional.of(PLAN_FRAGMENT),
                     ImmutableList.<TaskSource>of(),
                     INITIAL_EMPTY_OUTPUT_BUFFERS);
             assertEquals(taskInfo.getState(), TaskState.RUNNING);
@@ -171,7 +172,7 @@ public class TestSqlTaskManager
             TaskId taskId = TASK_ID;
             TaskInfo taskInfo = sqlTaskManager.updateTask(TEST_SESSION,
                     taskId,
-                    PLAN_FRAGMENT,
+                    Optional.of(PLAN_FRAGMENT),
                     ImmutableList.<TaskSource>of(),
                     INITIAL_EMPTY_OUTPUT_BUFFERS);
             assertEquals(taskInfo.getState(), TaskState.RUNNING);
@@ -199,7 +200,7 @@ public class TestSqlTaskManager
             TaskId taskId = TASK_ID;
             TaskInfo taskInfo = sqlTaskManager.updateTask(TEST_SESSION,
                     taskId,
-                    PLAN_FRAGMENT,
+                    Optional.of(PLAN_FRAGMENT),
                     ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.of(SPLIT), true)),
                     INITIAL_EMPTY_OUTPUT_BUFFERS.withBuffer(OUT, 0).withNoMoreBufferIds());
             assertEquals(taskInfo.getState(), TaskState.RUNNING);
@@ -226,7 +227,7 @@ public class TestSqlTaskManager
 
             TaskInfo taskInfo = sqlTaskManager.updateTask(TEST_SESSION,
                     taskId,
-                    PLAN_FRAGMENT,
+                    Optional.of(PLAN_FRAGMENT),
                     ImmutableList.<TaskSource>of(),
                     INITIAL_EMPTY_OUTPUT_BUFFERS);
             assertEquals(taskInfo.getState(), TaskState.RUNNING);


### PR DESCRIPTION
We need the plan fragment only for creating the SqlTaskExecution. Plans
for multistage queries can be huge and increase the size of the update
request. Change this so we send the plan only if it is required.