### PR TITLE
Simplifies predicates in binary logical expressions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
@@ -37,16 +37,11 @@ import java.util.Queue;
 
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
-import static com.facebook.presto.sql.tree.ComparisonExpression.Type.EQUAL;
-import static com.facebook.presto.sql.tree.ComparisonExpression.Type.GREATER_THAN;
-import static com.facebook.presto.sql.tree.ComparisonExpression.Type.GREATER_THAN_OR_EQUAL;
-import static com.facebook.presto.sql.tree.ComparisonExpression.Type.IS_DISTINCT_FROM;
-import static com.facebook.presto.sql.tree.ComparisonExpression.Type.LESS_THAN;
-import static com.facebook.presto.sql.tree.ComparisonExpression.Type.LESS_THAN_OR_EQUAL;
-import static com.facebook.presto.sql.tree.ComparisonExpression.Type.NOT_EQUAL;
 import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
 import static com.google.common.base.Predicates.not;
+import static com.google.common.collect.Iterables.contains;
 import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.transform;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Objects.requireNonNull;
 
@@ -56,24 +51,26 @@ public final class ExpressionUtils
 
     public static List<Expression> extractConjuncts(Expression expression)
     {
-        if (expression instanceof LogicalBinaryExpression && ((LogicalBinaryExpression) expression).getType() == LogicalBinaryExpression.Type.AND) {
-            LogicalBinaryExpression and = (LogicalBinaryExpression) expression;
-            return ImmutableList.<Expression>builder()
-                    .addAll(extractConjuncts(and.getLeft()))
-                    .addAll(extractConjuncts(and.getRight()))
-                    .build();
-        }
-
-        return ImmutableList.of(expression);
+        return extractPredicates(LogicalBinaryExpression.Type.AND, expression);
     }
 
     public static List<Expression> extractDisjuncts(Expression expression)
     {
-        if (expression instanceof LogicalBinaryExpression && ((LogicalBinaryExpression) expression).getType() == LogicalBinaryExpression.Type.OR) {
-            LogicalBinaryExpression or = (LogicalBinaryExpression) expression;
+        return extractPredicates(LogicalBinaryExpression.Type.OR, expression);
+    }
+
+    public static List<Expression> extractPredicates(LogicalBinaryExpression expression)
+    {
+        return extractPredicates(expression.getType(), expression);
+    }
+
+    public static List<Expression> extractPredicates(LogicalBinaryExpression.Type type, Expression expression)
+    {
+        if (expression instanceof LogicalBinaryExpression && ((LogicalBinaryExpression) expression).getType() == type) {
+            LogicalBinaryExpression logicalBinaryExpression = (LogicalBinaryExpression) expression;
             return ImmutableList.<Expression>builder()
-                    .addAll(extractDisjuncts(or.getLeft()))
-                    .addAll(extractDisjuncts(or.getRight()))
+                    .addAll(extractPredicates(type, logicalBinaryExpression.getLeft()))
+                    .addAll(extractPredicates(type, logicalBinaryExpression.getRight()))
                     .build();
         }
 
@@ -114,6 +111,20 @@ public final class ExpressionUtils
         return queue.remove();
     }
 
+    public static Expression combinePredicates(LogicalBinaryExpression.Type type, Expression... expressions)
+    {
+        return combinePredicates(type, Arrays.asList(expressions));
+    }
+
+    public static Expression combinePredicates(LogicalBinaryExpression.Type type, Iterable<Expression> expressions)
+    {
+        if (type == LogicalBinaryExpression.Type.AND) {
+            return combineConjuncts(expressions);
+        }
+
+        return combineDisjuncts(expressions);
+    }
+
     public static Expression combineConjuncts(Expression... expressions)
     {
         return combineConjuncts(Arrays.asList(expressions));
@@ -129,11 +140,16 @@ public final class ExpressionUtils
         requireNonNull(expressions, "expressions is null");
 
         // Flatten all the expressions into their component conjuncts
-        expressions = Iterables.concat(Iterables.transform(expressions, ExpressionUtils::extractConjuncts));
+        expressions = Iterables.concat(transform(expressions, ExpressionUtils::extractConjuncts));
 
         // Strip out all true literal conjuncts
-        expressions = Iterables.filter(expressions, not(Predicates.<Expression>equalTo(TRUE_LITERAL)));
+        expressions = filter(expressions, not(Predicates.<Expression>equalTo(TRUE_LITERAL)));
         expressions = removeDuplicates(expressions);
+
+        if (contains(expressions, FALSE_LITERAL)) {
+            return FALSE_LITERAL;
+        }
+
         return Iterables.isEmpty(expressions) ? emptyDefault : and(expressions);
     }
 
@@ -152,11 +168,16 @@ public final class ExpressionUtils
         requireNonNull(expressions, "expressions is null");
 
         // Flatten all the expressions into their component disjuncts
-        expressions = Iterables.concat(Iterables.transform(expressions, ExpressionUtils::extractDisjuncts));
+        expressions = Iterables.concat(transform(expressions, ExpressionUtils::extractDisjuncts));
 
         // Strip out all false literal disjuncts
-        expressions = Iterables.filter(expressions, not(Predicates.<Expression>equalTo(FALSE_LITERAL)));
+        expressions = filter(expressions, not(Predicates.<Expression>equalTo(FALSE_LITERAL)));
         expressions = removeDuplicates(expressions);
+
+        if (contains(expressions, TRUE_LITERAL)) {
+            return TRUE_LITERAL;
+        }
+
         return Iterables.isEmpty(expressions) ? emptyDefault : or(expressions);
     }
 
