### PR TITLE
Enable index joins to probe through certain window functions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -33,9 +33,12 @@ import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.planner.plan.SortNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.QualifiedNameReference;
+import com.facebook.presto.sql.tree.WindowFrame;
 import com.google.common.base.Functions;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableBiMap;
@@ -314,6 +317,39 @@ public class IndexJoinOptimizer
         }
 
         @Override
+        public PlanNode visitWindow(WindowNode node, RewriteContext<Context> context)
+        {
+            if (!node.getWindowFunctions().values().stream()
+                    .map(FunctionCall::getName)
+                    .allMatch(metadata.getFunctionRegistry()::isAggregationFunction)) {
+                return node;
+            }
+
+            // Don't need this restriction if we can prove that all order by symbols are deterministically produced
+            if (!node.getOrderBy().isEmpty()) {
+                return node;
+            }
+
+            // Only RANGE frame type currently supported for aggregation functions because it guarantees the
+            // same value for each peer group.
+            // ROWS frame type requires the ordering to be fully deterministic (e.g. deterministically sorted on all columns)
+            if (node.getFrame().getType() != WindowFrame.Type.RANGE) {
+                return node;
+            }
+
+            // Lookup symbols can only be passed through if they are part of the partitioning
+            Set<Symbol> partitionByLookupSymbols = context.get().getLookupSymbols().stream()
+                    .filter(node.getPartitionBy()::contains)
+                    .collect(toImmutableSet());
+
+            if (partitionByLookupSymbols.isEmpty()) {
+                return node;
+            }
+
+            return context.defaultRewrite(node, new Context(partitionByLookupSymbols, context.get().getSuccess()));
+        }
+
+        @Override
         public PlanNode visitIndexSource(IndexSourceNode node, RewriteContext<Context> context)
         {
             throw new IllegalStateException("Should not be trying to generate an Index on something that has already been determined to use an Index");
@@ -436,6 +472,16 @@ public class IndexJoinOptimizer
             public Map<Symbol, Symbol> visitFilter(FilterNode node, Set<Symbol> lookupSymbols)
             {
                 return node.getSource().accept(this, lookupSymbols);
+            }
+
+            @Override
+            public Map<Symbol, Symbol> visitWindow(WindowNode node, Set<Symbol> lookupSymbols)
+            {
+                Set<Symbol> partitionByLookupSymbols = lookupSymbols.stream()
+                        .filter(node.getPartitionBy()::contains)
+                        .collect(toImmutableSet());
+                checkState(!partitionByLookupSymbols.isEmpty(), "No lookup symbols were able to pass through the aggregation group by");
+                return node.getSource().accept(this, partitionByLookupSymbols);
             }
 
             @Override


### PR DESCRIPTION
For example, the following query should be able to be index joined if
the TPCH orders table has an index on orderkey:

SELECT *
FROM lineitem
JOIN (SELECT *, COUNT(*) OVER (PARTITION BY orderkey) FROM orders) o
ON l.orderkey = o.orderkey

This change constrains the allowable index join probes to window functions
consisting of aggregation functions that have windows partitioned by
some superset of the join keys, without an order by clause, and
with only range frame specification.