### PR TITLE
Format cumulative memory in UI to have appropriate unit

### DIFF
--- a/presto-main/src/main/resources/webapp/query.html
+++ b/presto-main/src/main/resources/webapp/query.html
@@ -290,7 +290,11 @@ d3.json('/v1/query/' + window.location.search.substring(1), function (query) {
 });
 
 function formatCumulativeMemory(cumulativeMemory) {
-    return (cumulativeMemory / Math.pow(1000.0, 4)).toLocaleString() + 'GB seconds';
+    var byteSeconds = cumulativeMemory / 1000.0; // Byte miliSeconds to byte seconds
+    if (byteSeconds < 1) return byteSeconds.toLocaleString() + 'Byte seconds';
+    var sizes = ['Byte', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
+    var sizeIndex = Math.floor(Math.log(byteSeconds) / Math.log(1000));
+    return (byteSeconds / Math.pow(1000, sizeIndex)).toFixed(3).toLocaleString() + sizes[sizeIndex] + ' seconds';
 }
 
 function formatStackTrace(info) {


### PR DESCRIPTION
#4583 
It formats it to have only 3 digits after decimal point like: `12.345<Unit> seconds`

I guess the reason for using pow(1000, 4) instead of pow(1000, 3) in existing implementation while converting bytes to gigabytes is that it is also converting time from miliseconds to seconds. So I also included it in the comment.

Also I didn't want to use `if` and cover as many as possible units, that's why I chose this implementation.
