### PR TITLE
Remove grouping set test from some connectors

### DIFF
--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -31,6 +31,20 @@ public class TestCassandraDistributed
     }
 
     @Override
+    public void testGroupingSetMixedExpressionAndColumn()
+            throws Exception
+    {
+        // Cassandra does not support DATE
+    }
+
+    @Override
+    public void testGroupingSetMixedExpressionAndOrdinal()
+            throws Exception
+    {
+        // Cassandra does not support DATE
+    }
+
+    @Override
     public void testRenameTable()
             throws Exception
     {

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributed.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributed.java
@@ -149,6 +149,16 @@ public class TestRedisDistributed
     {
     }
 
+    @Override
+    public void testGroupingSetMixedExpressionAndColumn()
+    {
+    }
+
+    @Override
+    public void testGroupingSetMixedExpressionAndOrdinal()
+    {
+    }
+
     //
     // Redis connector always return a single split for the test data set
     // TODO fix test to have multiple splits


### PR DESCRIPTION
Tests added to AbstractTestQueries that relied on the type of the
TPC-H shipdate column being DATE fail when run against the Redis and
Cassandra connectors. Prevented these tests from running against these
by overriding them in connector-specific test classes.