### PR TITLE
Fix optimization backfire for NOT IN

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.predicate.Marker;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.Range;
 import com.facebook.presto.spi.predicate.Ranges;
+import com.facebook.presto.spi.predicate.SortedRangeSet;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.predicate.ValueSet;
 import com.facebook.presto.spi.type.Type;
@@ -129,6 +130,17 @@ public final class DomainTranslator
     {
         List<Expression> disjuncts = new ArrayList<>();
         List<Expression> singleValues = new ArrayList<>();
+
+        List<Range> complementedSet = SortedRangeSet.copyOf(type, ranges.getOrderedRanges()).complement().getOrderedRanges();
+        if (complementedSet.stream().allMatch(Range::isSingleValue)) {
+            return ImmutableList.of(new NotExpression(new InPredicate(
+                    reference,
+                    new InListExpression(
+                            complementedSet.stream()
+                                    .map(range -> toExpression(range.getSingleValue(), type))
+                                    .collect(toList())))));
+        }
+
         for (Range range : ranges.getOrderedRanges()) {
             checkState(!range.isAll()); // Already checked
             if (range.isSingleValue()) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
@@ -158,6 +158,17 @@ public class TestDomainTranslator
     }
 
     @Test
+    public void testInOptimization()
+            throws Exception
+    {
+        TupleDomain<Symbol> tupleDomain = withColumnDomains(ImmutableMap.<Symbol, Domain>builder()
+                .put(A, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L), Range.range(BIGINT, 1L, false, 2L, false), Range.range(BIGINT, 2L, false, 3L, false), Range.greaterThan(BIGINT, 3L)), false))
+                .build());
+
+        assertEquals(toPredicate(tupleDomain), not(in(A, ImmutableList.of(1L, 2L, 3L))));
+    }
+
+    @Test
     public void testToPredicateNone()
             throws Exception
     {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3589,6 +3589,7 @@ public abstract class AbstractTestQueries
                 .mapToObj(Long::toString)
                 .collect(joining(", "));
         assertQuery("SELECT orderkey FROM orders WHERE orderkey IN (" + longValues + ")");
+        assertQuery("SELECT orderkey FROM orders WHERE orderkey NOT IN (" + longValues + ")");
 
         String arrayValues = range(0, 5000).asLongStream()
                 .mapToObj(i -> format("ARRAY[%s, %s, %s]", i, i + 1, i + 2))


### PR DESCRIPTION
Optimizations convert NOT IN queries to discontinuous ranges. For
example, NOT IN (1, 2, 3) turns into <1 || (>1 && <2) || >3. Queries
with a large number of values in the IN list become slow (or in some
cases generated classes that were too large) as a result of
this. Added a check to convert these ranges back into NOT INs.

Fixes #4434 