### PR TITLE
Fix NPE when query fails during parsing/planning

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
@@ -155,6 +155,10 @@ public class QueryMonitor
 
     private static Optional<TaskInfo> findFailedTask(StageInfo stageInfo)
     {
+        if (stageInfo == null) {
+            return Optional.empty();
+        }
+
         for (StageInfo subStage : stageInfo.getSubStages()) {
             Optional<TaskInfo> task = findFailedTask(subStage);
             if (task.isPresent()) {


### PR DESCRIPTION
Commit 135626b793b42841c77f6b8c8b7fe80fac8ffc46 introduced a bug
where queries that fail during parsing/analysis/planning
throw an NPE when the completion event is processed.

This is due to an incorrect assumption that QueryInfos always
have an output stage, which is not true for queries that fail
before execution starts.

Fixes https://github.com/facebook/presto/issues/4701