### PR TITLE
Consider invalid Raptor $shard_uuid value as false predicate

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardPredicate.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardPredicate.java
@@ -107,10 +107,18 @@ class ShardPredicate
             if (handle.isShardUuid()) {
                 // TODO: support multiple shard UUIDs
                 if (domain.isSingleValue()) {
+                    Slice uuidText = checkType(entry.getValue().getSingleValue(), Slice.class, "value");
+                    Slice uuidBytes;
+                    try {
+                        uuidBytes = uuidStringToBytes(uuidText);
+                    }
+                    catch (IllegalArgumentException e) {
+                        predicate.add("false");
+                        continue;
+                    }
                     predicate.add("shard_uuid = ?");
-                    types.add(jdbcType(type));
-                    Slice uuidSlice = checkType(entry.getValue().getSingleValue(), Slice.class, "value");
-                    values.add(uuidStringToBytes(uuidSlice));
+                    types.add(jdbcType);
+                    values.add(uuidBytes);
                 }
                 continue;
             }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/util/UuidUtil.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/util/UuidUtil.java
@@ -132,6 +132,7 @@ public final class UuidUtil
     /**
      * @param uuidSlice textual representation of UUID
      * @return byte representation of UUID
+     * @throws IllegalArgumentException if uuidSlice is not a valid string representation of UUID
      */
     public static Slice uuidStringToBytes(Slice uuidSlice)
     {


### PR DESCRIPTION
Before this fix, it throws an uncategorized exception when invalid Raptor $shard_uuid is encountered.

Fixes #3951 