### PR TITLE
Improve error messages for ArraySliceFunction

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySliceFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySliceFunction.java
@@ -69,8 +69,8 @@ public final class ArraySliceFunction
 
     public static Block slice(Type type, Block array, long fromIndex, long length)
     {
-        checkCondition(length >= 0, INVALID_FUNCTION_ARGUMENT, "Invalid array length");
-        checkCondition(fromIndex != 0, INVALID_FUNCTION_ARGUMENT, "Invalid start index");
+        checkCondition(length >= 0, INVALID_FUNCTION_ARGUMENT, "length must be greater than or equal to 0");
+        checkCondition(fromIndex != 0, INVALID_FUNCTION_ARGUMENT, "SQL array indices start at 1");
 
         int size = array.getPositionCount();
         if (size == 0) {


### PR DESCRIPTION
Fixes #4745 

```
presto> select slice(array[1,2],1,-1);
Query 20160312_050640_00001_uae5q failed: length must be greater than or equal to 0

presto> select slice(array[1,2],0,1);
Query 20160312_050654_00002_uae5q failed: SQL array indices start at 1
```