@@ -171,28 +192,6 @@ public final class ExpressionUtils
                 .stream()
                 .filter((conjunct) -> !DeterminismEvaluator.isDeterministic(conjunct))
                 .collect(toImmutableList()));
-    }
-
-    public static ComparisonExpression.Type flipComparison(ComparisonExpression.Type type)
-    {
-        switch (type) {
-            case EQUAL:
-                return EQUAL;
-            case NOT_EQUAL:
-                return NOT_EQUAL;
-            case LESS_THAN:
-                return GREATER_THAN;
-            case LESS_THAN_OR_EQUAL:
-                return GREATER_THAN_OR_EQUAL;
-            case GREATER_THAN:
-                return LESS_THAN;
-            case GREATER_THAN_OR_EQUAL:
-                return LESS_THAN_OR_EQUAL;
-            case IS_DISTINCT_FROM:
-                return IS_DISTINCT_FROM;
-            default:
-                throw new IllegalArgumentException("Unsupported comparison: " + type);
-        }
     }
 
     public static Function<Expression, Expression> expressionOrNullSymbols(final Predicate<Symbol>... nullSymbolScopes)
@@ -222,32 +221,12 @@ public final class ExpressionUtils
     private static Iterable<Expression> removeDuplicates(Iterable<Expression> expressions)
     {
         // Capture all non-deterministic predicates
-        Iterable<Expression> nonDeterministicDisjuncts = Iterables.filter(expressions, not(DeterminismEvaluator::isDeterministic));
+        Iterable<Expression> nonDeterministicDisjuncts = filter(expressions, not(DeterminismEvaluator::isDeterministic));
 
         // Capture and de-dupe all deterministic predicates
-        Iterable<Expression> deterministicDisjuncts = ImmutableSet.copyOf(Iterables.filter(expressions, DeterminismEvaluator::isDeterministic));
+        Iterable<Expression> deterministicDisjuncts = ImmutableSet.copyOf(filter(expressions, DeterminismEvaluator::isDeterministic));
 
         return Iterables.concat(nonDeterministicDisjuncts, deterministicDisjuncts);
-    }
-
-    private static ComparisonExpression.Type negate(ComparisonExpression.Type type)
-    {
-        switch (type) {
-            case EQUAL:
-                return NOT_EQUAL;
-            case NOT_EQUAL:
-                return EQUAL;
-            case LESS_THAN:
-                return GREATER_THAN_OR_EQUAL;
-            case LESS_THAN_OR_EQUAL:
-                return GREATER_THAN;
-            case GREATER_THAN:
-                return LESS_THAN_OR_EQUAL;
-            case GREATER_THAN_OR_EQUAL:
-                return LESS_THAN;
-            default:
-                throw new IllegalArgumentException("Unsupported comparison: " + type);
-        }
     }
 
     public static Expression normalize(Expression expression)
