### PR TITLE
Optimize some TupleDomains to produce fewer expressions

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
@@ -158,6 +158,60 @@ public class TestDomainTranslator
     }
 
     @Test
+    public void testInOptimization()
+            throws Exception
+    {
+        Domain testDomain = Domain.create(
+                ValueSet.all(BIGINT)
+                        .subtract(ValueSet.ofRanges(
+                                Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L))), false);
+
+        TupleDomain<Symbol> tupleDomain = withColumnDomains(ImmutableMap.<Symbol, Domain>builder().put(A, testDomain).build());
+        assertEquals(toPredicate(tupleDomain), not(in(A, ImmutableList.of(1L, 2L, 3L))));
+
+        testDomain = Domain.create(
+                ValueSet.ofRanges(
+                        Range.lessThan(BIGINT, 4L)).intersect(
+                        ValueSet.all(BIGINT)
+                                .subtract(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L)))), false);
+
+        tupleDomain = withColumnDomains(ImmutableMap.<Symbol, Domain>builder().put(A, testDomain).build());
+        assertEquals(toPredicate(tupleDomain), and(lessThan(A, longLiteral(4L)), not(in(A, ImmutableList.of(1L, 2L, 3L)))));
+
+        testDomain = Domain.create(ValueSet.ofRanges(
+                Range.range(BIGINT, 1L, true, 3L, true),
+                Range.range(BIGINT, 5L, true, 7L, true),
+                Range.range(BIGINT, 9L, true, 11L, true)),
+                false);
+
+        tupleDomain = withColumnDomains(ImmutableMap.<Symbol, Domain>builder().put(A, testDomain).build());
+        assertEquals(toPredicate(tupleDomain),
+                or(between(A, longLiteral(1L), longLiteral(3L)), (between(A, longLiteral(5L), longLiteral(7L))), (between(A, longLiteral(9L), longLiteral(11L)))));
+
+        testDomain = Domain.create(
+                ValueSet.ofRanges(
+                        Range.lessThan(BIGINT, 4L))
+                        .intersect(ValueSet.all(BIGINT)
+                                .subtract(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L))))
+                        .union(ValueSet.ofRanges(Range.range(BIGINT, 7L, true, 9L, true))), false);
+
+        tupleDomain = withColumnDomains(ImmutableMap.<Symbol, Domain>builder().put(A, testDomain).build());
+        assertEquals(toPredicate(tupleDomain), or(and(lessThan(A, longLiteral(4L)), not(in(A, ImmutableList.of(1L, 2L, 3L)))), between(A, longLiteral(7L), longLiteral(9L))));
+
+        testDomain = Domain.create(
+                ValueSet.ofRanges(Range.lessThan(BIGINT, 4L))
+                        .intersect(ValueSet.all(BIGINT)
+                                .subtract(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L))))
+                        .union(ValueSet.ofRanges(Range.range(BIGINT, 7L, false, 9L, false), Range.range(BIGINT, 11L, false, 13L, false))), false);
+
+        tupleDomain = withColumnDomains(ImmutableMap.<Symbol, Domain>builder().put(A, testDomain).build());
+        assertEquals(toPredicate(tupleDomain), or(
+                and(lessThan(A, longLiteral(4L)), not(in(A, ImmutableList.of(1L, 2L, 3L)))),
+                and(greaterThan(A, longLiteral(7L)), lessThan(A, longLiteral(9L))),
+                and(greaterThan(A, longLiteral(11L)), lessThan(A, longLiteral(13L)))));
+    }
+
+    @Test
     public void testToPredicateNone()
             throws Exception
     {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3608,6 +3608,7 @@ public abstract class AbstractTestQueries
                 .mapToObj(Long::toString)
                 .collect(joining(", "));
         assertQuery("SELECT orderkey FROM orders WHERE orderkey IN (" + longValues + ")");
+        assertQuery("SELECT orderkey FROM orders WHERE orderkey NOT IN (" + longValues + ")");
 
         String arrayValues = range(0, 5000).asLongStream()
                 .mapToObj(i -> format("ARRAY[%s, %s, %s]", i, i + 1, i + 2))


### PR DESCRIPTION
Optimizations convert NOT IN queries to discontinuous ranges. For
example, NOT IN (1, 2, 3) turns into <1 || (>1 && <2) || >3. Queries
with a large number of values in the IN list become slow (or in some
cases generated classes that were too large) as a result of this.

Added an optimization to convert ranges into expressions with NOT INs
if doing so would produce fewer expressions.

Fixes #4434.