### PR TITLE
Skip DriverContext memory free when the delta is zero

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -223,6 +223,9 @@ public class DriverContext
 
     public void freeMemory(long bytes)
     {
+        if (bytes == 0) {
+            return;
+        }
         checkArgument(bytes >= 0, "bytes is negative");
         checkArgument(bytes <= memoryReservation.get(), "tried to free more memory than is reserved");
         pipelineContext.freeMemory(bytes);
@@ -231,6 +234,9 @@ public class DriverContext
 
     public void freeSystemMemory(long bytes)
     {
+        if (bytes == 0) {
+            return;
+        }
         checkArgument(bytes >= 0, "bytes is negative");
         checkArgument(bytes <= systemMemoryReservation.get(), "tried to free more memory than is reserved");
         pipelineContext.freeSystemMemory(bytes);


### PR DESCRIPTION
In a moment, we found that more than 10% of worker thread were blocked to enter synchronized `freeSystemMemory` even though the system memory delta was zero.

In case of `pageSource.getNextPage` returns null (means data is not ready from the pageSource)
`getOutput` could be called quite often and tries to enter monitor region.

```
"20160303_083754_05456_mw7rr.4.11-19-53" #53 prio=5 os_prio=0 tid=0x00007f6ced7fe190 nid=0x9491 waiting for monitor entry [0x00007f6c8b6f5000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at com.facebook.presto.operator.PipelineContext.freeSystemMemory(PipelineContext.java:237)
	- waiting to lock <0x00007f6fdd0a6f88> (a com.facebook.presto.operator.PipelineContext)
	at com.facebook.presto.operator.DriverContext.freeSystemMemory(DriverContext.java:236)
	at com.facebook.presto.operator.OperatorContext$OperatorSystemMemoryContext.updateBytes(OperatorContext.java:497)
	at com.facebook.presto.memory.LocalMemoryContext.setBytes(LocalMemoryContext.java:38)
	at com.facebook.presto.operator.ScanFilterAndProjectOperator.getOutput(ScanFilterAndProjectOperator.java:267)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:380)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:303)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:577)
	at com.facebook.presto.execution.TaskExecutor$PrioritizedSplitRunner.process(TaskExecutor.java:529)
	at com.facebook.presto.execution.TaskExecutor$Runner.run(TaskExecutor.java:665)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```