### PR TITLE
Add convenience function date

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/DateOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DateOperators.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.operator.scalar.ScalarFunction;
 import com.facebook.presto.operator.scalar.ScalarOperator;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
@@ -126,6 +127,7 @@ public final class DateOperators
         return utf8Slice(printDate((int) value));
     }
 
+    @ScalarFunction("date")
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.DATE)
     public static long castFromSlice(@SqlType(StandardTypes.VARCHAR) Slice value)

--- a/presto-main/src/main/java/com/facebook/presto/type/TimestampOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimestampOperators.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.operator.scalar.ScalarFunction;
 import com.facebook.presto.operator.scalar.ScalarOperator;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
@@ -95,6 +96,7 @@ public final class TimestampOperators
         return min <= value && value <= max;
     }
 
+    @ScalarFunction("date")
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.DATE)
     public static long castToDate(ConnectorSession session, @SqlType(StandardTypes.TIMESTAMP) long value)

--- a/presto-main/src/main/java/com/facebook/presto/type/TimestampWithTimeZoneOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimestampWithTimeZoneOperators.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.operator.scalar.ScalarFunction;
 import com.facebook.presto.operator.scalar.ScalarOperator;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
@@ -100,6 +101,7 @@ public final class TimestampWithTimeZoneOperators
         return unpackMillisUtc(min) <= unpackMillisUtc(value) && unpackMillisUtc(value) <= unpackMillisUtc(max);
     }
 
+    @ScalarFunction("date")
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.DATE)
     public static long castToDate(@SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long value)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -196,6 +196,14 @@ public class TestDateTimeFunctions
     }
 
     @Test
+    public void testDate()
+    {
+        assertFunction("date('" + DATE_ISO8601_STRING + "')", DateType.DATE, toDate(DATE));
+        assertFunction("date(" + WEIRD_TIMESTAMP_LITERAL + ")", DateType.DATE, toDate(DATE));
+        assertFunction("date(" + TIMESTAMP_LITERAL + ")", DateType.DATE, toDate(DATE));
+    }
+
+    @Test
     public void testFromISO8601()
     {
         assertFunction("from_iso8601_timestamp('" + TIMESTAMP_ISO8601_STRING + "')", TIMESTAMP_WITH_TIME_ZONE, toTimestampWithTimeZone(TIMESTAMP_WITH_NUMERICAL_ZONE));


### PR DESCRIPTION
Fixes #4581 
Here `date(x)` is not being redirected to `cast(x as date)`. Rather it has a separate flow. I am not sure whether that is correct?
Queries work fine though. Have also written test cases.
```
presto> select date('2015-09-10');
   _col0
------------
 2015-09-10
(1 row)
```

```
presto> select date(timestamp '2012-08-08 01:00:13');
   _col0
------------
 2012-08-08
(1 row)
```

```
presto> select date(1);
Query 20160222_124319_00005_rhwby failed: CAST to date cannot be applied to bigint
```

Please review.

### Edit(after review changes):

```
presto> select date(TIMESTAMP '2001-08-22 03:29:05.321 +03:30');
   _col0
------------
 2001-08-22
```

```
presto> select date(TIMESTAMP '2001-08-22 03:29:05.321');
   _col0
------------
 2001-08-22
```

```
presto> select date('2001-08-22');
   _col0
------------
 2001-08-22
```
