### PR TITLE
Reduce lock contention in getStageInfo

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -249,7 +249,9 @@ public final class SqlStageExecution
         return !tasks.isEmpty();
     }
 
-    public synchronized List<RemoteTask> getAllTasks()
+    // do not synchronize
+    // this is used for query info building which should be independent of scheduling work
+    public List<RemoteTask> getAllTasks()
     {
         return tasks.values().stream()
                 .flatMap(Set::stream)


### PR DESCRIPTION
Remove unnecessary lock on getAllTasks which is used by getStageInfo.  This
can cause long pauses when a client fetches query info, which is sent with
each StatementResource response.