### PR TITLE
[PrestoS3FileSystem] Collect AWS client execute time metric

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystemMetricCollector.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystemMetricCollector.java
@@ -20,7 +20,11 @@ import com.amazonaws.util.AWSRequestMetrics;
 import com.amazonaws.util.TimingInfo;
 import io.airlift.units.Duration;
 
-import static com.amazonaws.util.AWSRequestMetrics.Field;
+import static com.amazonaws.util.AWSRequestMetrics.Field.ClientExecuteTime;
+import static com.amazonaws.util.AWSRequestMetrics.Field.HttpClientRetryCount;
+import static com.amazonaws.util.AWSRequestMetrics.Field.HttpRequestTime;
+import static com.amazonaws.util.AWSRequestMetrics.Field.RequestCount;
+import static com.amazonaws.util.AWSRequestMetrics.Field.ThrottleException;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -40,10 +44,11 @@ public class PrestoS3FileSystemMetricCollector
         AWSRequestMetrics metrics = request.getAWSRequestMetrics();
 
         TimingInfo timingInfo = metrics.getTimingInfo();
-        Number requestCounts = timingInfo.getCounter(Field.RequestCount.name());
-        Number retryCounts = timingInfo.getCounter(Field.HttpClientRetryCount.name());
-        Number throttleExceptions = timingInfo.getCounter(Field.ThrottleException.name());
-        TimingInfo requestTime = timingInfo.getSubMeasurement(Field.HttpRequestTime.name());
+        Number requestCounts = timingInfo.getCounter(RequestCount.name());
+        Number retryCounts = timingInfo.getCounter(HttpClientRetryCount.name());
+        Number throttleExceptions = timingInfo.getCounter(ThrottleException.name());
+        TimingInfo requestTime = timingInfo.getSubMeasurement(HttpRequestTime.name());
+        TimingInfo clientExecuteTime = timingInfo.getSubMeasurement(ClientExecuteTime.name());
 
         if (requestCounts != null) {
             stats.updateAwsRequestCount(requestCounts.longValue());
@@ -59,6 +64,10 @@ public class PrestoS3FileSystemMetricCollector
 
         if (requestTime != null && requestTime.getTimeTakenMillisIfKnown() != null) {
             stats.addAwsRequestTime(new Duration(requestTime.getTimeTakenMillisIfKnown(), MILLISECONDS));
+        }
+
+        if (clientExecuteTime != null && clientExecuteTime.getTimeTakenMillisIfKnown() != null) {
+            stats.addAwsClientExecuteTime(new Duration(clientExecuteTime.getTimeTakenMillisIfKnown(), MILLISECONDS));
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystemStats.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystemStats.java
@@ -50,6 +50,7 @@ public class PrestoS3FileSystemStats
     private final CounterStat awsRetryCount = new CounterStat();
     private final CounterStat awsThrottleExceptions = new CounterStat();
     private final TimeStat awsRequestTime = new TimeStat(MILLISECONDS);
+    private final TimeStat awsClientExecuteTime = new TimeStat(MILLISECONDS);
 
     @Managed
     @Nested
@@ -179,6 +180,13 @@ public class PrestoS3FileSystemStats
 
     @Managed
     @Nested
+    public TimeStat getAwsClientExecuteTime()
+    {
+        return awsClientExecuteTime;
+    }
+
+    @Managed
+    @Nested
     public CounterStat getGetObjectRetries()
     {
         return getObjectRetries;
@@ -287,6 +295,11 @@ public class PrestoS3FileSystemStats
     public void addAwsRequestTime(Duration duration)
     {
         awsRequestTime.add(duration);
+    }
+
+    public void addAwsClientExecuteTime(Duration duration)
+    {
+        awsClientExecuteTime.add(duration);
     }
 
     public void newGetObjectRetry()


### PR DESCRIPTION
This PR adds support for collecting the client execute time metric, which is the end-to-end time for http requests to the AWS services.

From its javadoc:
```Java
/**
* Total number of milliseconds taken for a request/response including
* the time taken to execute the request handlers, round trip to AWS,
* and the time taken to execute the response handlers.
*/
ClientExecuteTime,
```