### PR TITLE
Add parsing error test to distributed queries

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -129,6 +129,13 @@ public abstract class AbstractTestQueries
         super(queryRunner);
     }
 
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "line 1:16: no viable alternative at input.*")
+    public void testParsingError()
+            throws Exception
+    {
+        computeActual("SELECT foo FROM");
+    }
+
     @Test
     public void selectNull()
             throws Exception


### PR DESCRIPTION
This reproduces the issue fixed in 0498c0df5aff14c9f7f88db1fe2e43ed3470aa5b

None of the existing tests catch it because it only propagates
to the caller if they happen during parsing (which causes the
QueryMonitor to be called inline). Errors that occur during
planning and analysis call the QueryMonitor in a background thread,
so they go to the logs, instead.