### PR TITLE
Update 0.137 release notes

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.137.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.137.rst
@@ -5,15 +5,19 @@ Release 0.137
 General Changes
 ---------------
 
+* Fix ``current_date`` to return correct results for all time zones.
+* Fix invalid plans when scalar subqueries use ``GROUP BY``, ``DISTINCT`` or ``JOIN``.
+* Do not allow creating views with a column type of ``UNKNOWN``.
+* Improve expression optimizer to remove some redundant operations.
 * Add :func:`bit_count`, :func:`bitwise_not`, :func:`bitwise_and`,
   :func:`bitwise_or`, and :func:`bitwise_xor` functions.
 * Add :func:`approx_distinct` aggregation support for ``VARBINARY`` input.
-* Fix ``current_date`` to return correct results for all time zones.
-* Improve expression optimizer to remove some redundant operations.
+* Add create time to query detail page in UI.
+* Add support for ``VARCHAR(length)`` type.
+* Track per-stage peak memory usage.
 * Allow using double input for :func:`approx_percentile` with an array of
   percentiles.
-* Do not allow creating views with a column type of ``UNKNOWN``.
-* Add create time to query detail page in UI.
+* Add API to JDBC driver to track query progress.
 
 Hive Changes
 ------------


### PR DESCRIPTION
Re-organize entries so that bug fixes are all grouped together
before new features.

Added some missing entries and removed the entry related to the
expression optimizer change that was reverted before the release.