### PR TITLE
Fix bug in CTAS when temporary directory is not used

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
@@ -324,8 +324,9 @@ public class HivePageSink
                 target = locationService.targetPath(locationHandle, partitionName);
                 write = locationService.writePath(locationHandle, partitionName).get();
 
-                if (partitionName.isPresent()) {
-                    // verify the target directory for the partition does not already exist
+                if (partitionName.isPresent() && !target.equals(write)) {
+                    // When target path is different from write path,
+                    // verify that the target directory for the partition does not already exist
                     if (HiveWriteUtils.pathExists(hdfsEnvironment, target)) {
                         throw new PrestoException(HIVE_PATH_ALREADY_EXISTS, format("Target directory for new partition '%s' of table '%s.%s' already exists: %s",
                                 partitionName,


### PR DESCRIPTION
When writing to a new table in Hive connector, it asserts that the target directory doesn't already exist for every partition (or once in the case of unpartitioned table), which is doomed to fail when a temporary directory is not used. This check is now removed when it is detected that temporary directory is
not used.

Test is not added because Hive integration test doesn't simulate multiple workers, and Hive integration smoke test doesn't exist for S3.

Fixes #4531 