@@ -256,7 +235,7 @@ public final class ExpressionUtils
             NotExpression not = (NotExpression) expression;
             if (not.getValue() instanceof ComparisonExpression) {
                 ComparisonExpression comparison = (ComparisonExpression) not.getValue();
-                return new ComparisonExpression(negate(comparison.getType()), comparison.getLeft(), comparison.getRight());
+                return new ComparisonExpression(comparison.getType().negate(), comparison.getLeft(), comparison.getRight());
             }
         }
         return expression;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
@@ -59,7 +59,6 @@ import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.sql.ExpressionUtils.and;
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.combineDisjunctsWithDefault;
-import static com.facebook.presto.sql.ExpressionUtils.flipComparison;
 import static com.facebook.presto.sql.ExpressionUtils.or;
 import static com.facebook.presto.sql.planner.LiteralInterpreter.toExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
@@ -545,7 +544,7 @@ public final class DomainTranslator
             return Optional.of(new NormalizedSimpleComparison((QualifiedNameReference) left, comparison.getType(), new NullableValue(expressionTypes.get(comparison.getRight()), right)));
         }
         if (right instanceof QualifiedNameReference && !(left instanceof Expression)) {
-            return Optional.of(new NormalizedSimpleComparison((QualifiedNameReference) right, flipComparison(comparison.getType()), new NullableValue(expressionTypes.get(comparison.getLeft()), left)));
+            return Optional.of(new NormalizedSimpleComparison((QualifiedNameReference) right, comparison.getType().flip(), new NullableValue(expressionTypes.get(comparison.getLeft()), left)));
         }
         return Optional.empty();
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -79,7 +79,6 @@ import java.util.Set;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
-import static com.facebook.presto.sql.ExpressionUtils.flipComparison;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.planner.ExpressionInterpreter.evaluateConstantExpression;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Type.EQUAL;
@@ -258,7 +257,7 @@ class RelationPlanner
                 else if (firstDependencies.stream().allMatch(right.canResolvePredicate()) && secondDependencies.stream().allMatch(left.canResolvePredicate())) {
                     leftExpression = comparison.getRight();
                     rightExpression = comparison.getLeft();
-                    comparisonType = flipComparison(comparisonType);
+                    comparisonType = comparisonType.flip();
                 }
                 else {
                     // must have a complex expression that involves both tuples on one side of the comparison expression (e.g., coalesce(left.x, right.x) = 1)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyExpressions.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.DeterminismEvaluator;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.LiteralInterpreter;
 import com.facebook.presto.sql.planner.NoOpSymbolResolver;
@@ -29,19 +30,36 @@ import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionRewriter;
+import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.LogicalBinaryExpression;
+import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
+import java.util.Collection;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import static com.facebook.presto.sql.ExpressionUtils.combinePredicates;
+import static com.facebook.presto.sql.ExpressionUtils.extractPredicates;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static com.facebook.presto.sql.tree.ComparisonExpression.Type.IS_DISTINCT_FROM;
+import static com.facebook.presto.sql.tree.LogicalBinaryExpression.Type.OR;
+import static com.facebook.presto.util.ImmutableCollectors.toImmutableList;
+import static java.util.Collections.emptySet;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toSet;
 
 public class SimplifyExpressions
         extends PlanOptimizer
@@ -126,11 +144,127 @@ public class SimplifyExpressions
                     originalConstraint);
         }
 
