### PR TITLE
Look up parquet columns by name case-insensitively

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
@@ -26,22 +26,28 @@ public final class ParquetTypeUtils
     public static parquet.schema.Type getParquetType(HiveColumnHandle column, MessageType messageType, boolean useParquetColumnNames)
     {
         if (useParquetColumnNames) {
-            if (messageType.containsField(column.getName())) {
-                return messageType.getType(column.getName());
-            }
-            // parquet is case-sensitive, but hive is not. all hive columns get converted to lowercase
-            // check for direct match above but if no match found, try case-insensitive match
-            for (Type type : messageType.getFields()) {
-                if (type.getName().equalsIgnoreCase(column.getName())) {
-                    return type;
-                }
-            }
-            return null;
+            return getParquetTypeByName(column.getName(), messageType);
         }
 
         if (column.getHiveColumnIndex() < messageType.getFieldCount()) {
             return messageType.getType(column.getHiveColumnIndex());
         }
+        return null;
+    }
+
+    private static parquet.schema.Type getParquetTypeByName(String columnName, MessageType messageType)
+    {
+        if (messageType.containsField(columnName)) {
+            return messageType.getType(columnName);
+        }
+        // parquet is case-sensitive, but hive is not. all hive columns get converted to lowercase
+        // check for direct match above but if no match found, try case-insensitive match
+        for (Type type : messageType.getFields()) {
+            if (type.getName().equalsIgnoreCase(columnName)) {
+                return type;
+            }
+        }
+
         return null;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.parquet;
 
 import com.facebook.presto.hive.HiveColumnHandle;
 import parquet.schema.MessageType;
+import parquet.schema.Type;
 
 public final class ParquetTypeUtils
 {
@@ -27,6 +28,13 @@ public final class ParquetTypeUtils
         if (useParquetColumnNames) {
             if (messageType.containsField(column.getName())) {
                 return messageType.getType(column.getName());
+            }
+            // parquet is case-sensitive, but hive is not. all hive columns get converted to lowercase
+            // check for direct match above but if no match found, try case-insensitive match
+            for (Type type : messageType.getFields()) {
+                if (type.getName().equalsIgnoreCase(column.getName())) {
+                    return type;
+                }
             }
             return null;
         }


### PR DESCRIPTION
Parquet schemas are case sensitive but hive is not so camelCase parquet fields are not found when accessed as lowercase hive columns.