### PR TITLE
Improve error messages for invalid casts

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/DateOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DateOperators.java
@@ -136,7 +136,7 @@ public final class DateOperators
             return parseDate(trim(value).toStringUtf8());
         }
         catch (IllegalArgumentException e) {
-            throw new PrestoException(INVALID_CAST_ARGUMENT, e);
+            throw new PrestoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to date: " + value.toStringUtf8(), e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/TimeOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimeOperators.java
@@ -125,7 +125,7 @@ public final class TimeOperators
             return parseTimeWithoutTimeZone(session.getTimeZoneKey(), value.toStringUtf8());
         }
         catch (IllegalArgumentException e) {
-            throw new PrestoException(INVALID_CAST_ARGUMENT, e);
+            throw new PrestoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to time: " + value.toStringUtf8(), e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/TimestampOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimestampOperators.java
@@ -147,7 +147,7 @@ public final class TimestampOperators
             return parseTimestampWithoutTimeZone(session.getTimeZoneKey(), trim(value).toStringUtf8());
         }
         catch (IllegalArgumentException e) {
-            throw new PrestoException(INVALID_CAST_ARGUMENT, e);
+            throw new PrestoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/TimestampWithTimeZoneOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimestampWithTimeZoneOperators.java
@@ -152,7 +152,7 @@ public final class TimestampWithTimeZoneOperators
             return parseTimestampWithTimeZone(session.getTimeZoneKey(), trim(value).toStringUtf8());
         }
         catch (IllegalArgumentException e) {
-            throw new PrestoException(INVALID_CAST_ARGUMENT, e);
+            throw new PrestoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp with time zone: " + value.toStringUtf8(), e);
         }
     }
 


### PR DESCRIPTION
Fixes #4681 

### time
```
presto> select cast('03:04:05.321a' as time);
Query 20160312_053303_00000_zn4jy failed: Invalid format: "03:04:05.321a" is malformed at "a"
```
changes to
```
presto>  select cast('03:04:05.321a' as time);
Query 20160313_033839_00002_z8n78 failed: Value cannot be cast to time: 03:04:05.321a
```

### timestamp with time zone
```
presto> select cast('2016-09-09-abc' as timestamp with time zone);
Query 20160312_053321_00001_zn4jy failed: Invalid format: "2016-09-09-abc" is malformed at "-abc"
```
changes to 
```
presto> select cast('2016-09-09-abc' as timestamp with time zone);
Query 20160313_033901_00003_z8n78 failed: Value cannot be cast to timestamp with time zone: 2016-09-09-abc
```

### timestamp
```
presto> select cast('2016-09-09-abc' as timestamp);
Query 20160312_053328_00002_zn4jy failed: Invalid format: "2016-09-09-abc" is malformed at "-abc"
```
changes to 
```
presto> select cast('2016-09-09-abc' as timestamp);
Query 20160313_033937_00004_z8n78 failed: Value cannot be cast to timestamp: 2016-09-09-abc
```

### date
```
presto> select cast('2016-09-09-abc' as date);
Query 20160312_053338_00003_zn4jy failed: Invalid format: "2016-09-09-abc" is malformed at "-abc"
```
changes to 
```
presto> select cast('2016-09-09-abc' as date);
Query 20160313_033800_00000_z8n78 failed: Value cannot be cast to date: 2016-09-09-abc
```