-        private Expression simplifyExpression(Expression input)
+        private Expression simplifyExpression(Expression expression)
         {
-            IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(session, metadata, sqlParser, types, input);
-            ExpressionInterpreter interpreter = ExpressionInterpreter.expressionOptimizer(input, metadata, session, expressionTypes);
-            return LiteralInterpreter.toExpression(interpreter.optimize(NoOpSymbolResolver.INSTANCE), expressionTypes.get(input));
+            expression = ExpressionTreeRewriter.rewriteWith(new PushDownNegationsExpressionRewriter(), expression);
+            expression = ExpressionTreeRewriter.rewriteWith(new ExtractCommonPredicatesExpressionRewriter(), expression, NodeContext.ROOT_NODE);
+            IdentityHashMap<Expression, Type> expressionTypes = getExpressionTypes(session, metadata, sqlParser, types, expression);
+            ExpressionInterpreter interpreter = ExpressionInterpreter.expressionOptimizer(expression, metadata, session, expressionTypes);
+            return LiteralInterpreter.toExpression(interpreter.optimize(NoOpSymbolResolver.INSTANCE), expressionTypes.get(expression));
+        }
+    }
+
+    private static class PushDownNegationsExpressionRewriter
+            extends ExpressionRewriter<Void>
+    {
+        @Override
+        public Expression rewriteNotExpression(NotExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        {
+            if (node.getValue() instanceof LogicalBinaryExpression) {
+                LogicalBinaryExpression child = (LogicalBinaryExpression) node.getValue();
+                List<Expression> predicates = extractPredicates(child);
+                List<Expression> negatedPredicates = predicates.stream()
+                        .map(predicate -> treeRewriter.rewrite((Expression) new NotExpression(predicate), context))
+                        .collect(toImmutableList());
+                return combinePredicates(child.getType().flip(), negatedPredicates);
+            }
+            else if (node.getValue() instanceof ComparisonExpression && ((ComparisonExpression) node.getValue()).getType() != IS_DISTINCT_FROM) {
+                ComparisonExpression child = (ComparisonExpression) node.getValue();
+                return new ComparisonExpression(
+                        child.getType().negate(),
+                        treeRewriter.rewrite(child.getLeft(), context),
+                        treeRewriter.rewrite(child.getRight(), context));
+            }
+            else if (node.getValue() instanceof NotExpression) {
+                NotExpression child = (NotExpression) node.getValue();
+                return treeRewriter.rewrite(child.getValue(), context);
+            }
+
+            return new NotExpression(treeRewriter.rewrite(node.getValue(), context));
+        }
+    }
+
+    private enum NodeContext
+    {
+        ROOT_NODE,
+        NOT_ROOT_NODE;
+
+        boolean isRootNode()
+        {
+            return this == ROOT_NODE;
+        }
+    }
+
+    private static class ExtractCommonPredicatesExpressionRewriter
+            extends ExpressionRewriter<NodeContext>
+    {
+        @Override
+        public Expression rewriteExpression(Expression node, NodeContext context, ExpressionTreeRewriter<NodeContext> treeRewriter)
+        {
+            if (context.isRootNode()) {
+                return treeRewriter.rewrite(node, NodeContext.NOT_ROOT_NODE);
+            }
+
+            return null;
+        }
+
+        @Override
+        public Expression rewriteLogicalBinaryExpression(LogicalBinaryExpression node, NodeContext context, ExpressionTreeRewriter<NodeContext> treeRewriter)
+        {
+            List<Expression> predicates = extractPredicates(node.getType(), node).stream()
+                    .map(expression -> treeRewriter.rewrite(expression, NodeContext.NOT_ROOT_NODE))
+                    .collect(toImmutableList());
+
+            List<List<Expression>> subPredicates = getSubPredicates(predicates);
+
+            Set<Expression> commonPredicates = ImmutableSet.copyOf(subPredicates.stream()
+                    .map(this::filterDeterministicPredicates)
+                    .reduce(Sets::intersection)
+                    .orElse(emptySet()));
+
+            List<List<Expression>> uncorrelatedSubPredicates = subPredicates.stream()
+                    .map(predicateList -> removeAll(predicateList, commonPredicates))
+                    .collect(toImmutableList());
+
+            LogicalBinaryExpression.Type flippedNodeType = node.getType().flip();
+
+            List<Expression> uncorrelatedPredicates = uncorrelatedSubPredicates.stream()
+                    .map(predicate -> combinePredicates(flippedNodeType, predicate))
+                    .collect(toImmutableList());
+            Expression combinedUncorrelatedPredicates = combinePredicates(node.getType(), uncorrelatedPredicates);
+
+            // Do not simplify top level conjuncts if it would result in top level disjuncts
+            // Conjuncts are easier to process when pushing down predicates.
+            if (context.isRootNode() && flippedNodeType == OR && !combinedUncorrelatedPredicates.equals(FALSE_LITERAL)) {
+                return combinePredicates(node.getType(), predicates);
+            }
+
+            return combinePredicates(flippedNodeType, ImmutableList.<Expression>builder()
+                    .addAll(commonPredicates)
+                    .add(combinedUncorrelatedPredicates)
+                    .build());
+        }
+
+        private List<List<Expression>> getSubPredicates(List<Expression> predicates)
+        {
+            return predicates.stream()
+                    .map(predicate -> predicate instanceof LogicalBinaryExpression ?
+                            extractPredicates((LogicalBinaryExpression) predicate) : ImmutableList.of(predicate))
+                    .collect(toImmutableList());
+        }
+
+        private Set<Expression> filterDeterministicPredicates(List<Expression> predicates)
+        {
+            return predicates.stream()
+                    .filter(DeterminismEvaluator::isDeterministic)
+                    .collect(toSet());
+        }
+
+        private static <T> List<T> removeAll(Collection<T> collection, Collection<T> elementsToRemove)
+        {
+            return collection.stream()
+                    .filter(element -> !elementsToRemove.contains(element))
+                    .collect(toImmutableList());
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSimplifyExpressions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSimplifyExpressions.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.DependencyExtractor;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionRewriter;
+import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.LogicalBinaryExpression;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.sql.ExpressionUtils.binaryExpression;
+import static com.facebook.presto.sql.ExpressionUtils.extractPredicates;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.testng.Assert.assertEquals;
+
+public class TestSimplifyExpressions
+{
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final SimplifyExpressions SIMPLIFIER = new SimplifyExpressions(createTestMetadataManager(), SQL_PARSER);
+
+    @Test
+    public void testPushesDownNegations()
+    {
+        assertSimplifies("NOT X", "NOT X");
+        assertSimplifies("NOT NOT X", "X");
+        assertSimplifies("NOT NOT NOT X", "NOT X");
+        assertSimplifies("NOT NOT NOT X", "NOT X");
+
+        assertSimplifies("NOT (X > Y)", "X <= Y");
+        assertSimplifies("NOT (X > (NOT NOT Y))", "X <= Y");
+        assertSimplifies("X > (NOT NOT Y)", "X > Y");
+        assertSimplifies("NOT (X AND Y AND (NOT (Z OR V)))", "(NOT X) OR (NOT Y) OR (Z OR V)");
+        assertSimplifies("NOT (X OR Y OR (NOT (Z OR V)))", "(NOT X) AND (NOT Y) AND (Z OR V)");
+        assertSimplifies("NOT (X OR Y OR (Z OR V))", "(NOT X) AND (NOT Y) AND ((NOT Z) AND (NOT V))");
+
+        assertSimplifies("NOT (X IS DISTINCT FROM Y)", "NOT (X IS DISTINCT FROM Y)");
+    }
+
+    @Test
+    public void testExtractsCommonPredicate()
+    {
+        assertSimplifies("X AND X", "X");
+        assertSimplifies("X OR X", "X");
+        assertSimplifies("(X OR Y) AND (X OR Y)", "X OR Y");
+
+        assertSimplifies("(A AND V) OR V", "V");
+        assertSimplifies("(A OR V) AND V", "V");
+        assertSimplifies("(A OR B OR C) AND (A OR B)", "A OR B");
+        assertSimplifies("(A AND B) OR (A AND B AND C)", "A AND B");
+        assertSimplifies("I = ((A OR B) AND (A OR B OR C))", "I = (A OR B)");
+        assertSimplifies("(X OR Y) AND (X OR Z)", "(X OR Y) AND (X OR Z)");
+        assertSimplifies("(X AND Y AND V) OR (X AND Y AND Z)", "(X AND Y) AND (V OR Z)");
+        assertSimplifies("((X OR Y OR V) AND (X OR Y OR Z)) = I", "((X OR Y) OR (V AND Z)) = I");
+
+        assertSimplifies("((X OR V) AND V) OR ((X OR V) AND V)", "V");
+        assertSimplifies("((X OR V) AND X) OR ((X OR V) AND V)", "X OR V");
+
+        assertSimplifies("((X OR V) AND Z) OR ((X OR V) AND V)", "(((X OR V) AND Z) OR V)");
+        assertSimplifies("X AND ((Y AND Z) OR (Y AND V) OR (Y AND X))", "X AND Y AND (Z OR V OR X)");
+        assertSimplifies("(A AND B AND C AND D) OR (A AND B AND E) OR (A AND F)", "A AND ((B AND C AND D) OR (B AND E) OR F)");
+    }
+
+    private static void assertSimplifies(String expression, String expected)
+    {
+        assertEquals(
+                normalize(simplifyExpressions(SQL_PARSER.createExpression(expression))),
+                normalize(SQL_PARSER.createExpression(expected)));
+    }
+
+    private static Expression simplifyExpressions(Expression expression)
+    {
+        PlanNodeIdAllocator planNodeIdAllocator = new PlanNodeIdAllocator();
+        FilterNode filterNode = new FilterNode(
+                planNodeIdAllocator.getNextId(),
+                new ValuesNode(planNodeIdAllocator.getNextId(), emptyList(), emptyList()), expression);
+        FilterNode simplifiedNode = (FilterNode) SIMPLIFIER.optimize(
+                filterNode,
+                TEST_SESSION,
+                booleanSymbolTypeMapFor(expression),
+                new SymbolAllocator(),
+                planNodeIdAllocator);
+        return simplifiedNode.getPredicate();
+    }
+
+    private static Map<Symbol, Type> booleanSymbolTypeMapFor(Expression expression)
+    {
+        return DependencyExtractor.extractUnique(expression).stream()
+                .collect(Collectors.toMap(symbol -> symbol, symbol -> BOOLEAN));
+    }
+
+    private static Expression normalize(Expression expression)
+    {
+        return ExpressionTreeRewriter.rewriteWith(new NormalizeExpressionRewriter(), expression);
+    }
+
+    private static class NormalizeExpressionRewriter
+            extends ExpressionRewriter<Void>
+    {
+        @Override
+        public Expression rewriteLogicalBinaryExpression(LogicalBinaryExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        {
+            List<Expression> predicates = extractPredicates(node.getType(), node).stream()
+                    .map(p -> treeRewriter.rewrite(p, context))
+                    .sorted((p1, p2) -> p1.toString().compareTo(p2.toString()))
+                    .collect(toList());
+            return binaryExpression(node.getType(), predicates);
+        }
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ComparisonExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ComparisonExpression.java
@@ -42,6 +42,48 @@ public class ComparisonExpression
         {
             return value;
         }
+
+        public Type flip()
+        {
+            switch (this) {
+                case EQUAL:
+                    return EQUAL;
+                case NOT_EQUAL:
+                    return NOT_EQUAL;
+                case LESS_THAN:
+                    return GREATER_THAN;
+                case LESS_THAN_OR_EQUAL:
+                    return GREATER_THAN_OR_EQUAL;
+                case GREATER_THAN:
+                    return LESS_THAN;
+                case GREATER_THAN_OR_EQUAL:
+                    return LESS_THAN_OR_EQUAL;
+                case IS_DISTINCT_FROM:
+                    return IS_DISTINCT_FROM;
+                default:
+                    throw new IllegalArgumentException("Unsupported comparison: " + this);
+            }
+        }
+
+        public Type negate()
+        {
+            switch (this) {
+                case EQUAL:
+                    return NOT_EQUAL;
+                case NOT_EQUAL:
+                    return EQUAL;
+                case LESS_THAN:
+                    return GREATER_THAN_OR_EQUAL;
+                case LESS_THAN_OR_EQUAL:
+                    return GREATER_THAN;
+                case GREATER_THAN:
+                    return LESS_THAN_OR_EQUAL;
+                case GREATER_THAN_OR_EQUAL:
+                    return LESS_THAN;
+                default:
+                    throw new IllegalArgumentException("Unsupported comparison: " + this);
+            }
+        }
     }
 
     private final Type type;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/LogicalBinaryExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/LogicalBinaryExpression.java
@@ -23,7 +23,19 @@ public class LogicalBinaryExpression
 {
     public enum Type
     {
-        AND, OR
+        AND, OR;
+
+        public Type flip()
+        {
+            switch (this) {
+                case AND:
+                    return LogicalBinaryExpression.Type.OR;
+                case OR:
+                    return LogicalBinaryExpression.Type.AND;
+                default:
+                    throw new IllegalArgumentException("Unsupported logical expression type: " + this);
+            }
+        }
     }
 
     private final Type type;


### PR DESCRIPTION
It is possible that common sub-predicate occures in multiple predicates.
For instance:
(X AND Y) OR (X AND V)
or
(X OR Y) AND (X OR V)

In such cases it is possible to extract this common predicate:
X AND (Y OR V)
or
X OR (Y AND V)

This will let join predicates to be pushed to the top, therefore
allowing for faster joins.

Additionally, this rewrite will remove duplicate predicates improving
query execution performance.
