### PR TITLE
PruneIdentity should preserver output symbol order

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneIdentityProjections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneIdentityProjections.java
@@ -56,7 +56,7 @@ public class PruneIdentityProjections
         {
             PlanNode source = context.rewrite(node.getSource());
 
-            if (node.getOutputSymbols().size() != source.getOutputSymbols().size()) {
+            if (!node.getOutputSymbols().equals(source.getOutputSymbols())) {
                 // Can't get rid of this projection. It constrains the output tuple from the underlying operator
                 return replaceChildren(node, ImmutableList.of(source));
             }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -323,6 +323,11 @@ public abstract class AbstractTestDistributedQueries
                 + " UNION ALL SELECT DATE '2001-01-02', -2"
                 + " UNION ALL SELECT DATE '2001-01-03', -3");
 
+        // changed column order with UNION query
+        assertUpdate("INSERT INTO test_insert (orderkey, orderdate)"
+                + " SELECT orderkey, orderdate FROM orders"
+                + " UNION ALL SELECT orderkey, orderdate FROM orders", "SELECT 2 * count(*) FROM orders");
+
         assertUpdate("DROP TABLE test_insert");
     }
 


### PR DESCRIPTION
PruneIdentity optimization can eliminated expected changed output symbol order when we `INSERT INTO` data from `UNION` query. 

Otherwise `PageSink` get a page having invalid order.
```
java.lang.IndexOutOfBoundsException: end index (3756) must not be greater than size (3752)
	at io.airlift.slice.Preconditions.checkPositionIndexes(Preconditions.java:94)
	at io.airlift.slice.Slice.checkIndexLength(Slice.java:1194)
	at io.airlift.slice.Slice.getLong(Slice.java:409)
	at com.facebook.presto.spi.block.AbstractFixedWidthBlock.getLong(AbstractFixedWidthBlock.java:72)
	at com.facebook.presto.spi.type.BigintType.getLong(BigintType.java:92)
	at com.facebook.presto.hive.HiveWriteUtils$BigintFieldBuilder.setField(HiveWriteUtils.java:593)
	at com.facebook.presto.hive.HivePageSink$HiveRecordWriter.addRow(HivePageSink.java:564)
	at com.facebook.presto.hive.HivePageSink.appendPage(HivePageSink.java:279)
	at com.facebook.presto.spi.classloader.ClassLoaderSafeConnectorPageSink.appendPage(ClassLoaderSafeConnectorPageSink.java:41)
	at com.facebook.presto.operator.TableWriterOperator.addInput(TableWriterOperator.java:186)
```