### PR TITLE
Remove grouping set test from TestRedisDistributed

### DIFF
--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributedHash.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributedHash.java
@@ -149,6 +149,18 @@ public class TestRedisDistributedHash
     {
     }
 
+    @Override
+    public void testGroupingSetMixedExpressionAndColumn()
+            throws Exception
+    {
+    }
+
+    @Override
+    public void testGroupingSetMixedExpressionAndOrdinal()
+            throws Exception
+    {
+    }
+
     //
     // Redis connector always return a single split for the test data set
     // TODO fix test to have multiple splits


### PR DESCRIPTION
The distributed Redis connector does not support the DATE type in the
grouping set tests.