### PR TITLE
Fix nullif and isDistinctFrom code generation

### DIFF
--- a/presto-bytecode/src/main/java/com/facebook/presto/bytecode/BytecodeBlock.java
+++ b/presto-bytecode/src/main/java/com/facebook/presto/bytecode/BytecodeBlock.java
@@ -601,7 +601,7 @@ public class BytecodeBlock
         if (type == long.class || type == double.class) {
             nodes.add(OpCode.DUP2);
         }
-        else {
+        else if (type != void.class) {
             nodes.add(OpCode.DUP);
         }
         return this;

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/IsDistinctFromCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/IsDistinctFromCodeGenerator.java
@@ -66,6 +66,8 @@ public class IsDistinctFromCodeGenerator
             // the generated block should be unreachable. However, a boolean need to be pushed to balance the stack
             neitherSideIsNull = new BytecodeBlock()
                     .comment("unreachable code")
+                    .pop(rightType.getJavaType())
+                    .pop(leftType.getJavaType())
                     .push(false);
         }
         else {
@@ -97,8 +99,8 @@ public class IsDistinctFromCodeGenerator
                                 .append(new IfStatement()
                                         .condition(wasNull)
                                         .ifTrue(new BytecodeBlock()
-                                                .pop(leftType.getJavaType())
                                                 .pop(rightType.getJavaType())
+                                                .pop(leftType.getJavaType())
                                                 .push(true))
                                         .ifFalse(neitherSideIsNull))))
                 .append(wasNull.set(constantFalse()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/NullIfCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/NullIfCodeGenerator.java
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantTrue;
-import static com.facebook.presto.type.TypeRegistry.getCommonSuperTypeSignature;
 
 public class NullIfCodeGenerator
         implements BytecodeGenerator
@@ -53,10 +52,6 @@ public class NullIfCodeGenerator
         Type firstType = first.getType();
         Type secondType = second.getType();
 
-        // this is a hack! We shouldn't be determining type coercions at this point, but there's no way
-        // around it in the current expression AST
-        TypeSignature commonType = getCommonSuperTypeSignature(firstType.getTypeSignature(), secondType.getTypeSignature()).get();
-
         // if (equal(cast(first as <common type>), cast(second as <common type>))
         Signature operatorSignature = generatorContext.getRegistry().resolveOperator(OperatorType.EQUAL, ImmutableList.of(firstType, secondType));
         ScalarFunctionImplementation equalsFunction = generatorContext.getRegistry().getScalarFunctionImplementation(operatorSignature);
@@ -64,8 +59,8 @@ public class NullIfCodeGenerator
                 operatorSignature.getName(),
                 equalsFunction,
                 ImmutableList.of(
-                        cast(generatorContext, new BytecodeBlock().dup(firstType.getJavaType()), firstType.getTypeSignature(), commonType),
-                        cast(generatorContext, generatorContext.generate(second), secondType.getTypeSignature(), commonType)));
+                        cast(generatorContext, new BytecodeBlock().dup(firstType.getJavaType()), firstType, operatorSignature.getArgumentTypes().get(0)),
+                        cast(generatorContext, generatorContext.generate(second), secondType, operatorSignature.getArgumentTypes().get(1))));
 
         BytecodeBlock conditionBlock = new BytecodeBlock()
                 .append(equalsCall)
@@ -86,11 +81,19 @@ public class NullIfCodeGenerator
         return block;
     }
 
-    private BytecodeNode cast(BytecodeGeneratorContext generatorContext, BytecodeNode argument, TypeSignature fromType, TypeSignature toType)
+    private BytecodeNode cast(
+            BytecodeGeneratorContext generatorContext,
+            BytecodeNode argument,
+            Type actualType,
+            TypeSignature requiredType)
     {
+        if (actualType.getTypeSignature().equals(requiredType)) {
+            return argument;
+        }
+
         Signature function = generatorContext
-            .getRegistry()
-            .getCoercion(fromType, toType);
+                .getRegistry()
+                .getCoercion(actualType.getTypeSignature(), requiredType);
 
         // TODO: do we need a full function call? (nullability checks, etc)
         return generatorContext.generateCall(function.getName(), generatorContext.getRegistry().getScalarFunctionImplementation(function), ImmutableList.of(argument));

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -71,6 +71,7 @@ import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static com.facebook.presto.type.JsonType.JSON;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -1124,6 +1125,17 @@ public class TestExpressionCompiler
         assertExecute("coalesce(cast(null as varchar), 'foo', cast(null as varchar))", VARCHAR, "foo");
 
         assertExecute("coalesce(cast(null as bigint), null, cast(null as bigint))", BIGINT, null);
+
+        Futures.allAsList(futures).get();
+    }
+
+    @Test
+    public void testNullifForUnknown()
+            throws Exception
+    {
+        assertExecute("nullif(NULL, NULL)", UNKNOWN, null);
+        assertExecute("nullif(NULL, 2)", UNKNOWN, null);
+        assertExecute("nullif(2, NULL)", BIGINT, 2);
 
         Futures.allAsList(futures).get();
     }


### PR DESCRIPTION
During the DECIMAL type development we have introduced operators that might accept arguments with different java types. For such cases `nullif` and `isDistinctFrom` code generation was failing.