### PR TITLE
Fix correctness for DIRECT_SWITCH in InCodeGenerator

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -864,6 +864,12 @@ public class TestExpressionCompiler
             assertExecute(generateExpression("%s in ('what?', null, 'foo', 'mellow', 'end')", value),
                     BOOLEAN,
                     value == null ? null : testValues.contains(value) ? true : null);
+            assertExecute(generateExpression("%s in (cast('what?' AS VARCHAR(10)), cast('foo' AS VARCHAR(10)), null, 'mellow', 'end')", value),
+                    BOOLEAN,
+                    value == null ? null : testValues.contains(value) ? true : null);
+            assertExecute(generateExpression("%s in ('what?', CAST(null AS VARCHAR(10)), 'foo', 'mellow', 'end')", value),
+                    BOOLEAN,
+                    value == null ? null : testValues.contains(value) ? true : null);
         }
 
         Futures.allAsList(futures).get();


### PR DESCRIPTION
Instead of returning null immediately when we found NULL argument in a switch we must remember
that one of the arguments was null, and return it only if not matched.

Was:

'what?' in (cast('what?' AS VARCHAR(10)), cast('foo' AS VARCHAR(10)), null, 'mellow', 'end')" => NULL

Should be:

'what?' in (cast('what?' AS VARCHAR(10)), cast('foo' AS VARCHAR(10)), null, 'mellow', 'end')" => TRUE