### PR TITLE
Change buildSql in QueryBuilder to return PreparedStatement

### DIFF
--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -107,6 +107,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>json</artifactId>
             <scope>test</scope>

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.Driver;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -246,9 +247,11 @@ public class BaseJdbcClient
     }
 
     @Override
-    public String buildSql(JdbcSplit split, List<JdbcColumnHandle> columnHandles)
+    public PreparedStatement buildSql(JdbcSplit split, List<JdbcColumnHandle> columnHandles)
+            throws SQLException
     {
         return new QueryBuilder(identifierQuote).buildSql(
+                getConnection(split),
                 split.getCatalogName(),
                 split.getSchemaName(),
                 split.getTableName(),

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -21,6 +21,7 @@ import io.airlift.slice.Slice;
 import javax.annotation.Nullable;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collection;
@@ -43,7 +44,8 @@ public interface JdbcClient
     Connection getConnection(JdbcSplit split)
             throws SQLException;
 
-    String buildSql(JdbcSplit split, List<JdbcColumnHandle> columnHandles);
+    PreparedStatement buildSql(JdbcSplit split, List<JdbcColumnHandle> columnHandles)
+            throws SQLException;
 
     JdbcOutputTableHandle beginCreateTable(ConnectorTableMetadata tableMetadata);
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
@@ -29,6 +29,7 @@ import io.airlift.slice.Slice;
 import org.joda.time.chrono.ISOChronology;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -55,7 +56,7 @@ public class JdbcRecordCursor
     private final List<JdbcColumnHandle> columnHandles;
 
     private final Connection connection;
-    private final Statement statement;
+    private final PreparedStatement statement;
     private final ResultSet resultSet;
     private boolean closed;
 
@@ -63,13 +64,11 @@ public class JdbcRecordCursor
     {
         this.columnHandles = ImmutableList.copyOf(requireNonNull(columnHandles, "columnHandles is null"));
 
-        String sql = jdbcClient.buildSql(split, columnHandles);
         try {
             connection = jdbcClient.getConnection(split);
-            statement = jdbcClient.getStatement(connection);
-
-            log.debug("Executing: %s", sql);
-            resultSet = statement.executeQuery(sql);
+            statement = jdbcClient.buildSql(split, columnHandles);
+            log.debug("Executing: %s", statement.toString());
+            resultSet = statement.executeQuery();
         }
         catch (SQLException e) {
             throw handleSqlException(e);

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
@@ -24,6 +24,9 @@ import com.facebook.presto.spi.type.Type;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,12 +41,35 @@ public class QueryBuilder
 {
     private final String quote;
 
+    private static class TypeAndValue
+    {
+        public final Type type;
+        public final Object value;
+
+        public TypeAndValue(Type type, Object value)
+        {
+            this.type = requireNonNull(type, "type is null");
+            this.value = requireNonNull(value, "value is null");
+        }
+
+        public Type getType()
+        {
+            return type;
+        }
+
+        public Object getValue()
+        {
+            return value;
+        }
+    }
+
     public QueryBuilder(String quote)
     {
         this.quote = requireNonNull(quote, "quote is null");
     }
 
-    public String buildSql(String catalog, String schema, String table, List<JdbcColumnHandle> columns, TupleDomain<ColumnHandle> tupleDomain)
+    public PreparedStatement buildSql(Connection connection, String catalog, String schema, String table, List<JdbcColumnHandle> columns, TupleDomain<ColumnHandle> tupleDomain)
+            throws SQLException
     {
         StringBuilder sql = new StringBuilder();
 
@@ -62,31 +88,57 @@ public class QueryBuilder
         }
         sql.append(quote(table));
 
-        List<String> clauses = toConjuncts(columns, tupleDomain);
+        List<TypeAndValue> accumulator = new ArrayList<>();
+
+        List<String> clauses = toConjuncts(columns, tupleDomain, accumulator);
         if (!clauses.isEmpty()) {
             sql.append(" WHERE ")
                     .append(Joiner.on(" AND ").join(clauses));
         }
 
-        return sql.toString();
+        PreparedStatement statement = connection.prepareStatement(sql.toString());
+
+        for (int i = 0; i < accumulator.size(); i++) {
+            TypeAndValue typeAndValue = accumulator.get(i);
+            if (typeAndValue.getType().equals(BigintType.BIGINT)) {
+                statement.setLong(i + 1, (Long) typeAndValue.getValue());
+            }
+            else if (typeAndValue.getType().equals(DoubleType.DOUBLE)) {
+                statement.setDouble(i + 1, (Double) typeAndValue.getValue());
+            }
+            else if (typeAndValue.getType().equals(BooleanType.BOOLEAN)) {
+                statement.setBoolean(i + 1, (Boolean) typeAndValue.getValue());
+            }
+            else {
+                throw new UnsupportedOperationException("Can't handle type: " + typeAndValue.getType());
+            }
+        }
+
+        return statement;
     }
 
-    private List<String> toConjuncts(List<JdbcColumnHandle> columns, TupleDomain<ColumnHandle> tupleDomain)
+    private static boolean isAcceptedType(Type type)
+    {
+        Type validType = requireNonNull(type, "type is null");
+        return validType.equals(BigintType.BIGINT) || validType.equals(DoubleType.DOUBLE) || validType.equals(BooleanType.BOOLEAN);
+    }
+
+    private List<String> toConjuncts(List<JdbcColumnHandle> columns, TupleDomain<ColumnHandle> tupleDomain, List<TypeAndValue> accumulator)
     {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
         for (JdbcColumnHandle column : columns) {
             Type type = column.getColumnType();
-            if (type.equals(BigintType.BIGINT) || type.equals(DoubleType.DOUBLE) || type.equals(BooleanType.BOOLEAN)) {
+            if (isAcceptedType(type)) {
                 Domain domain = tupleDomain.getDomains().get().get(column);
                 if (domain != null) {
-                    builder.add(toPredicate(column.getColumnName(), domain));
+                    builder.add(toPredicate(column.getColumnName(), domain, type, accumulator));
                 }
             }
         }
         return builder.build();
     }
 
-    private String toPredicate(String columnName, Domain domain)
+    private String toPredicate(String columnName, Domain domain, Type type, List<TypeAndValue> accumulator)
     {
         checkArgument(domain.getType().isOrderable(), "Domain type must be orderable");
 
@@ -110,10 +162,10 @@ public class QueryBuilder
                 if (!range.getLow().isLowerUnbounded()) {
                     switch (range.getLow().getBound()) {
                         case ABOVE:
-                            rangeConjuncts.add(toPredicate(columnName, ">", range.getLow().getValue()));
+                            rangeConjuncts.add(toPredicate(columnName, ">", range.getLow().getValue(), type, accumulator));
                             break;
                         case EXACTLY:
-                            rangeConjuncts.add(toPredicate(columnName, ">=", range.getLow().getValue()));
+                            rangeConjuncts.add(toPredicate(columnName, ">=", range.getLow().getValue(), type, accumulator));
                             break;
                         case BELOW:
                             throw new IllegalArgumentException("Low Marker should never use BELOW bound: " + range);
@@ -126,10 +178,10 @@ public class QueryBuilder
                         case ABOVE:
                             throw new IllegalArgumentException("High Marker should never use ABOVE bound: " + range);
                         case EXACTLY:
-                            rangeConjuncts.add(toPredicate(columnName, "<=", range.getHigh().getValue()));
+                            rangeConjuncts.add(toPredicate(columnName, "<=", range.getHigh().getValue(), type, accumulator));
                             break;
                         case BELOW:
-                            rangeConjuncts.add(toPredicate(columnName, "<", range.getHigh().getValue()));
+                            rangeConjuncts.add(toPredicate(columnName, "<", range.getHigh().getValue(), type, accumulator));
                             break;
                         default:
                             throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
@@ -143,10 +195,10 @@ public class QueryBuilder
 
         // Add back all of the possible single values either as an equality or an IN predicate
         if (singleValues.size() == 1) {
-            disjuncts.add(toPredicate(columnName, "=", getOnlyElement(singleValues)));
+            disjuncts.add(toPredicate(columnName, "=", getOnlyElement(singleValues), type, accumulator));
         }
         else if (singleValues.size() > 1) {
-            disjuncts.add(quote(columnName) + " IN (" + Joiner.on(",").join(transform(singleValues, QueryBuilder::encode)) + ")");
+            disjuncts.add(quote(columnName) + " IN (" + Joiner.on(",").join(transform(singleValues, value -> bindValue(value, type, accumulator))) + ")");
         }
 
         // Add nullability disjuncts
@@ -158,9 +210,9 @@ public class QueryBuilder
         return "(" + Joiner.on(" OR ").join(disjuncts) + ")";
     }
 
-    private String toPredicate(String columnName, String operator, Object value)
+    private String toPredicate(String columnName, String operator, Object value, Type type, List<TypeAndValue> accumulator)
     {
-        return quote(columnName) + " " + operator + " " + encode(value);
+        return quote(columnName) + " " + operator + " " + bindValue(value, type, accumulator);
     }
 
     private String quote(String name)
@@ -169,11 +221,10 @@ public class QueryBuilder
         return quote + name + quote;
     }
 
-    private static String encode(Object value)
+    private static String bindValue(Object value, Type type, List<TypeAndValue> accumulator)
     {
-        if (value instanceof Number || value instanceof Boolean) {
-            return value.toString();
-        }
-        throw new UnsupportedOperationException("Can't handle type: " + value.getClass().getName());
+        checkArgument(isAcceptedType(type), "Can't handle type: %s", type);
+        accumulator.add(new TypeAndValue(type, value));
+        return "?";
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcQueryBuilder.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcQueryBuilder.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.Range;
+import com.facebook.presto.spi.predicate.SortedRangeSet;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.type.DoubleType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.IDBI;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestJdbcQueryBuilder
+{
+    private IDBI dbi;
+    private Handle dummyHandle;
+    private List<JdbcColumnHandle> cols = new ArrayList<>();
+
+    @BeforeMethod
+    public void setup()
+            throws SQLException
+    {
+        dbi = new DBI("jdbc:h2:mem:test" + System.nanoTime());
+        dummyHandle = dbi.open();
+        Connection connection = dummyHandle.getConnection();
+        PreparedStatement preparedStatement = connection.prepareStatement("create table \"test_table\" (" + "" +
+                "\"col_0\" BIGINT, " +
+                "\"col_1\" DOUBLE, " +
+                "\"col_2\" BOOLEAN, " +
+                ")");
+        preparedStatement.execute();
+        StringBuilder stringBuilder = new StringBuilder("insert into \"test_table\" values ");
+        int len = 1000;
+        for (int i = 0; i < len; i++) {
+            stringBuilder.append("(" + i + ", " + (200000.0 + i / 2.0) + ", " + (i % 2 == 0) + ")");
+            if (i != len - 1) {
+                stringBuilder.append(",");
+            }
+        }
+        PreparedStatement preparedStatement2 = connection.prepareStatement(stringBuilder.toString());
+        preparedStatement2.execute();
+
+        cols.add(new JdbcColumnHandle("test_id", "col_0", BigintType.BIGINT));
+        cols.add(new JdbcColumnHandle("test_id", "col_1", DoubleType.DOUBLE));
+        cols.add(new JdbcColumnHandle("test_id", "col_2", BooleanType.BOOLEAN));
+    }
+
+    @AfterMethod
+    public void teardown()
+    {
+        dummyHandle.close();
+    }
+
+    @Test
+    public void testNormalBuildSql()
+            throws SQLException
+    {
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                cols.get(0), Domain.create(SortedRangeSet.copyOf(BigintType.BIGINT,
+                        ImmutableList.of(
+                                Range.equal(BigintType.BIGINT, 128L),
+                                Range.equal(BigintType.BIGINT, 180L),
+                                Range.equal(BigintType.BIGINT, 233L),
+                                Range.lessThan(BigintType.BIGINT, 25L),
+                                Range.range(BigintType.BIGINT, 66L, true, 96L, true),
+                                Range.greaterThan(BigintType.BIGINT, 192L))),
+                        false),
+                cols.get(1), Domain.create(SortedRangeSet.copyOf(DoubleType.DOUBLE,
+                        ImmutableList.of(
+                                Range.equal(DoubleType.DOUBLE, 200011.0),
+                                Range.equal(DoubleType.DOUBLE, 200014.0),
+                                Range.equal(DoubleType.DOUBLE, 200017.0),
+                                Range.equal(DoubleType.DOUBLE, 200116.5),
+                                Range.range(DoubleType.DOUBLE, 200030.0, true, 200036.0, true),
+                                Range.range(DoubleType.DOUBLE, 200048.0, true, 200099.0, true))),
+                        false),
+                cols.get(2), Domain.create(SortedRangeSet.copyOf(BooleanType.BOOLEAN,
+                        ImmutableList.of(Range.equal(BooleanType.BOOLEAN, true))),
+                        false)
+        ));
+        Connection connection = dummyHandle.getConnection();
+
+        PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(connection, "", "", "test_table", cols, tupleDomain);
+
+        ResultSet res = preparedStatement.executeQuery();
+
+        ImmutableSet.Builder<Long> builder = ImmutableSet.builder();
+        while (res.next()) {
+            builder.add((Long) res.getObject("col_0"));
+        }
+        assertEquals(builder.build(), ImmutableSet.of(22L, 66L, 68L, 70L, 72L, 96L, 128L, 180L, 194L, 196L, 198L));
+    }
+
+    @Test
+    public void testEmptyBuildSql()
+            throws SQLException
+    {
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                cols.get(0), Domain.all(BigintType.BIGINT),
+                cols.get(1), Domain.onlyNull(DoubleType.DOUBLE)
+        ));
+        Connection connection = dummyHandle.getConnection();
+
+        PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(connection, "", "", "test_table", cols, tupleDomain);
+
+        ResultSet res = preparedStatement.executeQuery();
+        assertEquals(res.next(), false);
+    }
+}


### PR DESCRIPTION
Use methods in PreparedStatement such as 'setDouble', 'setBoolean', and 'setLong' to construct SQL query instead of appending the result of 'toString' method from an object, which could help prevent SQL injection in value fields.