### PR TITLE
Fix broken "respect format" flag

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -36,6 +36,8 @@ public class HiveMetadataFactory
     private final boolean allowAddColumn;
     private final boolean allowRenameColumn;
     private final boolean allowCorruptWritesForTesting;
+    private final boolean respectTableFormat;
+    private final HiveStorageFormat defaultStorageFormat;
     private final HiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
     private final HivePartitionManager partitionManager;
@@ -71,6 +73,8 @@ public class HiveMetadataFactory
                 hiveClientConfig.getAllowAddColumn(),
                 hiveClientConfig.getAllowRenameColumn(),
                 hiveClientConfig.getAllowCorruptWritesForTesting(),
+                hiveClientConfig.isRespectTableFormat(),
+                hiveClientConfig.getHiveStorageFormat(),
                 typeManager,
                 locationService,
                 tableParameterCodec,
@@ -90,6 +94,8 @@ public class HiveMetadataFactory
             boolean allowAddColumn,
             boolean allowRenameColumn,
             boolean allowCorruptWritesForTesting,
+            boolean respectTableFormat,
+            HiveStorageFormat defaultStorageFormat,
             TypeManager typeManager,
             LocationService locationService,
             TableParameterCodec tableParameterCodec,
@@ -103,6 +109,8 @@ public class HiveMetadataFactory
         this.allowAddColumn = allowAddColumn;
         this.allowRenameColumn = allowRenameColumn;
         this.allowCorruptWritesForTesting = allowCorruptWritesForTesting;
+        this.respectTableFormat = respectTableFormat;
+        this.defaultStorageFormat = requireNonNull(defaultStorageFormat, "defaultStorageFormat is null");
 
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
@@ -136,6 +144,8 @@ public class HiveMetadataFactory
                 allowAddColumn,
                 allowRenameColumn,
                 allowCorruptWritesForTesting,
+                respectTableFormat,
+                defaultStorageFormat,
                 typeManager,
                 locationService,
                 tableParameterCodec,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
@@ -122,7 +122,6 @@ public class HivePageSink
 
     private final Table table;
     private final boolean immutablePartitions;
-    private final boolean respectTableFormat;
     private final boolean compress;
 
     private HiveRecordWriter[] writers = new HiveRecordWriter[0];
@@ -140,7 +139,6 @@ public class HivePageSink
             PageIndexerFactory pageIndexerFactory,
             TypeManager typeManager,
             HdfsEnvironment hdfsEnvironment,
-            boolean respectTableFormat,
             int maxOpenPartitions,
             boolean immutablePartitions,
             boolean compress,
@@ -163,7 +161,6 @@ public class HivePageSink
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
 
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
-        this.respectTableFormat = respectTableFormat;
         this.maxOpenPartitions = maxOpenPartitions;
         this.immutablePartitions = immutablePartitions;
         this.compress = compress;
@@ -365,13 +362,8 @@ public class HivePageSink
                         table.getPartitionKeys());
                 target = locationService.targetPath(locationHandle, partitionName);
                 write = locationService.writePath(locationHandle, partitionName).orElse(target);
-                if (respectTableFormat) {
-                    outputFormat = table.getSd().getOutputFormat();
-                }
-                else {
-                    outputFormat = tableStorageFormat.getOutputFormat();
-                }
-                serDe = table.getSd().getSerdeInfo().getSerializationLib();
+                outputFormat = tableStorageFormat.getOutputFormat();
+                serDe = tableStorageFormat.getSerDe();
             }
         }
         else {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
@@ -36,7 +36,6 @@ public class HivePageSinkProvider
     private final HiveMetastore metastore;
     private final PageIndexerFactory pageIndexerFactory;
     private final TypeManager typeManager;
-    private final boolean respectTableFormat;
     private final int maxOpenPartitions;
     private final boolean immutablePartitions;
     private final boolean compressed;
@@ -57,7 +56,6 @@ public class HivePageSinkProvider
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
-        this.respectTableFormat = config.isRespectTableFormat();
         this.maxOpenPartitions = config.getMaxPartitionsPerWriter();
         this.immutablePartitions = config.isImmutablePartitions();
         this.compressed = config.getHiveCompressionCodec() != HiveCompressionCodec.NONE;
@@ -94,7 +92,6 @@ public class HivePageSinkProvider
                 pageIndexerFactory,
                 typeManager,
                 hdfsEnvironment,
-                respectTableFormat,
                 maxOpenPartitions,
                 immutablePartitions,
                 compressed,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -452,6 +452,8 @@ public abstract class AbstractTestHiveClient
                 true,
                 true,
                 true,
+                true,
+                HiveStorageFormat.RCBINARY,
                 typeManager,
                 locationService,
                 new TableParameterCodec(),


### PR DESCRIPTION
The check was being performed in the wrong place (HivePageSink).
By the time the execution got to that point, the choice of
which storage format to use had been made (by extracting it from
the table metadata), so both branches were performing the same
operation.