### PR TITLE
Remove unnecessary synchronized block in OperatorContext

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -444,14 +444,12 @@ public class OperatorContext
         @Override
         public synchronized void run()
         {
-            synchronized (this) {
-                if (finished) {
-                    return;
-                }
-                finished = true;
-                blockedMonitor.compareAndSet(this, null);
-                blockedWallNanos.getAndAdd(getBlockedTime());
+            if (finished) {
+                return;
             }
+            finished = true;
+            blockedMonitor.compareAndSet(this, null);
+            blockedWallNanos.getAndAdd(getBlockedTime());
         }
 
         public long getBlockedTime()


### PR DESCRIPTION
The `run()` method is already synchronized so the `synchronized(this)` block is unnecessary.